### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/problems/problem_traits.jl
+++ b/src/problems/problem_traits.jl
@@ -13,8 +13,7 @@ function is_diagonal_noise(prob::AbstractSDDEProblem{uType, tType, lType, iip, N
                                                                                                 uType,
                                                                                                 tType,
                                                                                                 lType,
-                                                                                                iip,
-                                                                                                ND
+                                                                                                iip
                                                                                                 }
     true
 end


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.