### PR TITLE
Throw early warning function argument errors

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2629,9 +2629,9 @@ function NonlinearFunction{iip,true}(f;
     _colorvec = colorvec
   end
 
-  jaciip = jac !== nothing ? isinplace(jac,6,"jac") : iip
-  jvpiip = jvp !== nothing ? isinplace(jvp,7,"jvp") : iip
-  vjpiip = vjp !== nothing ? isinplace(vjp,7,"vjp") : iip
+  jaciip = jac !== nothing ? isinplace(jac,3,"jac") : iip
+  jvpiip = jvp !== nothing ? isinplace(jvp,4,"jvp") : iip
+  vjpiip = vjp !== nothing ? isinplace(vjp,4,"vjp") : iip
 
   nonconforming = (jaciip,jvpiip,vjpiip) .!= iip
   if any(nonconforming)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2158,10 +2158,10 @@ function DynamicalSDEFunction{iip,false}(f1,f2,g; mass_matrix=I,
                    tgrad,jac,jvp,vjp,jac_prototype,sparsity,
                    Wfact,Wfact_t,paramjac,syms,observed,colorvec)
 end
-# Here I changed `isinplace(f2, 4) -> isinplace(f2, 5)` to allow for extra arguments for dynamical functions.
-DynamicalSDEFunction(f1,f2,g; kwargs...) = DynamicalSDEFunction{isinplace(f2, 4)}(f1, f2, g; kwargs...)
+
+DynamicalSDEFunction(f1,f2,g; kwargs...) = DynamicalSDEFunction{isinplace(f2, 5)}(f1, f2, g; kwargs...)
 DynamicalSDEFunction{iip}(f1,f2, g; kwargs...) where iip =
-DynamicalSDEFunction{iip,RECOMPILE_BY_DEFAULT}(SDEFunction(f1,g), SDEFunction{iip}(f2,g), g; kwargs...)
+DynamicalSDEFunction{iip,RECOMPILE_BY_DEFAULT}(SDEFunction{iip}(f1,g), SDEFunction{iip}(f2,g), g; kwargs...)
 DynamicalSDEFunction(f::DynamicalSDEFunction; kwargs...) = f
 
 function RODEFunction{iip,true}(f;

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2689,7 +2689,7 @@ function NonlinearFunction{iip,false}(f;
 end
 NonlinearFunction{iip}(f; kwargs...) where iip = NonlinearFunction{iip,RECOMPILE_BY_DEFAULT}(f; kwargs...)
 NonlinearFunction{iip}(f::NonlinearFunction; kwargs...) where iip = f
-NonlinearFunction(f; kwargs...) = NonlinearFunction{isinplace(f, 4),RECOMPILE_BY_DEFAULT}(f; kwargs...)
+NonlinearFunction(f; kwargs...) = NonlinearFunction{isinplace(f, 3),RECOMPILE_BY_DEFAULT}(f; kwargs...)
 NonlinearFunction(f::NonlinearFunction; kwargs...) = f
 
 struct NoAD <: AbstractADType end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2159,7 +2159,7 @@ function DynamicalSDEFunction{iip,false}(f1,f2,g; mass_matrix=I,
                    Wfact,Wfact_t,paramjac,syms,observed,colorvec)
 end
 # Here I changed `isinplace(f2, 4) -> isinplace(f2, 5)` to allow for extra arguments for dynamical functions.
-DynamicalSDEFunction(f1,f2,g; kwargs...) = DynamicalSDEFunction{isinplace(f2, 5)}(f1, f2, g; kwargs...)
+DynamicalSDEFunction(f1,f2,g; kwargs...) = DynamicalSDEFunction{isinplace(f2, 4)}(f1, f2, g; kwargs...)
 DynamicalSDEFunction{iip}(f1,f2, g; kwargs...) where iip =
 DynamicalSDEFunction{iip,RECOMPILE_BY_DEFAULT}(SDEFunction(f1,g), SDEFunction{iip}(f2,g), g; kwargs...)
 DynamicalSDEFunction(f::DynamicalSDEFunction; kwargs...) = f

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -179,7 +179,7 @@ function isinplace(f,inplace_param_number,fname="f")
       # Find if there's a `f(args...)` dispatch
       # If so, no error
       for i in 1:length(nargs)
-        if nargs[i] < inplace_param_number && any(isequal(Vararg{Any}),methods(f)[1].sig.parameters)
+        if nargs[i] < inplace_param_number && any(isequal(Vararg{Any}),methods(f).ms[1].sig.parameters)
           # If varargs, assume iip
           return true
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -175,19 +175,17 @@ function isinplace(f,inplace_param_number,fname="f")
     elseif all(x->x>inplace_param_number,nargs)
       throw(TooManyArgumentsError(fname))
     elseif all(x->x<inplace_param_number-1,nargs)
-
-      #=
       # Possible extra safety?
       # Find if there's a `f(args...)` dispatch
       # If so, no error
       for i in 1:length(nargs)
         if nargs[i] < inplace_param_number && any(isequal(Vararg{Any}),methods(f)[1].sig.parameters)
-          return iip_dispatch
+          # If varargs, assume iip
+          return true
         end
       end
 
       # No varargs detected, error that there are dispatches but not the right ones
-      =#
 
       throw(TooFewArgumentsError(fname))
     else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -170,11 +170,25 @@ function isinplace(f,inplace_param_number,fname="f")
   oop_dispatch = any(x->x==inplace_param_number-1,nargs)
 
   if !iip_dispatch && !oop_dispatch
-    if nargs == 0
+    if length(nargs) == 0
       throw(NoMethodsError(fname))
     elseif all(x->x>inplace_param_number,nargs)
       throw(TooManyArgumentsError(fname))
     elseif all(x->x<inplace_param_number-1,nargs)
+
+      #=
+      # Possible extra safety?
+      # Find if there's a `f(args...)` dispatch
+      # If so, no error
+      for i in 1:length(nargs)
+        if nargs[i] < inplace_param_number && any(isequal(Vararg{Any}),methods(f)[1].sig.parameters)
+          return iip_dispatch
+        end
+      end
+
+      # No varargs detected, error that there are dispatches but not the right ones
+      =#
+
       throw(TooFewArgumentsError(fname))
     else
       throw(FunctionArgumentsError(fname))
@@ -187,7 +201,7 @@ function isinplace(f,inplace_param_number,fname="f")
 end
 
 isinplace(f::AbstractSciMLFunction{iip}) where {iip} = iip
-isinplace(f::AbstractSciMLFunction{iip}, inplace_param_number) where {iip} = iip
+isinplace(f::AbstractSciMLFunction{iip}, inplace_param_number,fname=nothing) where {iip} = iip
 
 """
     @CSI_str cmd

--- a/test/display.jl
+++ b/test/display.jl
@@ -7,7 +7,7 @@ end
 
 
 @testset "Respect :color setting in IOContext" begin
-    local prob = ODEProblem(identity, 1.0, (0.0, 1.0), ones(1,1))
+    local prob = ODEProblem((u,p,t)->u, 1.0, (0.0, 1.0), ones(1,1))
 
     # This test might be too specific
     # @test showtest(prob, true) == "\e[36mODEProblem\e[0m with uType \e[36mFloat64\e[0m and tType \e[36mFloat64\e[0m. In-place: \e[36mfalse\e[0m\ntimespan: (0.0, 1.0)\nu0: 1.0"

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -18,6 +18,7 @@ end
 ftoomany(u,p,t,x,y) = 2u
 u0 = 0.5
 tspan = (0.0,1.0)
+ODEProblem(ftoomany,u0,tspan)
 @test_throws SciMLBase.TooManyArgumentsError ODEProblem(ftoomany,u0,tspan)
 
 ftoofew(u,t) = 2u

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -18,7 +18,6 @@ end
 ftoomany(u,p,t,x,y) = 2u
 u0 = 0.5
 tspan = (0.0,1.0)
-ODEProblem(ftoomany,u0,tspan)
 @test_throws SciMLBase.TooManyArgumentsError ODEProblem(ftoomany,u0,tspan)
 
 ftoofew(u,t) = 2u

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -1,0 +1,231 @@
+using SciMLBase, Test
+
+ftoomany(u,p,t,x,y) = 2u
+u0 = 0.5
+tspan = (0.0,1.0)
+@test_throws SciMLBase.TooManyArgumentsError ODEProblem(ftoomany,u0,tspan)
+
+ftoofew(u,t) = 2u
+@test_throws SciMLBase.TooFewArgumentsError ODEProblem(ftoofew,u0,tspan)
+
+fmessedup(u,t) = 2u
+fmessedup(u,p,t,x,y) = 2u
+@test_throws SciMLBase.FunctionArgumentsError ODEProblem(fmessedup,u0,tspan)
+
+# Test SciMLFunctions
+
+foop(u,p,t) = u
+fiip(du,u,p,t) = du .= u
+
+jac(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,jac=jac)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,jac=jac)
+jac(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,jac=jac)
+ODEFunction(foop,jac=jac)
+jac(du,u,p,t) = [1.0]
+ODEFunction(fiip,jac=jac)
+@test_broken ODEFunction(foop,jac=jac)
+
+Wfact(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,Wfact=Wfact)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,Wfact=Wfact)
+Wfact(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,Wfact=Wfact)
+ODEFunction(foop,Wfact=Wfact)
+Wfact(du,u,p,t) = [1.0]
+ODEFunction(fiip,Wfact=Wfact)
+@test_broken ODEFunction(foop,Wfact=Wfact)
+
+Wfact_t(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,Wfact_t=Wfact_t)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,Wfact_t=Wfact_t)
+Wfact_t(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,Wfact_t=Wfact_t)
+ODEFunction(foop,Wfact_t=Wfact_t)
+Wfact_t(du,u,p,t) = [1.0]
+ODEFunction(fiip,Wfact_t=Wfact_t)
+@test_broken ODEFunction(foop,Wfact_t=Wfact_t)
+
+tgrad(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,tgrad=tgrad)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,tgrad=tgrad)
+tgrad(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,tgrad=tgrad)
+ODEFunction(foop,tgrad=tgrad)
+tgrad(du,u,p,t) = [1.0]
+ODEFunction(fiip,tgrad=tgrad)
+@test_broken ODEFunction(foop,tgrad=tgrad)
+
+paramjac(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,paramjac=paramjac)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,paramjac=paramjac)
+paramjac(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,paramjac=paramjac)
+ODEFunction(foop,paramjac=paramjac)
+paramjac(du,u,p,t) = [1.0]
+ODEFunction(fiip,paramjac=paramjac)
+@test_broken ODEFunction(foop,paramjac=paramjac)
+
+jvp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,jvp=jvp)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,jvp=jvp)
+jvp(u,v,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,jvp=jvp)
+ODEFunction(foop,jvp=jvp)
+jvp(du,u,v,p,t) = [1.0]
+ODEFunction(fiip,jvp=jvp)
+@test_broken ODEFunction(foop,jvp=jvp)
+
+vjp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(fiip,vjp=vjp)
+@test_throws SciMLBase.TooFewArgumentsError ODEFunction(foop,vjp=vjp)
+vjp(u,v,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError ODEFunction(fiip,vjp=vjp)
+ODEFunction(foop,vjp=vjp)
+vjp(du,u,v,p,t) = [1.0]
+ODEFunction(fiip,vjp=vjp)
+@test_broken ODEFunction(foop,vjp=vjp)
+
+# SDE
+
+foop(u,p,t) = u
+goop(u,p,t) = u
+
+fiip(du,u,p,t) = du .= u
+giip(du,u,p,t) = du .= u
+
+SDEFunction(fiip,giip)
+SDEFunction(foop,goop)
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(foop,giip)
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,goop)
+
+sjac(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,jac=sjac)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,jac=sjac)
+sjac(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,jac=sjac)
+SDEFunction(foop,goop,jac=sjac)
+sjac(du,u,p,t) = [1.0]
+SDEFunction(fiip,giip,jac=sjac)
+@test_broken SDEFunction(foop,goop,jac=sjac)
+
+sWfact(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,Wfact=sWfact)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,Wfact=sWfact)
+sWfact(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,Wfact=sWfact)
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,goop,Wfact=sWfact)
+SDEFunction(foop,goop,Wfact=sWfact)
+sWfact(du,u,p,t) = [1.0]
+SDEFunction(fiip,giip,Wfact=sWfact)
+@test_broken SDEFunction(foop,goop,Wfact=sWfact)
+
+sWfact_t(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,Wfact_t=sWfact_t)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,giip,Wfact_t=sWfact_t)
+sWfact_t(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,Wfact_t=sWfact_t)
+SDEFunction(foop,goop,Wfact_t=sWfact_t)
+sWfact_t(du,u,p,t) = [1.0]
+SDEFunction(fiip,giip,Wfact_t=sWfact_t)
+
+stgrad(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,tgrad=stgrad)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,tgrad=stgrad)
+stgrad(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,tgrad=stgrad)
+SDEFunction(foop,goop,tgrad=stgrad)
+stgrad(du,u,p,t) = [1.0]
+SDEFunction(fiip,giip,tgrad=stgrad)
+@test_broken SDEFunction(foop,goop,tgrad=stgrad)
+
+sparamjac(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,paramjac=sparamjac)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,paramjac=sparamjac)
+sparamjac(u,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,paramjac=sparamjac)
+SDEFunction(foop,goop,paramjac=sparamjac)
+sparamjac(du,u,p,t) = [1.0]
+SDEFunction(fiip,giip,paramjac=sparamjac)
+@test_broken SDEFunction(foop,goop,paramjac=sparamjac)
+
+sjvp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,jvp=sjvp)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,jvp=sjvp)
+sjvp(u,v,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,jvp=sjvp)
+SDEFunction(foop,goop,jvp=sjvp)
+sjvp(du,u,v,p,t) = [1.0]
+SDEFunction(fiip,giip,jvp=sjvp)
+@test_broken SDEFunction(foop,goop,jvp=sjvp)
+
+svjp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(fiip,giip,vjp=svjp)
+@test_throws SciMLBase.TooFewArgumentsError SDEFunction(foop,goop,vjp=svjp)
+svjp(u,v,p,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError SDEFunction(fiip,giip,vjp=svjp)
+SDEFunction(foop,goop,vjp=svjp)
+svjp(du,u,v,p,t) = [1.0]
+SDEFunction(fiip,giip,vjp=svjp)
+@test_broken SDEFunction(foop,goop,vjp=svjp)
+
+# DAEFunction
+
+dfoop(du,u,p,t) = du .+ u
+dfiip(res,du,u,p,t) = res .= du .+ u
+
+djac(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jac=djac)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jac=djac)
+djac(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jac=djac)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jac=djac)
+djac(du,u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jac=djac)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jac=djac)
+djac(du,u,p,gamma,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError DAEFunction(dfiip,jac=djac)
+DAEFunction(dfoop,jac=djac)
+djac(res,du,u,p,gamma,t) = [1.0]
+DAEFunction(dfiip,jac=djac)
+@test_broken DAEFunction(dfoop,jac=djac)
+
+djvp(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jvp=djvp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jvp=djvp)
+djvp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jvp=djvp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jvp=djvp)
+djvp(du,u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jvp=djvp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jvp=djvp)
+djvp(du,u,v,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,jvp=djvp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,jvp=djvp)
+djvp(du,u,v,p,gamma,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError DAEFunction(dfiip,jvp=djvp)
+DAEFunction(dfoop,jvp=djvp)
+djvp(res,du,u,v,p,gamma,t) = [1.0]
+DAEFunction(dfiip,jvp=djvp)
+@test_broken DAEFunction(dfoop,jvp=djvp)
+
+dvjp(u,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,vjp=dvjp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,vjp=dvjp)
+dvjp(u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,vjp=dvjp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,vjp=dvjp)
+dvjp(du,u,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,vjp=dvjp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,vjp=dvjp)
+dvjp(du,u,v,p,t) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfiip,vjp=dvjp)
+@test_throws SciMLBase.TooFewArgumentsError DAEFunction(dfoop,vjp=dvjp)
+dvjp(du,u,v,p,gamma,t) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError DAEFunction(dfiip,vjp=dvjp)
+DAEFunction(dfoop,vjp=dvjp)
+dvjp(res,du,u,v,p,gamma,t) = [1.0]
+DAEFunction(dfiip,vjp=dvjp)
+@test_broken DAEFunction(dfoop,vjp=dvjp)
+

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -229,3 +229,43 @@ dvjp(res,du,u,v,p,gamma,t) = [1.0]
 DAEFunction(dfiip,vjp=dvjp)
 @test_broken DAEFunction(dfoop,vjp=dvjp)
 
+# NonlinearFunction
+
+nfoop(u,p) = u
+nfiip(du,u,p) = du .= u
+
+njac(u) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfiip,jac=njac)
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfoop,jac=njac)
+njac(u,p) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError NonlinearFunction(nfiip,jac=njac)
+NonlinearFunction(nfoop,jac=njac)
+njac(du,u,p) = [1.0]
+NonlinearFunction(nfiip,jac=njac)
+@test_broken NonlinearFunction(nfoop,jac=njac)
+
+njvp(u) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfiip,jvp=njvp)
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfoop,jvp=njvp)
+njvp(u,p) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfiip,jvp=njvp)
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfoop,jvp=njvp)
+njvp(u,v,p) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError NonlinearFunction(nfiip,jvp=njvp)
+NonlinearFunction(nfoop,jvp=njvp)
+njvp(du,u,v,p) = [1.0]
+NonlinearFunction(nfiip,jvp=njvp)
+@test_broken NonlinearFunction(nfoop,jvp=njvp)
+
+nvjp(u) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfiip,vjp=nvjp)
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfoop,vjp=nvjp)
+nvjp(u,p) = [1.0]
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfiip,vjp=nvjp)
+@test_throws SciMLBase.TooFewArgumentsError NonlinearFunction(nfoop,vjp=nvjp)
+nvjp(u,v,p) = [1.0]
+@test_throws SciMLBase.NonconformingFunctionsError NonlinearFunction(nfiip,vjp=nvjp)
+NonlinearFunction(nfoop,vjp=nvjp)
+nvjp(du,u,v,p) = [1.0]
+NonlinearFunction(nfiip,vjp=nvjp)
+@test_broken NonlinearFunction(nfoop,vjp=nvjp)

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -1,5 +1,20 @@
 using SciMLBase, Test
 
+function test_num_args()
+    f(x) = 2x
+    f(x,y) = 2xy
+  
+    numpar = SciMLBase.numargs(f) # Should be [1,2]
+    g = (x,y) -> x^2
+    numpar2 = SciMLBase.numargs(g) # [2]
+    @show numpar,minimum(numpar) == 1,maximum(numpar) == 2
+    minimum(numpar) == 1 && maximum(numpar) == 2 && 
+                            maximum(numpar2) == 2 &&
+                            minimum(numpar2) == 2
+end
+  
+@test test_num_args()
+
 ftoomany(u,p,t,x,y) = 2u
 u0 = 0.5
 tspan = (0.0,1.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ end
 if GROUP == "Core" || GROUP == "All"
     @time @safetestset "Display" begin include("display.jl") end
     @time @safetestset "Existence functions" begin include("existence_functions.jl") end
+    @time @safetestset "Function Building Error Messages" begin include("function_building_error_messages.jl") end
     @time @safetestset "Integrator interface" begin include("integrator_tests.jl") end
     @time @safetestset "Table Traits" begin include("traits.jl") end
     @time @safetestset "Ensemble functionality" begin include("ensemble_tests.jl") end


### PR DESCRIPTION
Note that there is a broken case where `f` is `iip` and `jac` has `oop` and `iip` dispatches, but it throws a non-conforming error. That will take quite a bit of code to solve and is quite an edge case, so I'm not going to let that block this and will just keep as `@test_broken` with an issue open.