### PR TITLE
Use IO in Base.summary, respect :color setting

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -91,12 +91,13 @@ end
 
 ### Displays
 
-Base.summary(A::AbstractEnsembleSolution) = string("EnsembleSolution Solution of length ",length(A.u)," with uType:\n",eltype(A.u))
+Base.summary(io::IO, A::AbstractEnsembleSolution) =
+  print(io,"EnsembleSolution Solution of length ",length(A.u)," with uType:\n",eltype(A.u))
 function Base.show(io::IO, A::AbstractEnsembleSolution)
-  print(io,summary(A))
+  summary(io,A)
 end
 function Base.show(io::IO, m::MIME"text/plain", A::AbstractEnsembleSolution)
-  print(io,summary(A))
+  summary(io,A)
 end
 
 ### Plot Recipes

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -281,13 +281,16 @@ has_reinit(i::DEIntegrator) = false
 
 ### Display
 
-Base.summary(I::DEIntegrator) = string(
-                  TYPE_COLOR, nameof(typeof(I)),
-                  NO_COLOR, " with uType ",
-                  TYPE_COLOR, typeof(I.u),
-                  NO_COLOR, " and tType ",
-                  TYPE_COLOR, typeof(I.t), NO_COLOR)
-
+function Base.summary(io::IO, I::DEIntegrator)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color, nameof(typeof(I)),
+    no_color, " with uType ",
+    type_color, typeof(I.u),
+    no_color, " and tType ",
+    type_color, typeof(I.t),
+    no_color)
+end
 function Base.show(io::IO, A::DEIntegrator)
   println(io,string("t: ",A.t))
   print(io,"u: ")
@@ -301,7 +304,7 @@ end
 TreeViews.hastreeview(x::DEIntegrator) = true
 function TreeViews.treelabel(io::IO,x::DEIntegrator,
                              mime::MIME"text/plain" = MIME"text/plain"())
-  show(io,mime,Base.Text(Base.summary(x)))
+  summary(io,x)
 end
 
 ### Error check (retcode)

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -12,65 +12,90 @@ promote_tspan(tspan::AbstractArray) = length(tspan) == 2 ? promote_tspan((first(
 
 ### Displays
 
-Base.summary(prob::DEProblem) = string(TYPE_COLOR, nameof(typeof(prob)),
-                                       NO_COLOR, " with uType ",
-                                       TYPE_COLOR, typeof(prob.u0),
-                                       NO_COLOR, " and tType ",
-                                       TYPE_COLOR,
-                                       typeof(prob.tspan) <: Function ?
-                                       "Unknown" : (prob.tspan === nothing ?
-                                       "Nothing" : typeof(prob.tspan[1])),
-                                       NO_COLOR, ". In-place: ",
-                                       TYPE_COLOR, isinplace(prob),
-                                       NO_COLOR)
+function Base.summary(io::IO, prob::DEProblem)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color," with uType ",
+    type_color,typeof(prob.u0),
+    no_color," and tType ",
+    type_color,
+    typeof(prob.tspan) <: Function ?
+    "Unknown" : (prob.tspan === nothing ?
+    "Nothing" : typeof(prob.tspan[1])),
+    no_color,". In-place: ",
+    type_color,isinplace(prob),
+    no_color)
+end
 
 
-Base.summary(prob::AbstractLinearProblem) = string(TYPE_COLOR, nameof(typeof(prob)),
-                                                   NO_COLOR, ". In-place: ",
-                                                   TYPE_COLOR, isinplace(prob),
-                                                   NO_COLOR)
+function Base.summary(io::IO, prob::AbstractLinearProblem)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color,". In-place: ",
+    type_color,isinplace(prob),
+    no_color)
+end
 function Base.show(io::IO, A::AbstractLinearProblem)
-  show(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"b: ")
   show(io, A.b)
 end
 
-Base.summary(prob::AbstractNonlinearProblem{uType,iip}) where {uType,iip} = string(
-                                       TYPE_COLOR, nameof(typeof(prob)),
-                                       NO_COLOR, " with uType ",
-                                       TYPE_COLOR, uType,
-                                       NO_COLOR, ". In-place: ",
-                                       TYPE_COLOR, isinplace(prob),
-                                       NO_COLOR)
+function Base.summary(io::IO, prob::AbstractNonlinearProblem{uType,iip}) where {uType,iip}
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color," with uType ",
+    type_color,uType,
+    no_color,". In-place: ",
+    type_color,isinplace(prob),
+    no_color)
+end
 function Base.show(io::IO, A::AbstractNonlinearProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"u0: ")
   show(io, A.u0)
 end
 
