### PR TITLE
fix typo in commit about DynamicalODEProblem

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -85,8 +85,8 @@ abstract type AbstractDynamicalODEProblem end
 $(TYPEDEF)
 """
 struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
-# u' = f1(v)
-# v' = f2(t,u)
+# u' = f2(v)
+# v' = f1(t,u)
 """
     DynamicalODEProblem(f::DynamicalODEFunction,v0,u0,tspan,p=NullParameters(),callback=CallbackSet())
 


### PR DESCRIPTION
There was a small typo in a comment about DynamicalODEProblem.
Now the indices are in line with the [documentation](https://diffeq.sciml.ai/stable/types/dynamical_types/).

There seems to be similar problem with the Documentation of [HamiltonianProblem](https://github.com/SciML/DiffEqDocs.jl/issues/451).