### PR TITLE
Add `IncompleteProblemArgument`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.8.4"
+version = "1.9.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -482,6 +482,13 @@ Base type for AD choices.
 """
 abstract type AbstractADType end
 
+"""
+$(TYPEDEF)
+
+A placeholder for the argument of a problem.
+"""
+struct IncompleteProblemArgument end
+
 include("utils.jl")
 include("function_wrappers.jl")
 include("scimlfunctions.jl")


### PR DESCRIPTION
We can use

```julia
ODEProblem(fun, IncompleteProblemArgument(), (0, 10.0), IncompleteProblemArgument())
```

to explicitly hint to the libraries that incomplete initialization of a problem is intended.