### PR TITLE
Do not make AbstractHistoryFunction <: Function

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -270,7 +270,7 @@ export EnsembleSolution, EnsembleTestSolution, EnsembleSummary
 """
 $(TYPEDEF)
 """
-abstract type AbstractDiffEqInterpolation <: Function end
+abstract type AbstractDiffEqInterpolation end
 
 """
 $(TYPEDEF)


### PR DESCRIPTION
This effects Julia's specialization heuristics in undesirable ways. See https://discourse.julialang.org/t/delay-differential-equations-networks-with-different-delay-per-edge/69787