### PR TITLE
Add the `DynamicalODEProblem` problem_type

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -115,7 +115,7 @@ Define a dynamical ODE problem from the two functions `f1` and `f2`.
 This is determined automatically, but not inferred.
 """
 function DynamicalODEProblem{iip}(f1,f2,du0,u0,tspan,p=NullParameters();kwargs...) where iip
-  ODEProblem(DynamicalODEFunction{iip}(f1,f2),ArrayPartition(du0,u0),tspan,p;kwargs...)
+  ODEProblem(DynamicalODEFunction{iip}(f1,f2),ArrayPartition(du0,u0),tspan,p,DynamicalODEProblem{iip}();kwargs...)
 end
 
 # u'' = f(t,u,du,ddu)


### PR DESCRIPTION
All other problems in this file set the `problem_type` of the resulting `ODEProblem`, e.g. the SecondorderODEProblem here: 
https://github.com/SciML/SciMLBase.jl/blob/8f709a06f208bf24900a93e5384bab95fade6b2d/src/problems/ode_problems.jl#L154-L155

It therefore seemed to me that this should also be the case for `DynamicalODEProblem`s. 