### PR TITLE
More information in function argument errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.42.1"
+version = "1.42.2"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -14,7 +14,7 @@ https://diffeq.sciml.ai/stable/basics/solution/
 
 - `u`: the representation of the ODE solution. Given as an array of solutions, where `u[i]`
   corresponds to the solution at time `t[i]`. It is recommended in most cases one does not
-  access `sol.u` directly and instead use the array interface described in the Solution 
+  access `sol.u` directly and instead use the array interface described in the Solution
   Handling page of the DifferentialEquations.jl documentation.
 - `t`: the time points corresponding to the saved values of the ODE solution.
 - `prob`: the original ODEProblem that was solved.
@@ -129,7 +129,12 @@ function build_solution(prob::Union{AbstractODEProblem, AbstractDDEProblem},
                         interp = LinearInterpolation(t, u),
                         retcode = :Default, destats = nothing, kwargs...)
     T = eltype(eltype(u))
-    N = length((size(prob.u0)..., length(u)))
+
+    if prob.u0 === nothing
+        N = 2
+    else
+        N = length((size(prob.u0)..., length(u)))
+    end
 
     if typeof(prob.f) <: Tuple
         f = prob.f[1]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -182,7 +182,7 @@ function isinplace(f, inplace_param_number, fname = "f", iip_preferred = true)
         if length(nargs) == 0
             throw(NoMethodsError(fname))
         elseif all(x -> x > inplace_param_number, nargs)
-            throw(TooManyArgumentsError(fname,f))
+            throw(TooManyArgumentsError(fname, f))
         elseif all(x -> x < inplace_param_number - 1, nargs)
             # Possible extra safety?
             # Find if there's a `f(args...)` dispatch
@@ -197,9 +197,9 @@ function isinplace(f, inplace_param_number, fname = "f", iip_preferred = true)
 
             # No varargs detected, error that there are dispatches but not the right ones
 
-            throw(TooFewArgumentsError(fname,f))
+            throw(TooFewArgumentsError(fname, f))
         else
-            throw(FunctionArgumentsError(fname,f))
+            throw(FunctionArgumentsError(fname, f))
         end
     else
         if iip_preferred


### PR DESCRIPTION
Now it will mention the methods that are available:

```julia
julia> ODEProblem(ftoomany, u0, tspan)
ERROR: All methods for the model function `f` had too many arguments. For example,
an ODEProblem `f` must define either `f(u,p,t)` or `f(du,u,p,t)`. This error
can be thrown if you define an ODE model for example as `f(du,u,p1,p2,t)`.
For more information on the required number of arguments for the function
you were defining, consult the documentation for the `SciMLProblem` or
`SciMLFunction` type that was being constructed.

A common reason for this occurance is due to following the MATLAB or SciPy
convention for parameter passing, i.e. to add each parameter as an arguemnt.
In the SciML convention, if you wish to pass multiple parameters, use a
struct or other collection to hold the parameters. For example, here is the
parameterized Lorenz equation:

function lorenz(du,u,p,t)
  du[1] = p[1]*(u[2]-u[1])
  du[2] = u[1]*(p[2]-u[3]) - u[2]
  du[3] = u[1]*u[2] - p[3]*u[3]
 end
 u0 = [1.0;0.0;0.0]
 p = [10.0,28.0,8/3]
 tspan = (0.0,100.0)
 prob = ODEProblem(lorenz,u0,tspan,p)


Notice that `f` is defined with a single `p`, an array which matches the definition
of the `p` in the `ODEProblem`. Note that `p` can be any Julia struct.

Offending function: f
Methods:
# 1 method for generic function "ftoomany":
[1] ftoomany(u, p, t, x, y) in Main at c:\Users\accou\.julia\dev\SciMLBase\test\function_building_error_messages.jl:18

Stacktrace:
 [1] isinplace(f::Function, inplace_param_number::Int64, fname::String, iip_preferred::Bool)
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\utils.jl:185
 [2] isinplace(f::Function, inplace_param_number::Int64)
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\utils.jl:177
 [3] ODEFunction(f::Function; kwargs::Base.Pairs{Symbol, Union{Nothing, typeof(SciMLBase.DEFAULT_OBSERVED)}, NTuple{12, Symbol}, NamedTuple{(:analytic, :tgrad, :jac, :jvp, :vjp, :Wfact, :Wfact_t, :paramjac, :syms, :indepsym, :observed, :colorvec), Tuple{Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}}})
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\scimlfunctions.jl:1808
 [4] convert(#unused#::Type{ODEFunction}, f::Function)
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\scimlfunctions.jl:3067
 [5] ODEProblem(f::Function, u0::Float64, tspan::Tuple{Float64, Float64}, p::SciMLBase.NullParameters; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\problems\ode_problems.jl:135
 [6] ODEProblem(f::Function, u0::Float64, tspan::Tuple{Float64, Float64}, p::SciMLBase.NullParameters) (repeats 2 times)
   @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\problems\ode_problems.jl:134
 [7] top-level scope
   @ REPL[1]:1

```