### PR TITLE
Typo fixes in Optimization.jl documentation

### DIFF
--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -317,7 +317,7 @@ Both inequality and equality constraints are defined by the `f.cons` function in
 description of the problem structure. This `f.cons` is given as a function `f.cons(u,p)` which computes
 the value of the constraints at `u`. For example, take `f.cons(u,p) = u[1] - u[2]`.
 With these definitions, `lcons` and `ucons` define the bounds on the constraint that the solvers try to satisfy.
-If `lcons` and `ucons` are `nothing`, then there are no constraints bounds, meaning that the constraint is satisfied when `-Inf < f.cons < Inf` (which of course is always!). If `lcons[i] = ucons[i] = 0`, then the constraint is satisfied when `f.cons(u,p)[i] = 0`, and so this implies the equality constraint ``u[1] = u[2]`. If `lcons[i] = ucons[i] = a`, then ``u[1] - u[2] = a`` is the equality constraint. 
+If `lcons` and `ucons` are `nothing`, then there are no constraints bounds, meaning that the constraint is satisfied when `-Inf < f.cons < Inf` (which of course is always!). If `lcons[i] = ucons[i] = 0`, then the constraint is satisfied when `f.cons(u,p)[i] = 0`, and so this implies the equality constraint `u[1] = u[2]`. If `lcons[i] = ucons[i] = a`, then ``u[1] - u[2] = a`` is the equality constraint. 
 
 Inequality constraints are then given by making `lcons[i] != ucons[i]`. For example, `lcons[i] = -Inf` and `ucons[i] = 0` would imply the inequality constraint ``u[1] <= u[2]`` since any `f.cons[i] <= 0` satisfies the constraint. Similarly, `lcons[i] = -1` and `ucons[i] = 1` would imply that `-1 <= f.cons[i] <= 1` is required or ``-1 <= u[1] - u[2] <= 1``.
 

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1540,7 +1540,7 @@ OptimizationFunction{iip}(f,adtype::AbstractADType=NoAD();
 - `cons_j(res,x,p)` or `res=cons_j(x,p)`: the Jacobian of the constraints.
 - `cons_h(res,x,p)` or `res=cons_h(x,p)`: the Hessian of the constraints, provided as
    an array of Hessians with `res[i]` being the Hessian with respect to the `i`th output on `cons`.
-- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``.
+- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``. // This (and for hv) renders incorrectly, but didn't find why.
 - `hess_prototype`: a prototype matrix matching the type that matches the Hessian. For example,
   if the Hessian is tridiagonal, then an appropriately sized `Hessian` matrix can be used
   as the prototype and integrators will specialize on this structure where possible. Non-structured

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1542,7 +1542,7 @@ OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
 - `cons_j(res,x,p)` or `res=cons_j(x,p)`: the Jacobian of the constraints.
 - `cons_h(res,x,p)` or `res=cons_h(x,p)`: the Hessian of the constraints, provided as
    an array of Hessians with `res[i]` being the Hessian with respect to the `i`th output on `cons`.
-- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``. // This renders incorrectly (as does the hv doc), but didn't find why, fixes welcome.
+- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``.
 - `hess_prototype`: a prototype matrix matching the type that matches the Hessian. For example,
   if the Hessian is tridiagonal, then an appropriately sized `Hessian` matrix can be used
   as the prototype and integrators will specialize on this structure where possible. Non-structured

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1430,13 +1430,13 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-NonlinearFunction{iip,recompile}(f;
-                           analytic=nothing,
-                           jac=nothing,
-                           jvp=nothing,
-                           vjp=nothing,
-                           jac_prototype=nothing,
-                           sparsity=jac_prototype,
+NonlinearFunction{iip, recompile}(f;
+                           analytic = nothing,
+                           jac = nothing,
+                           jvp = nothing,
+                           vjp = nothing,
+                           jac_prototype = nothing,
+                           sparsity = jac_prototype,
                            paramjac = nothing,
                            syms = nothing,
                            indepsym = nothing,
@@ -1510,7 +1510,7 @@ OptimizationFunction{iip,AD,F,G,H,HV,C,CJ,CH,HP,CJP,CHP,S,HCV,CJCV,CHCV} <: Abst
 A representation of an optimization of an objective function `f`, defined by:
 
 ```math
-min_{u} f(u,p)
+\min_{u} f(u,p)
 ```
 
 and all of its related functions, such as the gradient of `f`, its Hessian,
@@ -1518,14 +1518,16 @@ and more. For all cases, `u` is the state and `p` are the parameters.
 
 ## Constructor
 
-OptimizationFunction{iip}(f,adtype::AbstractADType=NoAD();
-                          grad=nothing,hess=nothing,hv=nothing,
-                          cons=nothing, cons_j=nothing,cons_h=nothing,
-                          hess_prototype=nothing,cons_jac_prototype=nothing,
+```julia
+OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
+                          grad = nothing, hess = nothing, hv = nothing,
+                          cons = nothing, cons_j = nothing, cons_h = nothing,
+                          hess_prototype = nothing, cons_jac_prototype = nothing,
                           cons_hess_prototype = nothing,
                           syms = nothing, hess_colorvec = nothing,
                           cons_jac_colorvec = nothing,
                           cons_hess_colorvec = nothing)
+```
 
 - `adtype`: see the section "Defining Optimization Functions via AD"
 - `grad(G,u,p)` or `G=grad(u,p)`: the gradient of `f` with respect to `u`
@@ -1540,7 +1542,7 @@ OptimizationFunction{iip}(f,adtype::AbstractADType=NoAD();
 - `cons_j(res,x,p)` or `res=cons_j(x,p)`: the Jacobian of the constraints.
 - `cons_h(res,x,p)` or `res=cons_h(x,p)`: the Hessian of the constraints, provided as
    an array of Hessians with `res[i]` being the Hessian with respect to the `i`th output on `cons`.
-- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``. // This (and for hv) renders incorrectly, but didn't find why.
+- `paramjac(pJ,u,p)`: returns the parameter Jacobian ``\frac{df}{dp}``. // This renders incorrectly (as does the hv doc), but didn't find why, fixes welcome.
 - `hess_prototype`: a prototype matrix matching the type that matches the Hessian. For example,
   if the Hessian is tridiagonal, then an appropriately sized `Hessian` matrix can be used
   as the prototype and integrators will specialize on this structure where possible. Non-structured

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -29,7 +29,7 @@ The common local optimizer arguments are:
 Some optimizer algorithms have special keyword arguments documented in the
 solver portion of the documentation and their respective documentation.
 These arguments can be passed as `kwargs...` to `solve`. Similiarly, the special
-kewyword arguments for the `local_method` of a global optimizer are passed as a
+keyword arguments for the `local_method` of a global optimizer are passed as a
 `NamedTuple` to `local_options`.
 
 Over time we hope to cover more of these keyword arguments under the common interface.


### PR DESCRIPTION
Fixed trivial documentation bugs as I found them.