### PR TITLE
Restrict many ode_solutions.jl functions to actual `ODESolution`s

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -218,7 +218,7 @@ function calculate_solution_errors!(sol::AbstractODESolution; fill_uanalytic = t
     end
 end
 
-function build_solution(sol::AbstractODESolution{T, N}, u_analytic, errors) where {T, N}
+function build_solution(sol::ODESolution{T, N}, u_analytic, errors) where {T, N}
     ODESolution{T, N, typeof(sol.u), typeof(u_analytic), typeof(errors), typeof(sol.t),
                 typeof(sol.k),
                 typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
@@ -235,7 +235,7 @@ function build_solution(sol::AbstractODESolution{T, N}, u_analytic, errors) wher
                                                                                             sol.retcode)
 end
 
-function solution_new_retcode(sol::AbstractODESolution{T, N}, retcode) where {T, N}
+function solution_new_retcode(sol::ODESolution{T, N}, retcode) where {T, N}
     ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
                 typeof(sol.t), typeof(sol.k),
                 typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
@@ -252,7 +252,7 @@ function solution_new_retcode(sol::AbstractODESolution{T, N}, retcode) where {T,
                                                                                             retcode)
 end
 
-function solution_new_tslocation(sol::AbstractODESolution{T, N}, tslocation) where {T, N}
+function solution_new_tslocation(sol::ODESolution{T, N}, tslocation) where {T, N}
     ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
                 typeof(sol.t), typeof(sol.k),
                 typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
@@ -269,7 +269,7 @@ function solution_new_tslocation(sol::AbstractODESolution{T, N}, tslocation) whe
                                                                                             sol.retcode)
 end
 
-function solution_slice(sol::AbstractODESolution{T, N}, I) where {T, N}
+function solution_slice(sol::ODESolution{T, N}, I) where {T, N}
     ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
                 typeof(sol.t), typeof(sol.k),
                 typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u[I],
@@ -291,7 +291,7 @@ function solution_slice(sol::AbstractODESolution{T, N}, I) where {T, N}
                                                                                             sol.retcode)
 end
 
-function sensitivity_solution(sol::AbstractODESolution, u, t)
+function sensitivity_solution(sol::ODESolution, u, t)
     T = eltype(eltype(u))
     N = length((size(sol.prob.u0)..., length(u)))
     interp = if typeof(sol.interp) <: LinearInterpolation

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -41,6 +41,13 @@ struct ODESolution{T, N, uType, uType2, DType, tType, rateType, P, A, IType, DE}
     destats::DE
     retcode::Symbol
 end
+function ODESolution{T, N}(u, u_analytic, errors, t, k, prob, alg, interp, dense,
+                           tslocation, destats, retcode) where {T, N}
+    return ODESolution{T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
+                       typeof(k), typeof(prob), typeof(alg), typeof(interp), typeof(destats)
+                       }(u, u_analytic, errors, t, k, prob, alg, interp, dense, tslocation,
+                         destats, retcode)
+end
 function (sol::AbstractODESolution)(t, ::Type{deriv} = Val{0}; idxs = nothing,
                                     continuity = :left) where {deriv}
     sol(t, deriv, idxs, continuity)
