### PR TITLE
SDE u_analytic with noise as NoiseFunction

### DIFF
--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -114,8 +114,16 @@ function calculate_solution_errors!(sol::AbstractRODESolution; fill_uanalytic = 
     end
 
     if fill_uanalytic
-        for i in 1:length(sol)
-            push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[i]))
+        empty!(sol.u_analytic)
+        if sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
+            for i in 1:length(sol)
+            
+                push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))))
+            end
+        else
+            for i in 1:length(sol)
+                push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[i]))                
+            end
         end
     end
 

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -116,12 +116,14 @@ function calculate_solution_errors!(sol::AbstractRODESolution; fill_uanalytic = 
     if fill_uanalytic
         empty!(sol.u_analytic)
         if sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
-            for i in 1:length(sol)  
-                push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))))
+            for i in 1:length(sol)
+                push!(sol.u_analytic,
+                      f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))))
             end
         else
             for i in 1:length(sol)
-                push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[i]))                
+                push!(sol.u_analytic,
+                      f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[i]))
             end
         end
     end

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -116,8 +116,7 @@ function calculate_solution_errors!(sol::AbstractRODESolution; fill_uanalytic = 
     if fill_uanalytic
         empty!(sol.u_analytic)
         if sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
-            for i in 1:length(sol)
-            
+            for i in 1:length(sol)  
                 push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))))
             end
         else


### PR DESCRIPTION
This allows the computation of `sol.u_analytic` for problems of type `AbstractSDDEProblem` or `AbstractRODEProblem` with `noise` given as a `NoiseFunction`.

Previously, `sol.W[i]` would be called at https://github.com/SciML/SciMLBase.jl/blob/8bab6d3bc11c8db65d73875a2ea0f43bd854dd87/src/solutions/rode_solutions.jl#L118 regardless of being a proper vector-like `NoiseProcess` or a `NoiseFunction`, which would error for the latter. Checking whether `sol.W` is a `sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}` and calling `first(sol.W(sol.t[i]))` instead fixes the problem.

I also make sure to `empty!(sol.u_analytic)` before filling it to avoid inadvertently doubling its size from a possible previous call to `calculate_solution_errors!(sol)`.