### PR TITLE
Add 5-arg `mul!`

### DIFF
--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -16,6 +16,8 @@ for op in (:*, :/, :\), T in (:AbstractArray, :Number)
 end
 LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray) =
   mul!(Y, convert(AbstractMatrix,L), B)
+LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray, α::Number, β::Number) =
+  mul!(Y, convert(AbstractMatrix,L), B, α, β)
 LinearAlgebra.ldiv!(Y::AbstractVecOrMat, L::AbstractDiffEqLinearOperator, B::AbstractVecOrMat) =
   ldiv!(Y, convert(AbstractMatrix,L), B)
 for pred in (:isreal, :issymmetric, :ishermitian, :isposdef)


### PR DESCRIPTION
This PR simply adds a 5-arg `mul!` for `AbstractDiffEqLinearOperator`.

I'd like this functionality to be able to compose more things together and facilitate in place computations of sums of ODE-like functions and linear operators, i.e. something like `f(u) + L * u`:

```julia
f(du, u, p, t) # some in-place function writes du <- f(u)
mul!(du, L, u, 1, 1) # du <- L * u + f(u)
```

I'm not sure this is the right way to add this, please let me know if I need to think more about it! 😅 My current thinking is that I could use that, but maybe there's just no need for it?  🤷