### PR TITLE
Fix integrator parameter indexing, enable tests

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -421,11 +421,10 @@ Base.@propagate_inbounds function Base.getindex(A::DEIntegrator,
 end
 
 Base.@propagate_inbounds function Base.getindex(A::DEIntegrator, sym)
-    if issymbollike(sym) || all(issymbollike, sym)
-        if sym isa AbstractArray
-            return map(s -> A[s], collect(sym))
-        end
+    if issymbollike(sym)
         i = sym_to_index(sym, A)
+    elseif all(issymbollike, sym)
+        return getindex.((A,), sym)
     else
         i = sym
     end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -436,7 +436,7 @@ Base.@propagate_inbounds function Base.getindex(A::DEIntegrator, sym)
         if issymbollike(sym) && indepsym !== nothing && Symbol(sym) == indepsym
             A.t
         elseif issymbollike(sym) && paramsyms !== nothing && Symbol(sym) in paramsyms
-            A.p[findfirst(Symbol(sym), paramsyms)]
+            A.p[findfirst(isequal(Symbol(sym)), paramsyms)]
         else
             observed(A, sym)
         end

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -61,11 +61,10 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractTimeseriesSolution,
 end
 
 Base.@propagate_inbounds function Base.getindex(A::AbstractTimeseriesSolution, sym)
-    if issymbollike(sym) || all(issymbollike, sym)
-        if sym isa AbstractArray
-            return map(s -> A[s], collect(sym))
-        end
+    if issymbollike(sym)
         i = sym_to_index(sym, A)
+    elseif all(issymbollike, sym)
+        return getindex.((A,), sym)
     else
         i = sym
     end

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -54,8 +54,8 @@ step!(integrator, 100.0, true)
 @test integrator[lorenz1.x] isa Real
 @test integrator[t] isa Real
 @test integrator[α] isa Real
-# @test integrator[γ] isa Real
-# @test integrator[γ] == 2.0
+@test integrator[γ] isa Real
+@test integrator[γ] == 2.0
 
 @testset "Symbolic set_u!" begin
     @variables u(t)

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -56,6 +56,7 @@ step!(integrator, 100.0, true)
 @test integrator[α] isa Real
 @test integrator[γ] isa Real
 @test integrator[γ] == 2.0
+@test integrator[(lorenz1.σ, lorenz1.ρ)] isa Tuple
 
 @testset "Symbolic set_u!" begin
     @variables u(t)

--- a/test/downstream/symbol_indexing.jl
+++ b/test/downstream/symbol_indexing.jl
@@ -68,6 +68,7 @@ sol = solve(prob, Rodas4())
 @test length(sol[α, 5:10]) == 6
 @test sol[γ] isa Real
 @test sol[γ] == 2.0
+@test sol[(lorenz1.σ, lorenz1.ρ)] isa Tuple
 
 # Check if indexing using variable names from interpolated solution works
 interpolated_sol = sol(0.0:1.0:10.0)

--- a/test/downstream/symbol_indexing.jl
+++ b/test/downstream/symbol_indexing.jl
@@ -66,8 +66,8 @@ sol = solve(prob, Rodas4())
 @test sol[α] isa Vector
 @test sol[α, 3] isa Float64
 @test length(sol[α, 5:10]) == 6
-# @test sol[γ] isa Real
-# @test sol[γ] == 2.0
+@test sol[γ] isa Real
+@test sol[γ] == 2.0
 
 # Check if indexing using variable names from interpolated solution works
 interpolated_sol = sol(0.0:1.0:10.0)


### PR DESCRIPTION
- Indexing integrators with parameters was broken, fixed it
- This wasn't caught by tests because the tests were commented. When the feature was introduced it needed changes in MTK and would've failed CI.
- Closes #273 