### PR TITLE
Define single argument getindex method for AbstractNoTimeSolution

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -2,6 +2,7 @@
 const AllObserved = RecursiveArrayTools.AllObserved
 
 # No Time Solution : Forward to `A.u`
+Base.getindex(A::AbstractNoTimeSolution) = A.u[]
 Base.getindex(A::AbstractNoTimeSolution,i::Int) = A.u[i]
 Base.getindex(A::AbstractNoTimeSolution,I::Vararg{Int, N}) where {N} = A.u[I]
 Base.getindex(A::AbstractNoTimeSolution,I::AbstractArray{Int}) = A.u[I]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ if GROUP == "Core" || GROUP == "All"
     @time @safetestset "Table Traits" begin include("traits.jl") end
     @time @safetestset "Ensemble functionality" begin include("ensemble_tests.jl") end
     @time @safetestset "DiffEqOperator tests" begin include("diffeqoperator.jl") end
+    @time @safetestset "Solution interface" begin include("solution_interface.jl") end
 end
 
 if !is_APPVEYOR && GROUP == "Downstream"

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -1,0 +1,6 @@
+using Test, SciMLBase
+
+@testset "getindex" begin
+    u = rand(1)
+    @test SciMLBase.build_linear_solution(nothing, u, zeros(1), nothing)[] == u[]
+end


### PR DESCRIPTION
Currently, I'm getting
```julia
julia> u = rand(1)
1-element Vector{Float64}:
 0.994423898075866

julia> u[]
0.994423898075866

julia> SciMLBase.build_linear_solution(nothing, u, zeros(1), nothing)[]
ERROR: ArgumentError: invalid index: () of type Tuple{}
Stacktrace:
 [1] to_index(i::Tuple{})
   @ Base ./indices.jl:300
 [2] to_index(A::Vector{Float64}, i::Tuple{})
   @ Base ./indices.jl:277
 [3] to_indices
   @ ./indices.jl:333 [inlined]
 [4] to_indices
   @ ./indices.jl:325 [inlined]
 [5] getindex
   @ ./abstractarray.jl:1218 [inlined]
 [6] getindex(::SciMLBase.LinearSolution{Float64, 1, Vector{Float64}, Vector{Float64}, Nothing, Nothing})
   @ SciMLBase ~/.julia/dev/SciMLBase/src/solutions/solution_interface.jl:6
 [7] top-level scope
   @ REPL[7]:1
```
and after this change I'm getting
```julia
julia> SciMLBase.build_linear_solution(nothing, u, zeros(1), nothing)[]
0.994423898075866
```

I hit this case via https://github.com/JuliaArrays/StaticArrays.jl/blob/f395f356bc2ee0fb69d2187af084b3414961ad8f/src/convert.jl#L198

Where should I put the test?