### PR TITLE
Rode analytic with full `sol`

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1180,7 +1180,7 @@ struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, 
     observed::O
     colorvec::TCV
     sys::SYS
-    analytic_with_full_noise::FN
+    analytic_full::FN
 end
 
 """
@@ -2387,7 +2387,7 @@ function RODEFunction{iip, true}(f;
                                             DEFAULT_OBSERVED,
                                  colorvec = __has_colorvec(f) ? f.colorvec : nothing,
                                  sys = __has_sys(f) ? f.sys : nothing,
-                                 analytic_with_full_noise = __has_analytic_with_full_noise(f) = f.analytic_with_full_noise : nothing) where {iip}
+                                 analytic_full = __has_analytic_full(f) = f.analytic_full : nothing) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)
@@ -2427,10 +2427,10 @@ function RODEFunction{iip, true}(f;
                  typeof(jac), typeof(jvp), typeof(vjp), typeof(jac_prototype),
                  typeof(sparsity), typeof(Wfact), typeof(Wfact_t),
                  typeof(paramjac), typeof(syms), typeof(observed), typeof(_colorvec),
-                 typeof(sys), typeof(analytic_with_full_noise)}(f, mass_matrix, analytic, tgrad,
+                 typeof(sys), typeof(analytic_full)}(f, mass_matrix, analytic, tgrad,
                               jac, jvp, vjp, jac_prototype, sparsity,
                               Wfact, Wfact_t, paramjac, syms, observed,
-                              _colorvec, sys, analytic_with_full_noise)
+                              _colorvec, sys, analytic_full)
 end
 function RODEFunction{iip, false}(f;
                                   mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
@@ -2450,7 +2450,7 @@ function RODEFunction{iip, false}(f;
                                              DEFAULT_OBSERVED,
                                   colorvec = __has_colorvec(f) ? f.colorvec : nothing,
                                   sys = __has_sys(f) ? f.sys : nothing,
-                                  analytic_with_full_noise = __has_analytic_with_full_noise(f) = f.analytic_with_full_noise : nothing) where {iip}
+                                  analytic_full = __has_analytic_full(f) = f.analytic_full : nothing) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)
@@ -2491,7 +2491,7 @@ function RODEFunction{iip, false}(f;
                                                             jac, jvp, vjp, jac_prototype,
                                                             sparsity, Wfact, Wfact_t,
                                                             paramjac, syms, observed,
-                                                            _colorvec, sys, analytic_with_full_noise)
+                                                            _colorvec, sys, analytic_full)
 end
 function RODEFunction{iip}(f; kwargs...) where {iip}
     RODEFunction{iip, RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -3076,7 +3076,7 @@ __has_observed(f) = isdefined(f, :observed)
 __has_analytic(f) = isdefined(f, :analytic)
 __has_colorvec(f) = isdefined(f, :colorvec)
 __has_sys(f) = isdefined(f, :sys)
-__has_analytic_with_full_noise(f) = isdefined(f, :analytic_with_full_noise)
+__has_analytic_full(f) = isdefined(f, :analytic_full)
 
 # compatibility
 has_invW(f::AbstractSciMLFunction) = false

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1161,7 +1161,7 @@ For more details on this argument, see the ODEFunction documentation.
 
 The fields of the RODEFunction type directly match the names of the inputs.
 """
-struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, O, TCV, SYS, FN
+struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, O, TCV, SYS
                     } <:
        AbstractRODEFunction{iip}
     f::F
@@ -1180,7 +1180,7 @@ struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, 
     observed::O
     colorvec::TCV
     sys::SYS
