### PR TITLE
Change map for a for loop

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -187,6 +187,7 @@ function solve_batch(prob, alg, ::EnsembleSerial, II, pmap_batch_size; kwargs...
     throw(ArgumentError("number of trajectories must be positive"))
   end
   batch_data = [batch_func(first(II), prob, alg; kwargs...)]
+  sizehint!(batch_data,length(II))
   for i in 2:length(II)
     @inbounds push!(batch_data, batch_func(II[i], prob, alg; kwargs...))
   end


### PR DESCRIPTION
to work around https://github.com/JuliaLang/julia/issues/35800

which can cause very slow compile times in Julia 1.6. In Pumas, this change alone had the following effect on a single function call:

### Before:
```julia
40.194758 seconds (83.73 M allocations: 6.623 GiB, 2.70% gc time, 99.99% compilation time)
```

### After
```julia
2.916390 seconds (7.31 M allocations: 446.180 MiB, 3.71% gc time, 99.96% compilation time)
```

I'm erroring out in the empty case since it avoids the problem of determining the return type. I'd think that it's expected that the number of trajectories is positive. I actually think that part of the problem with `map` is that it has to consider the empty case but that is mostly speculation.