### PR TITLE
Add left & right params for Bracketing methods

### DIFF
--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -1,15 +1,15 @@
 """
 $(TYPEDEF)
 """
-struct NonlinearSolution{T,N,uType,R,P,A,O} <: AbstractNonlinearSolution{T,N}
+struct NonlinearSolution{T,N,uType,R,P,A,O,uType2} <: AbstractNonlinearSolution{T,N}
   u::uType
   resid::R
   prob::P
   alg::A
   retcode::Symbol
   original::O
-  left::uType
-  right::uType
+  left::uType2
+  right::uType2
 end
 
 const SteadyStateSolution = NonlinearSolution
@@ -26,16 +26,16 @@ function build_solution(prob::AbstractNonlinearProblem,
   N = length((size(prob.u0)...,))
 
   NonlinearSolution{T,N,typeof(u),typeof(resid),
-                    typeof(prob),typeof(alg),typeof(original)}(
+                    typeof(prob),typeof(alg),typeof(original),typeof(left)}(
                     u,resid,prob,alg,retcode,original,left,right)
 end
 
-function sensitivity_solution(sol::AbstractNonlinearProblem,u)
+function sensitivity_solution(sol::AbstractNonlinearSolution,u)
   T = eltype(eltype(u))
   N = length((size(sol.prob.u0)...,))
 
   NonlinearSolution{T,N,typeof(u),typeof(sol.resid),
                     typeof(sol.prob),typeof(sol.alg),
-                    typeof(sol.original)}(
-                    u,sol.resid,sol.prob,sol.alg,sol.retcode,sol.original)
+                    typeof(sol.original),typeof(sol.left)}(
+                    u,sol.resid,sol.prob,sol.alg,sol.retcode,sol.original,sol.left,sol.right)
 end

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -27,7 +27,7 @@ function build_solution(prob::AbstractNonlinearProblem,
 
   NonlinearSolution{T,N,typeof(u),typeof(resid),
                     typeof(prob),typeof(alg),typeof(original)}(
-                    u,resid,prob,alg,retcode,original)
+                    u,resid,prob,alg,retcode,original,left,right)
 end
 
 function sensitivity_solution(sol::AbstractNonlinearProblem,u)

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -8,6 +8,8 @@ struct NonlinearSolution{T,N,uType,R,P,A,O} <: AbstractNonlinearSolution{T,N}
   alg::A
   retcode::Symbol
   original::O
+  left::uType
+  right::uType
 end
 
 const SteadyStateSolution = NonlinearSolution
@@ -16,6 +18,8 @@ function build_solution(prob::AbstractNonlinearProblem,
                         alg,u,resid;calculate_error = true,
                         retcode = :Default,
                         original = nothing,
+                        left = nothing, 
+                        right = nothing,
                         kwargs...)
 
   T = eltype(eltype(u))


### PR DESCRIPTION
I have kept all `u`, `left` & `right` for compatibility issues. I will set `u` to `left` in case of bracketing methods. Should I also set `left = u` implicitly?
Ref: https://github.com/JuliaComputing/NonlinearSolve.jl/pull/28
@ChrisRackauckas @YingboMa , please review.