-    analytic_full::FN
+    analytic_full::Bool
 end
 
 """
@@ -2387,7 +2387,7 @@ function RODEFunction{iip, true}(f;
                                             DEFAULT_OBSERVED,
                                  colorvec = __has_colorvec(f) ? f.colorvec : nothing,
                                  sys = __has_sys(f) ? f.sys : nothing,
-                                 analytic_full = __has_analytic_full(f) = f.analytic_full : nothing) where {iip}
+                                 analytic_full = __has_analytic_full(f) = f.analytic_full : false) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)
@@ -2427,7 +2427,7 @@ function RODEFunction{iip, true}(f;
                  typeof(jac), typeof(jvp), typeof(vjp), typeof(jac_prototype),
                  typeof(sparsity), typeof(Wfact), typeof(Wfact_t),
                  typeof(paramjac), typeof(syms), typeof(observed), typeof(_colorvec),
-                 typeof(sys), typeof(analytic_full)}(f, mass_matrix, analytic, tgrad,
+                 typeof(sys)}(f, mass_matrix, analytic, tgrad,
                               jac, jvp, vjp, jac_prototype, sparsity,
                               Wfact, Wfact_t, paramjac, syms, observed,
                               _colorvec, sys, analytic_full)
@@ -2450,7 +2450,7 @@ function RODEFunction{iip, false}(f;
                                              DEFAULT_OBSERVED,
                                   colorvec = __has_colorvec(f) ? f.colorvec : nothing,
                                   sys = __has_sys(f) ? f.sys : nothing,
-                                  analytic_full = __has_analytic_full(f) = f.analytic_full : nothing) where {iip}
+                                  analytic_full = __has_analytic_full(f) = f.analytic_full : false) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1161,7 +1161,7 @@ For more details on this argument, see the ODEFunction documentation.
 
 The fields of the RODEFunction type directly match the names of the inputs.
 """
-struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, O, TCV, SYS
+struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, O, TCV, SYS, FN
                     } <:
        AbstractRODEFunction{iip}
     f::F
