### PR TITLE
problem with factorizing Identity

### DIFF
--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -124,7 +124,11 @@ Like DiffEqArrayOperator, but stores a Factorization instead.
 
 Supports left division and `ldiv!` when applied to an array.
 """
-struct FactorizedDiffEqArrayOperator{T<:Number, FType <: Union{Factorization{T},Diagonal{T},Bidiagonal{T}} <: AbstractDiffEqLinearOperator{T}
+struct FactorizedDiffEqArrayOperator{T<:Number, FType <: Union{Factorization{T},
+                                                               Diagonal{T},
+                                                               Bidiagonal{T},
+                                                              }
+                                    } <: AbstractDiffEqLinearOperator{T}
   F::FType
 end
 

--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -124,7 +124,7 @@ Like DiffEqArrayOperator, but stores a Factorization instead.
 
 Supports left division and `ldiv!` when applied to an array.
 """
-struct FactorizedDiffEqArrayOperator{T<:Number,FType<:Factorization{T}} <: AbstractDiffEqLinearOperator{T}
+struct FactorizedDiffEqArrayOperator{T<:Number, FType <: Union{Factorization{T},Diagonal{T},Bidiagonal{T}} <: AbstractDiffEqLinearOperator{T}
   F::FType
 end
 

--- a/test/diffeqoperator.jl
+++ b/test/diffeqoperator.jl
@@ -1,8 +1,11 @@
 using SciMLBase
+using LinearAlgebra
 
 @testset "DiffEqOperator" begin
     A = rand(10,10);
     @test eachindex(A) === eachindex(SciMLBase.DiffEqArrayOperator(A))
     @test eachindex(A') === eachindex(SciMLBase.DiffEqArrayOperator(A'))
-end
 
+    A = Matrix(I,10,10) |> SciMLBase.DiffEqArrayOperator
+    @test factorize(A) isa SciMLBase.FactorizedDiffEqArrayOperator
+end


### PR DESCRIPTION
apparently `LinearAlgebra.factorize` can output types that are not `Factorization`s, but have defined left-division. so we should loosen type parameterization on `FactorizedDiffEqArrayOperator` to allow for `Diagonal`, `Bidiagonal`, and others. Would be good to have a flag in ArrayInterface that tells if a type has `ldiv!` defined. 

```julia
julia> using LinearAlgebra, SciMLBase; n=8;
julia> p = LinearProblem(Matrix(I,n,n), rand(n));
julia> A = p.A
DiffEqArrayOperator{Bool, Matrix{Bool}, typeof(SciMLBase.DEFAULT_UPDATE_FUNC)}(Bool[1 0 … 0 0; 0 1 … 0 0; … ; 0 0 … 1 0; 0 0 … 0 1], SciMLBase.DEFAULT_UPDATE_FUNC)

julia> factorize(A)
ERROR: MethodError: no method matching SciMLBase.FactorizedDiffEqArrayOperator(::Diagonal{Bool, Vector{Bool}})
Closest candidates are:
  SciMLBase.FactorizedDiffEqArrayOperator(::FType) where {T<:Number, FType<:Factorization{T}} at /Users/vp/.julia/packages/SciMLBase/x3z0g/src/operators/basic_operators.jl:128
Stacktrace:
 [1] factorize(L::DiffEqArrayOperator{Bool, Matrix{Bool}, typeof(SciMLBase.DEFAULT_UPDATE_FUNC)})
   @ SciMLBase ~/.julia/packages/SciMLBase/x3z0g/src/operators/common_defaults.jl:29
 [2] top-level scope
   @ REPL[138]:1
```