### PR TITLE
correct initialize dae signature

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -205,7 +205,7 @@ Runs the DAE initialization to find a consistent state vector. The optional
 argument `initializealg` can be used to specify a different initialization
 algorithm to use.
 """
-initialize_dae!(integrator::DEIntegrator) =
+initialize_dae!(integrator::DEIntegrator, initializealg = integrator.initializealg) =
        error("initialize_dae!: method has not been implemented for the integrator")
 
 """


### PR DESCRIPTION
Looks like closing https://github.com/SciML/DiffEqBase.jl/issues/737 only requires changing the function signature. I want to enable something like: 

```
struct MyAlg <: SciMLBase.DAEInitializationAlgorithm end

function SciMLBase.initialize_dae!(::SciMLBase.AbstractDAEIntegrator, ::MyAlg)
     some logic 
    return
end
```