### PR TITLE
cODEFunction -> ODEFunction (bug left from removing convert).

### DIFF
--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -91,7 +91,7 @@ struct BVProblem{uType, tType, isinplace, P, F, bF, PT, K} <:
     end
 
     function BVProblem{iip}(f, bc, u0, tspan, p = NullParameters(); kwargs...) where {iip}
-        BVProblem(cODEFunction{iip}(f), bc, u0, tspan, p; kwargs...)
+        BVProblem(ODEFunction{iip}(f), bc, u0, tspan, p; kwargs...)
     end
 end
 


### PR DESCRIPTION
modified:   src/problems/bvp_problems.jl cODEFunction -> ODEFunction

Not covered by tests. 
```
#Working:
BVProblem(ode!, bc!, initial_guess, tspan, p)
# Will also work with this PR:
BVProblem{true}(ode!, bc!, initial_guess, tspan, p)
```
I'm not sure when and how enabling compilation affects start-up-time, but it could be a side effect of this fix.