### PR TITLE
Add the ability to remake an `AbstractEnsembleProblem`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -66,14 +66,6 @@ function remake(prob::ODEProblem; f=missing,
   ODEProblem{isinplace(prob)}(f,u0,tspan,p,prob.problem_type;prob.kwargs..., kwargs...)
 end
 
-# function remake(thing::AbstractJumpProblem; kwargs...)
-#   parameterless_type(thing)(remake(thing.prob;kwargs...))
-# end
-
-# function remake(thing::AbstractEnsembleProblem; kwargs...)
-#   parameterless_type(thing)(remake(thing.prob;kwargs...))
-# end
-
 for T in [
     AbstractJumpProblem,
     AbstractEnsembleProblem,

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -66,10 +66,17 @@ function remake(prob::ODEProblem; f=missing,
   ODEProblem{isinplace(prob)}(f,u0,tspan,p,prob.problem_type;prob.kwargs..., kwargs...)
 end
 
-function remake(thing::AbstractJumpProblem; kwargs...)
-  parameterless_type(thing)(remake(thing.prob;kwargs...))
-end
+# function remake(thing::AbstractJumpProblem; kwargs...)
+#   parameterless_type(thing)(remake(thing.prob;kwargs...))
+# end
 
-function remake(thing::AbstractEnsembleProblem; kwargs...)
-  parameterless_type(thing)(remake(thing.prob;kwargs...))
+# function remake(thing::AbstractEnsembleProblem; kwargs...)
+#   parameterless_type(thing)(remake(thing.prob;kwargs...))
+# end
+
+for T in [
+    AbstractJumpProblem,
+    AbstractEnsembleProblem,
+    ]
+  @eval remake(thing::$T;kwargs...) = parameterless_type(thing)(remake(thing.prob;kwargs...))
 end

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -69,3 +69,7 @@ end
 function remake(thing::AbstractJumpProblem; kwargs...)
   parameterless_type(thing)(remake(thing.prob;kwargs...))
 end
+
+function remake(thing::AbstractEnsembleProblem; kwargs...)
+  parameterless_type(thing)(remake(thing.prob;kwargs...))
+end


### PR DESCRIPTION
This should enable the user to modify either an `AbstractEnsembleProblem` or the problem stored therein. There could be an issue if one tries to modify a field in the inner problem but the keyword is also in the `AbstractEnsembleProblem`, but I'll leave that up to your discretion if that's a real issue.