### PR TITLE
Add missing method for indexing with `Colon`

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -7,6 +7,7 @@ Base.getindex(A::AbstractNoTimeSolution,i::Int) = A.u[i]
 Base.getindex(A::AbstractNoTimeSolution,I::Vararg{Int, N}) where {N} = A.u[I]
 Base.getindex(A::AbstractNoTimeSolution,I::AbstractArray{Int}) = A.u[I]
 Base.getindex(A::AbstractNoTimeSolution,I::CartesianIndex) = A.u[I]
+Base.getindex(A::AbstractNoTimeSolution,I::Colon) = A.u[I]
 Base.getindex(A::AbstractTimeseriesSolution,I::AbstractArray{Int}) = solution_slice(A,I)
 Base.setindex!(A::AbstractNoTimeSolution, v, i::Int) = (A.u[i] = v)
 Base.setindex!(A::AbstractNoTimeSolution, v, I::Vararg{Int, N}) where {N} = (A.u[I] = v)


### PR DESCRIPTION
`AbstractNoTimeSolution` is missing a method for `Base.getindex` with `Colon` as index.

This can lead otherwise to a `StackOverflowError` in a `SteadyStateAdjointProblem` through recursive calls to `Base.getindex(A::AbstractNoTimeSolution,sym)` when indexing the solution as `sol[:]`.