@@ -145,37 +152,34 @@ function build_solution(prob::Union{AbstractODEProblem, AbstractDDEProblem},
     if has_analytic(f)
         u_analytic = Vector{typeof(prob.u0)}()
         errors = Dict{Symbol, real(eltype(prob.u0))}()
-        sol = ODESolution{T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
-                          typeof(k),
-                          typeof(prob), typeof(alg), typeof(interp), typeof(destats)}(u,
-                                                                                      u_analytic,
-                                                                                      errors,
-                                                                                      t, k,
-                                                                                      prob,
-                                                                                      alg,
-                                                                                      interp,
-                                                                                      dense,
-                                                                                      0,
-                                                                                      destats,
-                                                                                      retcode)
+        sol = ODESolution{T, N}(u,
+                                u_analytic,
+                                errors,
+                                t, k,
+                                prob,
+                                alg,
+                                interp,
+                                dense,
+                                0,
+                                destats,
+                                retcode)
         if calculate_error
             calculate_solution_errors!(sol; timeseries_errors = timeseries_errors,
                                        dense_errors = dense_errors)
         end
         return sol
     else
-        return ODESolution{T, N, typeof(u), Nothing, Nothing, typeof(t), typeof(k),
-                           typeof(prob), typeof(alg), typeof(interp), typeof(destats)}(u,
-                                                                                       nothing,
-                                                                                       nothing,
-                                                                                       t, k,
-                                                                                       prob,
-                                                                                       alg,
-                                                                                       interp,
-                                                                                       dense,
-                                                                                       0,
-                                                                                       destats,
-                                                                                       retcode)
+        return ODESolution{T, N}(u,
+                                 nothing,
+                                 nothing,
+                                 t, k,
+                                 prob,
+                                 alg,
+                                 interp,
+                                 dense,
+                                 0,
+                                 destats,
+                                 retcode)
     end
 end
 
@@ -219,76 +223,63 @@ function calculate_solution_errors!(sol::AbstractODESolution; fill_uanalytic = t
 end
 
 function build_solution(sol::ODESolution{T, N}, u_analytic, errors) where {T, N}
-    ODESolution{T, N, typeof(sol.u), typeof(u_analytic), typeof(errors), typeof(sol.t),
-                typeof(sol.k),
-                typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
-                                                                                            u_analytic,
-                                                                                            errors,
-                                                                                            sol.t,
-                                                                                            sol.k,
-                                                                                            sol.prob,
-                                                                                            sol.alg,
-                                                                                            sol.interp,
-                                                                                            sol.dense,
-                                                                                            sol.tslocation,
-                                                                                            sol.destats,
-                                                                                            sol.retcode)
+    ODESolution{T, N}(sol.u,
+                      u_analytic,
+                      errors,
+                      sol.t,
+                      sol.k,
+                      sol.prob,
+                      sol.alg,
+                      sol.interp,
+                      sol.dense,
+                      sol.tslocation,
+                      sol.destats,
+                      sol.retcode)
 end
 
 function solution_new_retcode(sol::ODESolution{T, N}, retcode) where {T, N}
-    ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
-                typeof(sol.t), typeof(sol.k),
-                typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
-                                                                                            sol.u_analytic,
-                                                                                            sol.errors,
-                                                                                            sol.t,
-                                                                                            sol.k,
-                                                                                            sol.prob,
-                                                                                            sol.alg,
-                                                                                            sol.interp,
-                                                                                            sol.dense,
-                                                                                            sol.tslocation,
-                                                                                            sol.destats,
-                                                                                            retcode)
+    ODESolution{T, N}(sol.u,
+                      sol.u_analytic,
+                      sol.errors,
+                      sol.t,
+                      sol.k,
+                      sol.prob,
+                      sol.alg,
+                      sol.interp,
+                      sol.dense,
+                      sol.tslocation,
+                      sol.destats,
+                      retcode)
 end
 
 function solution_new_tslocation(sol::ODESolution{T, N}, tslocation) where {T, N}
-    ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
-                typeof(sol.t), typeof(sol.k),
-                typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u,
-                                                                                            sol.u_analytic,
-                                                                                            sol.errors,
-                                                                                            sol.t,
-                                                                                            sol.k,
-                                                                                            sol.prob,
-                                                                                            sol.alg,
-                                                                                            sol.interp,
-                                                                                            sol.dense,
-                                                                                            tslocation,
-                                                                                            sol.destats,
-                                                                                            sol.retcode)
+    ODESolution{T, N}(sol.u,
+                      sol.u_analytic,
+                      sol.errors,
+                      sol.t,
+                      sol.k,
+                      sol.prob,
+                      sol.alg,
+                      sol.interp,
+                      sol.dense,
+                      tslocation,
+                      sol.destats,
+                      sol.retcode)
 end
 
 function solution_slice(sol::ODESolution{T, N}, I) where {T, N}
-    ODESolution{T, N, typeof(sol.u), typeof(sol.u_analytic), typeof(sol.errors),
-                typeof(sol.t), typeof(sol.k),
-                typeof(sol.prob), typeof(sol.alg), typeof(sol.interp), typeof(sol.destats)}(sol.u[I],
-                                                                                            sol.u_analytic ===
-                                                                                            nothing ?
-                                                                                            nothing :
-                                                                                            sol.u_analytic[I],
-                                                                                            sol.errors,
-                                                                                            sol.t[I],
-                                                                                            sol.dense ?
-                                                                                            sol.k[I] :
-                                                                                            sol.k,
-                                                                                            sol.prob,
-                                                                                            sol.alg,
-                                                                                            sol.interp,
-                                                                                            false,
-                                                                                            sol.tslocation,
-                                                                                            sol.destats,
-                                                                                            sol.retcode)
+    ODESolution{T, N}(sol.u[I],
+                      sol.u_analytic === nothing ? nothing : sol.u_analytic[I],
+                      sol.errors,
+                      sol.t[I],
+                      sol.dense ? sol.k[I] : sol.k,
+                      sol.prob,
+                      sol.alg,
+                      sol.interp,
+                      false,
+                      sol.tslocation,
+                      sol.destats,
+                      sol.retcode)
 end
 
 function sensitivity_solution(sol::ODESolution, u, t)
@@ -302,11 +293,9 @@ function sensitivity_solution(sol::ODESolution, u, t)
         SensitivityInterpolation(t, u)
     end
 
-    ODESolution{T, N, typeof(u), typeof(sol.u_analytic), typeof(sol.errors),
-                typeof(t), Nothing, typeof(sol.prob), typeof(sol.alg),
-                typeof(interp), typeof(sol.destats)}(u, sol.u_analytic, sol.errors, t,
-                                                     nothing, sol.prob,
-                                                     sol.alg, interp,
-                                                     sol.dense, sol.tslocation,
-                                                     sol.destats, sol.retcode)
+    ODESolution{T, N}(u, sol.u_analytic, sol.errors, t,
+                      nothing, sol.prob,
+                      sol.alg, interp,
+                      sol.dense, sol.tslocation,
+                      sol.destats, sol.retcode)
 end


### PR DESCRIPTION
As stated in #212, many functions in `ode_solutions.jl` are defined for `AbstractODESolution` objects, yet they return actual `ODESolution`s. This PR restricts these functions to `sol::ODESolution`.

The PR also adds a simpler constructor that shortens the code quite a bit: Instead of providing *all* types, one can now build an ODESolution with just `ODESolution{T, N}(u, u_analytic, ...)`.Please let me know if this is a desired change or not! If not I'll just remove the second commit of this PR again.