### PR TITLE
fix serial ensembles for jumps with prob_funcs

### DIFF
--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -7,23 +7,24 @@ struct EnsembleProblem{T,T2,T3,T4,T5} <: AbstractEnsembleProblem
   output_func::T3
   reduction::T4
   u_init::T5
-  safetycopy::Bool
+  safetycopy::Union{Bool,Nothing}
 end
 
 DEFAULT_PROB_FUNC(prob,i,repeat) = prob
 DEFAULT_OUTPUT_FUNC(sol,i) = (sol,false)
 DEFAULT_REDUCTION(u,data,I) = append!(u, data), false
+DEFAULT_SAFETYCOPY(prob_func) = prob_func !== DEFAULT_PROB_FUNC
 EnsembleProblem(prob;
     output_func = DEFAULT_OUTPUT_FUNC,
     prob_func= DEFAULT_PROB_FUNC,
     reduction = DEFAULT_REDUCTION,
     u_init = nothing,
-    safetycopy = prob_func !== DEFAULT_PROB_FUNC) =
+    safetycopy = nothing) =
     EnsembleProblem(prob,prob_func,output_func,reduction,u_init,safetycopy)
 
 EnsembleProblem(;prob,
     output_func = DEFAULT_OUTPUT_FUNC,
     prob_func= DEFAULT_PROB_FUNC,
     reduction = DEFAULT_REDUCTION,
-    u_init = nothing, p = nothing, safetycopy = prob_func !== DEFAULT_PROB_FUNC) =
+    u_init = nothing, p = nothing, safetycopy = nothing) =
     EnsembleProblem(prob,prob_func,output_func,reduction,u_init,safetycopy)


### PR DESCRIPTION
Seems to fix the serial case that was resetting the seed for jump problems in https://github.com/SciML/DiffEqJump.jl/issues/184, while multithreading still works as before.

I'm not sure if this will work properly for distributed or GPU problems (but I don't know if what we have now seeds properly in those cases). 

Happy to modify if there is a better solution.