### PR TITLE
Fix docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.31.1"
+version = "1.31.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -4,7 +4,6 @@ $(TYPEDEF)
 struct StandardBVProblem end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines an BVP problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/bvp_types/
@@ -13,63 +12,6 @@ Documentation Page: https://diffeq.sciml.ai/stable/types/bvp_types/
 
 To define a BVP Problem, you simply need to give the function ``f`` and the initial
 condition ``u_0`` which define an ODE:
-
-```math
-\frac{du}{dt} = f(u,p,t)
-```
-
-along with an implicit function `bc!` which defines the residual equation, where
-
-```math
-bc(u,p,t) = 0
-```
-
-is the manifold on which the solution must live. A common form for this is the
-two-point `BVProblem` where the manifold defines the solution at two points:
-
-```math
-u(t_0) = a
-u(t_f) = b
-```
-
-## Problem Type
-
-### Constructors
-
-```julia
-TwoPointBVProblem{isinplace}(f,bc!,u0,tspan,p=NullParameters();kwargs...)
-BVProblem{isinplace}(f,bc!,u0,tspan,p=NullParameters();kwargs...)
-```
-
-For any BVP problem type, `bc!` is the inplace function:
-
-```julia
-bc!(residual, u, p, t)
-```
-
-where `residual` computed from the current `u`. `u` is an array of solution values
-where `u[i]` is at time `t[i]`, while `p` are the parameters. For a `TwoPointBVProblem`,
-`t = tspan`. For the more general `BVProblem`, `u` can be all of the internal
-time points, and for shooting type methods `u=sol` the ODE solution.
-Note that all features of the `ODESolution` are present in this form.
-In both cases, the size of the residual matches the size of the initial condition.
-
-Parameters are optional, and if not given then a `NullParameters()` singleton
-will be used which will throw nice errors if you try to index non-existent
-parameters. Any extra keyword arguments are passed on to the solvers. For example,
-if you set a `callback` in the problem, then that `callback` will be added in
-every solve call.
-
-### Fields
-
-* `f`: The function for the ODE.
-* `bc`: The boundary condition function.
-* `u0`: The initial condition. Either the initial condition for the ODE as an
-  initial value problem, or a `Vector` of values for ``u(t_i)`` for collocation
-  methods
-* `tspan`: The timespan for the problem.
-* `p`: The parameters for the problem. Defaults to `NullParameters`
-* `kwargs`: The keyword arguments passed onto the solves.
 """
 struct BVProblem{uType,tType,isinplace,P,F,bF,PT,K} <: AbstractBVProblem{uType,tType,isinplace}
     f::F

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -1,5 +1,4 @@
 @doc doc"""
-$(TYPEDEF)
 
 Defines an implicit ordinary differential equation (ODE) or 
 differential-algebraic equation (DAE) problem.

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -4,7 +4,6 @@ $(TYPEDEF)
 struct StandardDDEProblem end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines a delay differential equation (DDE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/dde_types/

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -2,7 +2,6 @@ const DISCRETE_INPLACE_DEFAULT = convert(DiscreteFunction{true},(du,u,p,t) -> du
 const DISCRETE_OUTOFPLACE_DEFAULT = convert(DiscreteFunction{false},(u,p,t) -> u)
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines a discrete dynamical system problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/discrete_types/

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -4,7 +4,6 @@ $(TYPEDEF)
 struct StandardODEProblem end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines an ordinary differential equation (ODE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/ode_types/
@@ -153,7 +152,6 @@ function DynamicalODEProblem(f1,f2,du0,u0,tspan,p=NullParameters();kwargs...)
 end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines an dynamical ordinary differential equation (ODE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/dynamical_types/
@@ -225,7 +223,6 @@ function SecondOrderODEProblem(f,du0,u0,tspan,p=NullParameters();kwargs...)
 end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines a second order ordinary differential equation (ODE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/dynamical_types/
@@ -322,7 +319,6 @@ function SplitODEProblem(f1,f2,u0,tspan,p=NullParameters();kwargs...)
 end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines a split ordinary differential equation (ODE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/split_ode_types/

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,5 +1,4 @@
 @doc doc"""
-$(TYPEDEF)
 
 Defines a random ordinary differential equation (RODE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/rode_types/

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -1,5 +1,4 @@
 @doc doc"""
-$(TYPEDEF)
 
 Defines a stochastic delay differential equation (SDDE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/sdde_types/

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -4,7 +4,6 @@ $(TYPEDEF)
 struct StandardSDEProblem end
 
 @doc doc"""
-$(TYPEDEF)
 
 Defines an stochastic differential equation (SDE) problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/sde_types/

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,5 +1,4 @@
 @doc doc"""
-$(TYPEDEF)
 
 Defines an Defines a steady state ODE problem.
 Documentation Page: https://diffeq.sciml.ai/stable/types/steady_state_types/


### PR DESCRIPTION
Apparently 

```
@doc doc"""
$(TYPEDEF)
```

is not supported, and so you can't do typedef with the Latex support.