### PR TITLE
Remove fallback for `op(α::Number, L::Operator)`

### DIFF
--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -10,9 +10,9 @@ LinearAlgebra.opnorm(L::AbstractDiffEqLinearOperator, p::Real=2) = opnorm(conver
 Base.@propagate_inbounds Base.getindex(L::AbstractDiffEqLinearOperator, I::Vararg{Any,N}) where {N} = convert(AbstractMatrix,L)[I...]
 Base.getindex(L::AbstractDiffEqLinearOperator, I::Vararg{Int, N}) where {N} =
   convert(AbstractMatrix,L)[I...]
-for op in (:*, :/, :\), T in (:AbstractArray, :Number)
-  @eval Base.$op(L::AbstractDiffEqLinearOperator, x::$T) = $op(convert(AbstractMatrix,L), x)
-  @eval Base.$op(x::$T, L::AbstractDiffEqLinearOperator) = $op(x, convert(AbstractMatrix,L))
+for op in (:*, :/, :\)
+  @eval Base.$op(L::AbstractDiffEqLinearOperator, x::AbstractArray) = $op(convert(AbstractMatrix,L), x)
+  @eval Base.$op(x::AbstractArray, L::AbstractDiffEqLinearOperator) = $op(x, convert(AbstractMatrix,L))
 end
 LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray) =
   mul!(Y, convert(AbstractMatrix,L), B)


### PR DESCRIPTION
This PR removes (unintended?) fallbacks for `op(α, L)` and `op(L, α)` where `op ∈ (:*, :/, :\)` when `α` is a `Number` and `L` an `AbstractDiffEqLinearOperator`. 

This is because, currently, DiffEqOperators overwrites (pirates) at least the `α * L` method to create a lazy `DiffEqScaledOperator`. My understanding from Slack discussions with Chris is that these operations with scalars should be removed here to avoid downstream piracy from DiffEqOperators which provides more efficient lazy operator constructions.