### PR TITLE
Allow for early wrapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.53.0"
+version = "1.53.1"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -568,6 +568,8 @@ function specialization(f::Union{ODEFunction{iip, specialize},
     specialize
 end
 
+specialization(f::AbstractSciMLFunction) = FullSpecialize
+
 """
 $(TYPEDEF)
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -113,6 +113,20 @@ struct ODEProblem{uType, tType, isinplace, P, F, K, PT} <:
                                                     kwargs...) where {iip, recompile}
         ODEProblem{iip}(ODEFunction{iip, recompile}(f), u0, tspan, p; kwargs...)
     end
+
+    function ODEProblem{iip, FunctionWrapperSpecialize}(f, u0, tspan, p = NullParameters();
+        kwargs...) where {iip}
+
+        ptspan = promote_tspan(tspan)
+        if !(f isa FunctionWrapperWrappers.FunctionWrapperWrapper)
+            if iip
+                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f, (u0, u0, p, ptspan[1]))
+            else
+                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f, (u0, p, ptspan[1])))
+            end
+        end
+        ODEProblem{iip}(ff, u0, tspan, p; kwargs...)
+    end
 end
 
 """
@@ -126,7 +140,6 @@ end
 
 function ODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     iip = isinplace(f, 4)
-
     ptspan = promote_tspan(tspan)
     _f = ODEFunction{iip, AutoSpecialize}(f)
     ODEProblem(_f, u0, tspan, p; kwargs...)

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -115,14 +115,17 @@ struct ODEProblem{uType, tType, isinplace, P, F, K, PT} <:
     end
 
     function ODEProblem{iip, FunctionWrapperSpecialize}(f, u0, tspan, p = NullParameters();
-        kwargs...) where {iip}
-
+                                                        kwargs...) where {iip}
         ptspan = promote_tspan(tspan)
         if !(f isa FunctionWrapperWrappers.FunctionWrapperWrapper)
             if iip
-                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f, (u0, u0, p, ptspan[1]))
+                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f,
+                                                                             (u0, u0, p,
+                                                                              ptspan[1])))
             else
-                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f, (u0, p, ptspan[1])))
+                ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f,
+                                                                             (u0, p,
+                                                                              ptspan[1])))
             end
         end
         ODEProblem{iip}(ff, u0, tspan, p; kwargs...)

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -61,9 +61,25 @@ function remake(prob::ODEProblem; f = missing,
     end
 
     if f === missing
-        _f = prob.f
+        if specialization(prob.f) === FunctionWrapperSpecialize
+            ptspan = promote_tspan(tspan)
+            if iip
+                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(unwrapped_f(prob.f), (u0, u0, p, ptspan[1]))
+            else
+                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(unwrapped_f(prob.f), (u0, p, ptspan[1])))
+            end
+        else
+            _f = prob.f
+        end
     elseif f isa AbstractODEFunction
         _f = f
+    elseif specialization(prob.f) === FunctionWrapperSpecialize
+        ptspan = promote_tspan(tspan)
+        if iip
+            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f, (u0, u0, p, ptspan[1]))
+        else
+            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f, (u0, p, ptspan[1])))
+        end
     else
         _f = ODEFunction{isinplace(prob), specialization(prob.f)}(f)
     end

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -60,6 +60,8 @@ function remake(prob::ODEProblem; f = missing,
         p = prob.p
     end
 
+    iip = isinplace(prob)
+
     if f === missing
         if specialization(prob.f) === FunctionWrapperSpecialize
             ptspan = promote_tspan(tspan)

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -64,9 +64,13 @@ function remake(prob::ODEProblem; f = missing,
         if specialization(prob.f) === FunctionWrapperSpecialize
             ptspan = promote_tspan(tspan)
             if iip
-                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(unwrapped_f(prob.f), (u0, u0, p, ptspan[1]))
+                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(unwrapped_f(prob.f),
+                                                                             (u0, u0, p,
+                                                                              ptspan[1])))
             else
-                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(unwrapped_f(prob.f), (u0, p, ptspan[1])))
+                _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(unwrapped_f(prob.f),
+                                                                             (u0, p,
+                                                                              ptspan[1])))
             end
         else
             _f = prob.f
@@ -76,9 +80,12 @@ function remake(prob::ODEProblem; f = missing,
     elseif specialization(prob.f) === FunctionWrapperSpecialize
         ptspan = promote_tspan(tspan)
         if iip
-            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f, (u0, u0, p, ptspan[1]))
+            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f,
+                                                                         (u0, u0, p,
+                                                                          ptspan[1])))
         else
-            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f, (u0, p, ptspan[1])))
+            _f = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f,
+                                                                         (u0, p, ptspan[1])))
         end
     else
         _f = ODEFunction{isinplace(prob), specialization(prob.f)}(f)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1762,11 +1762,7 @@ function ODEFunction{iip, recompile}(f;
 
     if (recompile === FunctionWrapperSpecialize) &&
        !(f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
-        if iip
-            f = wrapfun_iip(f)
-        else
-            f = wrapfun_oop(f)
-        end
+        error("FunctionWrapperSpecialize must be used on the problem constructor for access to u0, p, and t types!")
     end
 
     if jac === nothing && isa(jac_prototype, AbstractDiffEqLinearOperator)


### PR DESCRIPTION
This is mostly for testing.

```julia
using OrdinaryDiffEq, SnoopCompile, Profile, ProfileView
function lorenz(du, u, p, t)
    du[1] = 10.0(u[2] - u[1])
    du[2] = u[1] * (28.0 - u[3]) - u[2]
    du[3] = u[1] * u[2] - (8 / 3) * u[3]
end

@time begin
    lorenzprob = ODEProblem{true, SciMLBase.AutoSpecialize}(lorenz, [1.0; 0.0; 0.0], (0.0, 1.0), Float64[])
    sol = solve(lorenzprob, Rosenbrock23())
end

# FunctionWrapperSpecialize:
# 1.475326 seconds (83.83 k allocations: 3.442 MiB, 99.79% compilation time)
# 0.000184 seconds (458 allocations: 40.070 KiB)
# AutoSpecialize:
# 1.597643 seconds (958.02 k allocations: 49.979 MiB, 99.85% compilation time)
# 0.000182 seconds (467 allocations: 40.203 KiB
```

This is with a change to OrdinaryDiffEq.jl precompiling both. Currently it looks like this does not give any advantage (other than in allocations) over using the AutoSpecialize form. But it's good to keep this machinery around because it's completed and the speed of light version of such wrapping, so it can allow us to easily build fully complete pre-wrapped system image packages while not impacting the standard use case.

This also adds a specialization fallback to FullSpecialize on the special AbstractSciMLFunctions, which they will not want to auto-wrap.