### PR TITLE
move NoInit from OrdinaryDiffEq

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -246,6 +246,11 @@ $(TYPEDEF)
 """
 abstract type DAEInitializationAlgorithm <: SciMLAlgorithm end
 
+"""
+$(TYPEDEF)
+"""
+struct NoInit <: DAEInitializationAlgorithm end
+
 # PDE Discretizations
 
 """


### PR DESCRIPTION
This is a different approach to achieving the intended outcome in #144. If `NoInit()` is defined in SciML base then it is possible to do the following 

```julia
function my_initialization(my_problem::SciMLBase.DEProblem, args...)
      return
end

SciMLBase.solve(
        my_problem,
        solver;
        initializealg = NoInit(),
    )
```

It leaves it to the developer to be responsible that the residual is withing the specified tolerance of the solver but its a reasonable workaround to avoid a full OrdinaryDiffEq dependency. 

