### PR TITLE
Relax type in the initialized array in responsible_map

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -183,12 +183,12 @@ function solve_batch(prob,alg,ensemblealg::EnsembleDistributed,II,pmap_batch_siz
 end
 
 function responsible_map(f,II...)
-  batch_data = [f(getindex.(II,1)...)]
+  batch_data = []
   sizehint!(batch_data,length(II[1]))
-  for i in 2:length(II[1])
+  for i in 1:length(II[1])
     @inbounds push!(batch_data, f(getindex.(II,i)...))
   end
-  batch_data
+  identity.(batch_data)
 end
 
 function SciMLBase.solve_batch(prob,alg,::EnsembleSerial,II,pmap_batch_size;kwargs...)

--- a/test/downstream/ensemble_zero_length.jl
+++ b/test/downstream/ensemble_zero_length.jl
@@ -12,3 +12,10 @@ ts = 0.0:0.1:1.0
 using SciMLBase.EnsembleAnalysis
 sim = solve(ensemble_prob,Tsit5(),EnsembleThreads(),trajectories=10,saveat=0.1)
 timeseries_point_meancov(sim,ts)
+
+function prob_sol(p)
+  prob = ODEProblem((u,p,t)->p*u, 0.5, (0.0,1.0), p, save_start=false, save_end=false)
+  sim = solve(prob,Tsit5())
+end
+mapres = SciMLBase.responsible_map(prob_sol, [0.5, diagm([1.0, 1.0])])
+@test length(mapres) == 2

--- a/test/downstream/ensemble_zero_length.jl
+++ b/test/downstream/ensemble_zero_length.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Test
+using OrdinaryDiffEq, Test, LinearAlgebra
 prob = ODEProblem((u,p,t)->1.01u,0.5,(0.0,1.0), save_start=false, save_end=false)
 function prob_func(prob,i,repeat)
   remake(prob,u0=rand()*prob.u0)
@@ -13,8 +13,8 @@ using SciMLBase.EnsembleAnalysis
 sim = solve(ensemble_prob,Tsit5(),EnsembleThreads(),trajectories=10,saveat=0.1)
 timeseries_point_meancov(sim,ts)
 
-function prob_sol(p)
-  prob = ODEProblem((u,p,t)->p*u, 0.5, (0.0,1.0), p, save_start=false, save_end=false)
+function prob_sol(_p)
+  prob = ODEProblem((u,p,t)->p.*u, _p, (0.0,1.0), _p, save_start=false, save_end=false)
   sim = solve(prob,Tsit5())
 end
 mapres = SciMLBase.responsible_map(prob_sol, [0.5, diagm([1.0, 1.0])])


### PR DESCRIPTION
`responsible_map` was leading to downstream issues where type signature of elements in ensemble solution don't match exactly.

https://github.com/SciML/DiffEqBase.jl/pull/510#issuecomment-629753607
Before

```
julia> @benchmark solve_ode(f, (a = 1, b = 1))
BenchmarkTools.Trial: 
  memory estimate:  6.32 MiB
  allocs estimate:  47533
  --------------
  minimum time:     6.613 ms (0.00% GC)
  median time:      8.372 ms (0.00% GC)
  mean time:        9.322 ms (7.21% GC)
  maximum time:     26.238 ms (0.00% GC)
  --------------
  samples:          535
  evals/sample:     1
 ```
  now
  
 ```
  BenchmarkTools.Trial: 
  memory estimate:  6.32 MiB
  allocs estimate:  47543
  --------------
  minimum time:     6.529 ms (0.00% GC)
  median time:      7.636 ms (0.00% GC)
  mean time:        8.178 ms (7.59% GC)
  maximum time:     20.434 ms (56.60% GC)
  --------------
  samples:          611
  evals/sample:     1
  ```
  
  https://github.com/SciML/DiffEqBase.jl/pull/510#issuecomment-629753801
  
  Before
  ```
  BenchmarkTools.Trial: 
  memory estimate:  796.84 KiB
  allocs estimate:  6016
  --------------
  minimum time:     536.576 μs (0.00% GC)
  median time:      672.692 μs (0.00% GC)
  mean time:        778.878 μs (11.43% GC)
  maximum time:     12.996 ms (88.09% GC)
  --------------
  samples:          6385
  evals/sample:     1
  ```
  now
  
  ```
  BenchmarkTools.Trial: 
  memory estimate:  808.78 KiB
  allocs estimate:  6148
  --------------
  minimum time:     574.533 μs (0.00% GC)
  median time:      726.960 μs (0.00% GC)
  mean time:        862.267 μs (9.92% GC)
  maximum time:     15.025 ms (95.01% GC)
  --------------
  samples:          5749
  evals/sample:     1
  ```