### PR TITLE
Add DynamicalSDEFunction and Problem

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -543,6 +543,7 @@ export ODEProblem, ODESolution
 export DynamicalODEFunction, DynamicalODEProblem,
        SecondOrderODEProblem, SplitFunction, SplitODEProblem
 export SplitSDEProblem
+export DynamicalSDEFunction, DynamicalSDEProblem
 export RODEProblem, RODESolution, SDEProblem
 export DAEProblem, DAESolution
 export DDEProblem


### PR DESCRIPTION
I've added the DynamicalSDEProblem and DynamicalSDEFunction. I'm not entirely sure if these are necessary since they're almost direct copies of the existing SplitSDEProblem/Function.

The reason for this PR is for [#259 in StochasticDiffEq](https://github.com/SciML/StochasticDiffEq.jl/issues/259). I've also submitted a PR to StochasticDiffEq that uses these functions with the BAOAB algorithm.

I don't understand the existence of the SplitSDEProblem type since its constructors just create the original SDEProblem instead, so as far as I can tell, the SplitSDEProblem itself is never used. I followed this trend for the new DynamicalSDEProblem but perhaps it's not necessary.