### PR TITLE
More informative diagnostic for dt <= dtmin

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -342,7 +342,7 @@ function check_error(integrator::DEIntegrator)
      integrator.t + integrator.dt < integrator.tdir*first(integrator.opts.tstops) :
      true) || (hasproperty(integrator,:accept_step) && !integrator.accept_step))
     if integrator.opts.verbose
-      @warn("dt <= dtmin. Aborting. There is either an error in your model specification or the true solution is unstable.")
+      @warn("dt($(integrator.dt)) <= dtmin($(integrator.opts.dtmin)) at t=$(integrator.t). Aborting. There is either an error in your model specification or the true solution is unstable.")
     end
     return :DtLessThanMin
   end


### PR DESCRIPTION
Include the actual values of `t`, `dt` and `dtmin` in the *dt <= dtmin* warning message to simplify the diagnostic.