@@ -1180,6 +1180,7 @@ struct RODEFunction{iip, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, S, 
     observed::O
     colorvec::TCV
     sys::SYS
+    analytic_with_full_noise::FN
 end
 
 """
@@ -2385,7 +2386,8 @@ function RODEFunction{iip, true}(f;
                                  observed = __has_observed(f) ? f.observed :
                                             DEFAULT_OBSERVED,
                                  colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                 sys = __has_sys(f) ? f.sys : nothing) where {iip}
+                                 sys = __has_sys(f) ? f.sys : nothing,
+                                 analytic_with_full_noise = __has_analytic_with_full_noise(f) = f.analytic_with_full_noise : nothing) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)
@@ -2425,10 +2427,10 @@ function RODEFunction{iip, true}(f;
                  typeof(jac), typeof(jvp), typeof(vjp), typeof(jac_prototype),
                  typeof(sparsity), typeof(Wfact), typeof(Wfact_t),
                  typeof(paramjac), typeof(syms), typeof(observed), typeof(_colorvec),
-                 typeof(sys)}(f, mass_matrix, analytic, tgrad,
+                 typeof(sys), typeof(analytic_with_full_noise)}(f, mass_matrix, analytic, tgrad,
                               jac, jvp, vjp, jac_prototype, sparsity,
                               Wfact, Wfact_t, paramjac, syms, observed,
-                              _colorvec, sys)
+                              _colorvec, sys, analytic_with_full_noise)
 end
 function RODEFunction{iip, false}(f;
                                   mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
@@ -2447,7 +2449,8 @@ function RODEFunction{iip, false}(f;
                                   observed = __has_observed(f) ? f.observed :
                                              DEFAULT_OBSERVED,
                                   colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                  sys = __has_sys(f) ? f.sys : nothing) where {iip}
+                                  sys = __has_sys(f) ? f.sys : nothing,
+                                  analytic_with_full_noise = __has_analytic_with_full_noise(f) = f.analytic_with_full_noise : nothing) where {iip}
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)
         if iip
             jac = update_coefficients! #(J,u,p,t)
@@ -2488,7 +2491,7 @@ function RODEFunction{iip, false}(f;
                                                             jac, jvp, vjp, jac_prototype,
                                                             sparsity, Wfact, Wfact_t,
                                                             paramjac, syms, observed,
-                                                            _colorvec, sys)
+                                                            _colorvec, sys, analytic_with_full_noise)
 end
 function RODEFunction{iip}(f; kwargs...) where {iip}
     RODEFunction{iip, RECOMPILE_BY_DEFAULT}(f; kwargs...)
@@ -3073,6 +3076,7 @@ __has_observed(f) = isdefined(f, :observed)
 __has_analytic(f) = isdefined(f, :analytic)
 __has_colorvec(f) = isdefined(f, :colorvec)
 __has_sys(f) = isdefined(f, :sys)
+__has_analytic_with_full_noise(f) = isdefined(f, :analytic_with_full_noise)
 
 # compatibility
 has_invW(f::AbstractSciMLFunction) = false

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -115,11 +115,8 @@ function calculate_solution_errors!(sol::AbstractRODESolution; fill_uanalytic = 
 
     if fill_uanalytic
         empty!(sol.u_analytic)
-        if f isa RODEFunction && f.analytic_with_full_noise == true
-            for i in 1:length(sol)
-                push!(sol.u_analytic,
-                      f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W))
-            end
+        if f isa RODEFunction && f.analytic_full == true
+            f.analytic(sol)
         elseif sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
             for i in 1:length(sol)
                 push!(sol.u_analytic,

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -115,7 +115,12 @@ function calculate_solution_errors!(sol::AbstractRODESolution; fill_uanalytic = 
 
     if fill_uanalytic
         empty!(sol.u_analytic)
-        if sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
+        if f isa RODEFunction && f.analytic_with_full_noise == true
+            for i in 1:length(sol)
+                push!(sol.u_analytic,
+                      f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W))
+            end
+        elseif sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
             for i in 1:length(sol)
                 push!(sol.u_analytic,
                       f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i]))))


### PR DESCRIPTION
When solving a linear RODE `dX/dt = g(t, W_t) X` , where `W_t` is a Wiener process or some other noise, the exact solution is `X_t = X_0 exp(\int_0^t g(W_s) ds)`. Similarly for a non-homogeneous linear RODE `dX/dt = h(W_t) + g(W_t) X`. Problem is that `u_analytic` receives, at a given time t, only `W_t` not the whole history `W_s` for `0 \leq s \leq t`. This PR adds an alternative `Bool` field `analytic_full` to `RODEFunction` that, when set to `true`, `solve` passes the whole `sol` to `f.analytic`. The user is responsible for mutating `sol.u_analytic` themselves, from `sol`.

Here is an example I am adding to `BenchmarkTools.jl`  (and a more generic version to `SDEProblemLibrary.jl`).
```julia
g(t, W) = sin(W)
f(u, t, p, W) = g(t, W) * u
u0 = 1.0
tspan = (0.0, 1.0)

function u_analytic!(sol)
    empty!(sol.u_analytic)
    integral = 0.0
    push!(sol.u_analytic, u0)
    for i in 2:length(sol)
        integral += (g(sol.W.t[i], sol.W.W[i]) + g(sol.W.t[i-1], sol.W.W[i-1])) * (sol.W.t[i] - sol.W.t[i-1]) / 2
        push!(sol.u_analytic, u0 * exp(integral))
    end
end

ff = RODEFunction(f, analytic=u_analytic!, analytic_full=true)
prob = RODEProblem(ff, u0, tspan)

sol = solve(prob, RandomHeun(), dt=1/100)
plot(sol)
plot!(sol.t, sol.u_analytic)
```

![plot_16](https://user-images.githubusercontent.com/17986148/187199704-f4642cb6-a1fe-4b9d-93bf-43d8d7193680.png)


At first, I thought of just passing `sol.W` to `f.analytic(u, p, t, sol.W)` for constructing `sol.u_analytic[i]`, but this amounts to computing the whole integral at each step `i` instead of just updating `int_{t0}^{t-dt}` to `\int_{t0}^t`, being highly inefficient. So, I opted for this less elegant but much more efficient way.