### PR TITLE
Start the soft deprecation of minimizer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -33,7 +33,7 @@ function Base.show(io::IO, A::AbstractOptimizationSolution)
 end
 
 Base.@propagate_inbounds function Base.getproperty(x::AbstractOptimizationSolution,s::Symbol)
-    if s == :minimizer
+    if s === :minimizer
         return getfield(x,:u)
     end
     return getfield(x,s)

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -32,6 +32,13 @@ function Base.show(io::IO, A::AbstractOptimizationSolution)
     return
 end
 
+Base.@propagate_inbounds function Base.getproperty(x::AbstractOptimizationSolution,s::Symbol)
+    if s == :minimizer
+        return getfield(x,:u)
+    end
+    return getfield(x,s)
+end
+
 Base.summary(A::AbstractOptimizationSolution) = string(
                       TYPE_COLOR, nameof(typeof(A)),
                       NO_COLOR, " with uType ",


### PR DESCRIPTION
This allows for using the new OptimizationSolution as the underbelly for DiffEqFlux.jl in a non-breaking way. This is going to be a very "soft" change, as in `.minimizer` will still work without throwing an error, and in about a year we can add a depwarn. But we will change the documentation and tests almost immediately. This will let users slowly phase out the use of `.minimizer`, and we can throw a depwarn on code about a year. Naturally it should all be moving from `sciml_train` to direct GalacticOptim use over that time.