-Base.summary(prob::AbstractOptimizationProblem) = string(
-                                       TYPE_COLOR, nameof(typeof(prob)),
-                                       NO_COLOR, ". In-place: ",
-                                       TYPE_COLOR, isinplace(prob),
-                                       NO_COLOR)
+function Base.summary(io::IO, prob::AbstractOptimizationProblem)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color,". In-place: ",
+    type_color,isinplace(prob),
+    no_color)
+end
 function Base.show(io::IO, A::AbstractOptimizationProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"u0: ")
   show(io, A.u0)
 end
 
-Base.summary(prob::AbstractQuadratureProblem) = string(
-                                                       TYPE_COLOR, nameof(typeof(prob)),
-                                                       NO_COLOR, ". In-place: ",
-                                                       TYPE_COLOR, isinplace(prob),
-                                                       NO_COLOR)
+function Base.summary(io::IO, prob::AbstractQuadratureProblem)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color,". In-place: ",
+    type_color,isinplace(prob),
+    no_color)
+end
 function Base.show(io::IO, A::AbstractQuadratureProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
 end
 
-Base.summary(prob::AbstractNoiseProblem) = string(nameof(typeof(prob))," with WType ",typeof(prob.noise.W[1])," and tType ",typeof(prob.tspan[1]),". In-place: ",isinplace(prob))
+function Base.summary(io::IO, prob::AbstractNoiseProblem)
+  print(io,
+  nameof(typeof(prob))," with WType ",typeof(prob.noise.W[1])," and tType ",typeof(prob.tspan[1]),". In-place: ",isinplace(prob))
+end
 function Base.show(io::IO, A::DEProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"timespan: ")
   show(io,A.tspan)
   println(io)
@@ -78,13 +103,15 @@ function Base.show(io::IO, A::DEProblem)
   show(io, A.u0)
 end
 function Base.show(io::IO, A::AbstractNoiseProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"timespan: ")
   show(io,A.tspan)
   println(io)
 end
 function Base.show(io::IO, A::AbstractDAEProblem)
-  println(io,summary(A))
+  summary(io,A)
+  println(io)
   print(io,"timespan: ")
   show(io,A.tspan)
   println(io)
@@ -95,13 +122,18 @@ function Base.show(io::IO, A::AbstractDAEProblem)
   show(io, A.du0)
 end
 
-Base.summary(prob::AbstractEnsembleProblem) = string(
-nameof(typeof(prob))," with problem ",nameof(typeof(prob.prob)))
-Base.show(io::IO, A::AbstractEnsembleProblem) = print(io,summary(A))
+function Base.summary(io::IO, prob::AbstractEnsembleProblem)
+  type_color,no_color = get_colorizers(io)
+  print(io,
+    nameof(typeof(prob)),
+    " with problem ",
+    nameof(typeof(prob.prob)))
+end
+Base.show(io::IO, A::AbstractEnsembleProblem) = summary(io,A)
 TreeViews.hastreeview(x::DEProblem) = true
 function TreeViews.treelabel(io::IO,x::DEProblem,
                              mime::MIME"text/plain" = MIME"text/plain"())
-  show(io,mime,Base.Text(Base.summary(x)))
+  summary(io,x)
 end
 
 struct NullParameters end
@@ -109,9 +141,12 @@ Base.getindex(::NullParameters,i...) = error("Parameters were indexed but the pa
 Base.iterate(::NullParameters) = error("Parameters were indexed but the parameters are `nothing`. You likely forgot to pass in parameters to the DEProblem!")
 
 function Base.show(io::IO, A::AbstractPDEProblem)
-  println(io,summary(A.prob))
+  summary(io,A.prob)
+  println(io)
   println(io)
 end
-Base.summary(prob::AbstractPDEProblem) = string(TYPE_COLOR,
-                                                nameof(typeof(prob)),
-                                                NO_COLOR)
+function Base.summary(io::IO, prob::AbstractPDEProblem)
+  print(io,
+    type_color,nameof(typeof(prob)),
+    no_color)
+end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -4,14 +4,19 @@ function DEFAULT_OBSERVED(sym,u,p,t)
   error("Indexing symbol $sym is unknown.")
 end
 
-Base.summary(prob::AbstractSciMLFunction) = string(TYPE_COLOR, nameof(typeof(prob)),
-                                                   NO_COLOR, ". In-place: ",
-                                                   TYPE_COLOR, isinplace(prob),
-                                                   NO_COLOR)
+function Base.summary(io::IO, prob::AbstractSciMLFunction)
+  type_color, no_color = get_colorizers(io)
+  print(io, 
+    type_color, nameof(typeof(prob)),
+    no_color, ". In-place: ",
+    type_color, isinplace(prob),
+    no_color)
+end
+
 TreeViews.hastreeview(x::AbstractSciMLFunction) = true
 function TreeViews.treelabel(io::IO,x::AbstractSciMLFunction,
                              mime::MIME"text/plain" = MIME"text/plain"())
-  show(io,mime,Base.Text(Base.summary(x)))
+  summary(io, x)
 end
 
 """

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -39,8 +39,11 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractOptimizationSoluti
     return getfield(x,s)
 end
 
-Base.summary(A::AbstractOptimizationSolution) = string(
-                      TYPE_COLOR, nameof(typeof(A)),
-                      NO_COLOR, " with uType ",
-                      TYPE_COLOR, eltype(A.u),
-                      NO_COLOR)
+function Base.summary(io::IO, A::AbstractOptimizationSolution)
+    type_color, no_color = get_colorizers(io)
+    print(io,
+        type_color, nameof(typeof(A)),
+        no_color, " with uType ",
+        type_color, eltype(A.u),
+        no_color)
+end

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -10,7 +10,7 @@ Base.setindex!(A::AbstractNoTimeSolution, v, i::Int) = (A.u[i] = v)
 Base.setindex!(A::AbstractNoTimeSolution, v, I::Vararg{Int, N}) where {N} = (A.u[I] = v)
 Base.size(A::AbstractNoTimeSolution) = size(A.u)
 
-Base.summary(A::AbstractNoTimeSolution) = string(nameof(typeof(A))," with uType ",eltype(A.u))
+Base.summary(io::IO, A::AbstractNoTimeSolution) = print(io,nameof(typeof(A))," with uType ",eltype(A.u))
 Base.show(io::IO, A::AbstractNoTimeSolution) = (print(io,"u: ");show(io, A.u))
 Base.show(io::IO, m::MIME"text/plain", A::AbstractNoTimeSolution) = (print(io,"u: ");show(io,m,A.u))
 
@@ -84,12 +84,15 @@ end
 
 ## AbstractTimeseriesSolution Interface
 
-Base.summary(A::AbstractTimeseriesSolution) = string(
-                      TYPE_COLOR, nameof(typeof(A)),
-                      NO_COLOR, " with uType ",
-                      TYPE_COLOR, eltype(A.u),
-                      NO_COLOR, " and tType ",
-                      TYPE_COLOR, eltype(A.t), NO_COLOR)
+function Base.summary(io::IO, A::AbstractTimeseriesSolution)
+  type_color, no_color = get_colorizers(io)
+  print(io,
+    type_color, nameof(typeof(A)),
+    no_color, " with uType ",
+    type_color, eltype(A.u),
+    no_color, " and tType ",
+    type_color, eltype(A.t), no_color)
+end
 
 function Base.show(io::IO, A::AbstractTimeseriesSolution)
   println(io,string("retcode: ",A.retcode))
@@ -112,7 +115,7 @@ end
 TreeViews.hastreeview(x::DESolution) = true
 function TreeViews.treelabel(io::IO,x::DESolution,
                              mime::MIME"text/plain" = MIME"text/plain"())
-  show(io,mime,Text(Base.summary(x)))
+  summary(io,x)
 end
 
 RecursiveArrayTools.tuples(sol::AbstractTimeseriesSolution) = tuple.(sol.u,sol.t)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -57,6 +57,8 @@ end
 const TYPE_COLOR = CSI"36"  # Cyan
 const NO_COLOR = CSI"0"
 
+get_colorizers(io::IO) = get(io, :color, false) ? (TYPE_COLOR,NO_COLOR) : ("", "")
+
 """
     @def name definition
 """

--- a/test/display.jl
+++ b/test/display.jl
@@ -1,0 +1,23 @@
+using Test, SciMLBase
+
+
+showtest(x, with_color=true) = sprint() do io
+    Base.show(IOContext(io, :color => with_color), MIME"text/plain"(), x)
+end
+
+
+@testset "Respect :color setting in IOContext" begin
+    local prob = ODEProblem(identity, 1.0, (0.0, 1.0), ones(1,1))
+
+    # This test might be too specific
+    # @test showtest(prob, true) == "\e[36mODEProblem\e[0m with uType \e[36mFloat64\e[0m and tType \e[36mFloat64\e[0m. In-place: \e[36mfalse\e[0m\ntimespan: (0.0, 1.0)\nu0: 1.0"
+
+
+    # Only test whether the colorizers are printed:
+    @test occursin(SciMLBase.TYPE_COLOR, showtest(prob, true))
+    @test occursin(SciMLBase.NO_COLOR, showtest(prob, true))
+    
+    @test !occursin(SciMLBase.TYPE_COLOR, showtest(prob, false))
+    @test !occursin(SciMLBase.NO_COLOR, showtest(prob, false))
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ const GROUP = get(ENV, "GROUP", "All")
 const is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
 
 @time begin
+@time @safetestset "Display" begin include("display.jl") end
 @time @safetestset "Existence functions" begin include("existence_functions.jl") end
 @time @safetestset "Integrator interface" begin include("integrator_tests.jl") end
 end


### PR DESCRIPTION
Resolves https://github.com/SciML/DifferentialEquations.jl/issues/728#issuecomment-789047602 by cleaning up the display methods.

# Problem

Currently, displaying an `ODEProblem` _in a display that does not support color_ looks glitchy, e.g.:
```
[36mODEProblem[0m with uType [36mArray{Int64,1}[0m and tType [36mFloat64[0m. In-place: [36mtrue[0m
timespan: (0.0, 100.0)
u0: [1, 0]
```

Here, `[36m` etc are "colorize" commands, `[36m` means "cyan from now on", when read by a terminal that supports color.

# Fix

Julia has a mechanism to solve such problems: `IOContext`. The `IO` (supertype of `IOContext`) argument to `Base.show`, `Base.summarize`, etc, contains extra information, including the `:color` flag, which the REPL sets to `true` if you are in a color terminal, and Pluto sets it to `false`, since it is not a (color) terminal.

The show methods in SciMLBase should check this `IOContext` property to switch colored output on or off. This is done by https://github.com/fonsp/SciMLBase.jl/blob/62c97e28276dfcfc398426198a15598cb566674e/src/utils.jl#L60 .

Many show methods in SciMLBase call `summary`, I have modified these calls to pass the `io` through to the `summary` call. I also changed the signatures of `Base.summary` overloads to take `io` as the first argument. This is the intended way to overload `Base.summary`, since the single-argument version is a fallback method built in to Julia. e.g.:

```julia
julia> struct Wow end

julia> Base.summary(io::IO, w::Wow) = println(io, "cool!")

julia> summary(Wow()) # (no io provided)
"cool!\n"
```

# Testing

Besides code review, I have only added one test, for an `ODEProblem`. To test fully test this PR, we should either:
- Add more tests like the one I wrote. This means constructing an instance for each type that has a show method defined, I wasn't sure how to do this easily.
- Use this branch of SciMLBase inside a REPL/Jupyter/Pluto session where all of these types occur, just to check that the show methods don't error.
- Be satisfied with code review.

FYI I changed the show methods for:
```
DEIntegrator

AbstractSciMLFunction

AbstractEnsembleSolution

DEProblem
AbstractLinearProblem
AbstractNonlinearProblem
AbstractOptimizationProblem
AbstractQuadratureProblem
AbstractNoiseProblem
AbstractEnsembleProblem
AbstractPDEProblem

AbstractOptimizationSolution

AbstractNoTimeSolution
```