### PR TITLE
Move `DiffEqScaledOperator`

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -444,6 +444,11 @@ abstract type AbstractDiffEqLinearOperator{T} <: AbstractDiffEqOperator{T} end
 
 """
 $(TYPEDEF)
+"""
+abstract type AbstractDiffEqCompositeOperator{T} <: AbstractDiffEqLinearOperator{T} end
+
+"""
+$(TYPEDEF)
 
 Base for types defining SciML functions.
 """
@@ -488,9 +493,9 @@ include("scimlfunctions.jl")
 include("alg_traits.jl")
 
 include("operators/operators.jl")
+include("operators/basic_operators.jl")
 include("operators/diffeq_operator.jl")
 include("operators/common_defaults.jl")
-include("operators/basic_operators.jl")
 
 include("problems/problem_utils.jl")
 include("problems/discrete_problems.jl")
@@ -573,7 +578,7 @@ export EnsembleAnalysis, EnsembleSummary
 
 export tuples, intervals, TimeChoiceIterator
 
-export AffineDiffEqOperator
+export AffineDiffEqOperator, DiffEqScaledOperator
 
 export DiffEqScalar, DiffEqArrayOperator, DiffEqIdentity
 

--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -13,6 +13,8 @@ Base.getindex(L::AbstractDiffEqLinearOperator, I::Vararg{Int, N}) where {N} =
 for op in (:*, :/, :\)
   @eval Base.$op(L::AbstractDiffEqLinearOperator, x::AbstractArray) = $op(convert(AbstractMatrix,L), x)
   @eval Base.$op(x::AbstractArray, L::AbstractDiffEqLinearOperator) = $op(x, convert(AbstractMatrix,L))
+  @eval Base.$op(L::DiffEqArrayOperator, x::Number) = $op(convert(AbstractMatrix,L), x)
+  @eval Base.$op(x::Number, L::DiffEqArrayOperator) = $op(x, convert(AbstractMatrix,L))
 end
 LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray) =
   mul!(Y, convert(AbstractMatrix,L), B)

--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -18,8 +18,6 @@ for op in (:*, :/, :\)
 end
 LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray) =
   mul!(Y, convert(AbstractMatrix,L), B)
-LinearAlgebra.ldiv!(Y::AbstractVecOrMat, L::AbstractDiffEqLinearOperator, B::AbstractVecOrMat) =
-  ldiv!(Y, convert(AbstractMatrix,L), B)
 for pred in (:isreal, :issymmetric, :ishermitian, :isposdef)
   @eval LinearAlgebra.$pred(L::AbstractDiffEqLinearOperator) = $pred(convert(AbstractArray, L))
 end

--- a/src/operators/common_defaults.jl
+++ b/src/operators/common_defaults.jl
@@ -10,9 +10,9 @@ LinearAlgebra.opnorm(L::AbstractDiffEqLinearOperator, p::Real=2) = opnorm(conver
 Base.@propagate_inbounds Base.getindex(L::AbstractDiffEqLinearOperator, I::Vararg{Any,N}) where {N} = convert(AbstractMatrix,L)[I...]
 Base.getindex(L::AbstractDiffEqLinearOperator, I::Vararg{Int, N}) where {N} =
   convert(AbstractMatrix,L)[I...]
-for op in (:*, :/, :\), T in (:AbstractArray, :Number)
-  @eval Base.$op(L::AbstractDiffEqLinearOperator, x::$T) = $op(convert(AbstractMatrix,L), x)
-  @eval Base.$op(x::$T, L::AbstractDiffEqLinearOperator) = $op(x, convert(AbstractMatrix,L))
+for op in (:*, :/, :\)
+  @eval Base.$op(L::AbstractDiffEqLinearOperator, x::AbstractArray) = $op(convert(AbstractMatrix,L), x)
+  @eval Base.$op(x::AbstractArray, L::AbstractDiffEqLinearOperator) = $op(x, convert(AbstractMatrix,L))
 end
 LinearAlgebra.mul!(Y::AbstractArray, L::AbstractDiffEqLinearOperator, B::AbstractArray) =
   mul!(Y, convert(AbstractMatrix,L), B)


### PR DESCRIPTION
As a continuation from https://github.com/SciML/SciMLBase.jl/pull/41#issuecomment-808957928

This moves the following from DiffEqOperators
- DiffEqScaledOperator
- AbstractDiffEqCompositeOperator (since it was required by subtyping)
- update_coefficients!
- getops (since it was needed for other functions)
- Base and LinearAlgebra overloads for DiffEqScaledOperator

This should be tested together with https://github.com/SciML/DiffEqOperators.jl/pull/363