### PR TITLE
Add the median to EnsembleSummary and adjust the plot recipe

### DIFF
--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -108,16 +108,18 @@ function SciMLBase.EnsembleSummary(sim::SciMLBase.AbstractEnsembleSolution{T,N},
                          t=sim[1].t;quantiles=[0.05,0.95]) where {T,N}
   if typeof(sim[1]) <: SciMLSolution
     m,v = timeseries_point_meanvar(sim,t)
+    med = timeseries_point_median(sim,t)
     qlow = timeseries_point_quantile(sim,quantiles[1],t)
     qhigh = timeseries_point_quantile(sim,quantiles[2],t)
   else
     m,v = timeseries_steps_meanvar(sim)
+    med = timeseries_steps_median(sim)
     qlow = timeseries_steps_quantile(sim,quantiles[1])
     qhigh = timeseries_steps_quantile(sim,quantiles[2])
   end
 
   trajectories = length(sim)
-  EnsembleSummary{T,N,typeof(t),typeof(m),typeof(v),typeof(qlow),typeof(qhigh)}(t,m,v,qlow,qhigh,trajectories,sim.elapsedTime,sim.converged)
+  EnsembleSummary{T,N,typeof(t),typeof(m),typeof(v),typeof(med),typeof(qlow),typeof(qhigh)}(t,m,v,med,qlow,qhigh,trajectories,sim.elapsedTime,sim.converged)
 end
 
 function timeseries_point_mean(sim,ts)

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -41,9 +41,9 @@ struct EnsembleSummary{T,N,Tt,S,S2,S3,S4,S5} <: AbstractEnsembleSolution{T,N,S}
   t::Tt
   u::S
   v::S2
-  med::S5
-  qlow::S3
-  qhigh::S4
+  med::S3
+  qlow::S4
+  qhigh::S5
   num_monte::Int
   elapsedTime::Float64
   converged::Bool

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -37,10 +37,11 @@ end
 """
 $(TYPEDEF)
 """
-struct EnsembleSummary{T,N,Tt,S,S2,S3,S4} <: AbstractEnsembleSolution{T,N,S}
+struct EnsembleSummary{T,N,Tt,S,S2,S3,S4,S5} <: AbstractEnsembleSolution{T,N,S}
   t::Tt
   u::S
   v::S2
+  med::S5
   qlow::S3
   qhigh::S4
   num_monte::Int
@@ -120,12 +121,12 @@ end
 @recipe function f(sim::EnsembleSummary;
                    idxs= typeof(sim.u[1])<:AbstractArray ? eachindex(sim.u[1]) : 1,
                    error_style=:ribbon,ci_type=:quantile)
-  if typeof(sim.u[1])<:AbstractArray
-    u = vecarr_to_vectors(sim.u)
-  else
-    u = [sim.u.u]
-  end
   if ci_type == :SEM
+    if typeof(sim.u[1])<:AbstractArray
+        u = vecarr_to_vectors(sim.u)
+    else
+        u = [sim.u.u]
+    end
     if typeof(sim.u[1])<:AbstractArray
       ci_low = vecarr_to_vectors(VectorOfArray([sqrt.(sim.v[i]/sim.num_monte).*1.96 for i in 1:length(sim.v)]))
       ci_high = ci_low
@@ -134,6 +135,11 @@ end
       ci_high = ci_low
     end
   elseif ci_type == :quantile
+    if typeof(sim.med[1])<:AbstractArray
+        u = vecarr_to_vectors(sim.med)
+    else
+        u = [sim.med.u]
+    end
     if typeof(sim.u[1])<:AbstractArray
       ci_low = u - vecarr_to_vectors(sim.qlow)
       ci_high = vecarr_to_vectors(sim.qhigh) - u

--- a/test/downstream/ensemble_zero_length.jl
+++ b/test/downstream/ensemble_zero_length.jl
@@ -13,6 +13,7 @@ ts = 0.0:0.1:1.0
 using SciMLBase.EnsembleAnalysis
 sim = solve(ensemble_prob,Tsit5(),EnsembleThreads(),trajectories=10,saveat=0.1)
 timeseries_point_meancov(sim,ts)
+timeseries_point_median(sim,ts)
 
 function prob_sol(_p)
   prob = ODEProblem((u,p,t)->p.*u, _p, (0.0,1.0), _p, save_start=false, save_end=false)


### PR DESCRIPTION
Fixes #132

The following script can be used for a before/after comparison:
```julia
using OrdinaryDiffEq, Plots

logistic(du, u, p, t) = @. du = p * u * (1 - u)
prob = ODEProblem(logistic, [1e-2], (0.0, 2.5), [3.0])
prob_func(prob, i, repeat) = i < 100 ? remake(prob, u0=[0.9]) : remake(prob, u0=[1e-2 + 0.001*randn()])
eprob = EnsembleProblem(prob, prob_func=prob_func)
esol = solve(eprob, Tsit5(), trajectories=1000)
esum = EnsembleSummary(esol, 0.0:0.01:2.5, quantiles=[0.1, 0.9])
plot(esum)
```
Now, the plot recipe plots the median and quantiles and the resulting plot becomes more easily interpretable.

I did not add any new tests or adjust version numbers, so please let me know what should be done in these regards.