### PR TITLE
Prevent inference pessimization

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2158,9 +2158,7 @@ for S in [
         Base.convert(::Type{$S}, x::$S) = x
         Base.convert(::Type{$S{iip}}, x::T) where {T<:$S{iip}} where iip = x
         function ConstructionBase.constructorof(::Type{<:$S{iip}}) where iip
-            let IIP = iip
-                (args...) -> $S{IIP, map(typeof, args)...}(args...)
-            end
+            (args...) -> $S{IIP, map(typeof, args)...}(args...)
         end
     end
 end


### PR DESCRIPTION
The `let` block here, together with the constprop heuristics drops the type from `Const(true)` to `Bool`,
with progressively worse type information resulting from there. The result is that inference ends up
inferring a bunch of unnecessary code, which slows down total inference time. We saw about a 20%
inference time improvement for ODE initialization with this change.