### PR TITLE
Fix typos

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,7 +63,7 @@ sets of problem types associated with common mathematical algorithms. These are:
 ## Inverse Problems, Parameter Estimation, and Structural Identification
 
 We note that parameter estimation and inverse problems are solved directly on their
-constituant problem types using tools like [DiffEqFlux.jl](https://github.com/SciML/DiffEqFlux.jl).
+constituent problem types using tools like [DiffEqFlux.jl](https://github.com/SciML/DiffEqFlux.jl).
 Thus for example, there is no `ODEInverseProblem`, and instead `ODEProblem` is used to
 find the parameters `p` that solve the inverse problem.
 

--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -40,7 +40,7 @@ section at the end of this page for some example usage.
   Defaults to saving all indices. For example, if you are solving a 3-dimensional ODE,
   and given `save_idxs = [1, 3]`, only the first and third components of the
   solution will be outputted.
-  Notice that of course in this case the outputed solution will be two-dimensional.
+  Notice that of course in this case the outputted solution will be two-dimensional.
 * `tstops`: Denotes *extra* times that the timestepping algorithm must step to.
   This should be used to help the solver deal with discontinuities and
   singularities, since stepping exactly at the time of the discontinuity will

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -187,7 +187,7 @@ multiple events.
    at the right index. Maximum index of `out` should be specified in the `len` property of callback. So this way you can have
    a chain of `len` events, which would cause the `i`th event to trigger when `out[i] = 0`.
 - `affect!`: This is a function `affect!(integrator, event_index)` which lets you modify `integrator` and it tells you about
-   which event occured using `event_idx` i.e. gives you index `i` for which `out[i]` came out to be zero.
+   which event occurred using `event_idx` i.e. gives you index `i` for which `out[i]` came out to be zero.
 - `len`: Number of callbacks chained. This is compulsory to be specified.
 
 Rest of the arguments have the same meaning as in [`ContinuousCallback`](@ref).
@@ -347,7 +347,7 @@ end
 """
     split_callbacks(cs, ds, args...)
 
-Split comma seperated callbacks into sets of continous and discrete callbacks.
+Split comma separated callbacks into sets of continuous and discrete callbacks.
 """
 @inline split_callbacks(cs, ds) = cs, ds
 @inline split_callbacks(cs, ds, c::Nothing, args...) = split_callbacks(cs, ds, args...)

--- a/src/operators/diffeq_operator.jl
+++ b/src/operators/diffeq_operator.jl
@@ -9,7 +9,7 @@ Takes in two tuples for split Affine DiffEqs
 
 1. update_coefficients! works by updating the coefficients of the component
    operators.
-2. Function calls L(u, p, t) and L(du, u, p, t) are fallbacks interpretted in this form.
+2. Function calls L(u, p, t) and L(du, u, p, t) are fallbacks interpreted in this form.
    This will allow them to work directly in the nonlinear ODE solvers without
    modification.
 3. f(du, u, p, t) is only allowed if a du_cache is given

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -134,9 +134,9 @@ This is determined automatically, but not inferred.
 * `kwargs`: The keyword arguments passed onto the solves.
 
 The for dynamical and second order DDEs, the history function will return an object with
-the indicies 1 and 2 defined, where `h(p, t_prev)[1]` is the value of ``f_2(v, u, h, p,
+the indices 1 and 2 defined, where `h(p, t_prev)[1]` is the value of ``f_2(v, u, h, p,
 t_{\mathrm{prev}})`` and `h(p, t_prev)[2]` is the value of ``f_1(v, u, h, p, t_{\mathrm{prev}})``
-(this is for consistency with the ordering of the intitial conditions in the constructor).
+(this is for consistency with the ordering of the initial conditions in the constructor).
 The supplied history function must also return such a 2-index object, which can be accomplished
 with a tuple `(v,u)` or vector `[v,u]`.
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -21,7 +21,7 @@ Note that we are not limited to numbers or vectors for `u₀`; one is allowed to
 provide `u₀` as arbitrary matrices / higher dimension tensors as well. ``u_{n+1}`` only depends on the previous
 iteration ``u_{n}`` and ``t_{n+1}``. The default ``t_{n+1}`` of `FunctionMap` is
 ``t_n = t_0 + n*dt`` (with `dt=1` being the default). For continuous-time Markov chains
-this is the time at which the change is occuring.
+this is the time at which the change is occurring.
 
 Note that if the discrete solver is set to have `scale_by_time=true`, then the problem
 is interpreted as the map:

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -23,9 +23,9 @@ runtime performance with a benefit of a greatly decreased compile-time.
 
 It is recommended that `AutoSpecialize` is not used in any benchmarking
 due to the potential effect of function wrapping on runtimes. `AutoSpecialize`'s
-use case is targetted at decreased latency for REPL performance and
+use case is targeted at decreased latency for REPL performance and
 not for cases where where top runtime performance is required (such as in
-optimization loops). Generally, for non-stiff equations the cost will be minimial
+optimization loops). Generally, for non-stiff equations the cost will be minimal
 and potentially not even measurable. For stiff equations, function wrapping
 has the limitation that only chunk sized 1 Dual numbers are allowed, which
 can decrease Jacobian construction performance.
@@ -33,8 +33,8 @@ can decrease Jacobian construction performance.
 ## Limitations of `AutoSpecialize`
 
 The following limitations are not fundamental to the implementation of `AutoSpecialize`,
-but are instead chosen as a comprimise between default precompilation times and
-ease of maintanance. Please open an issue to discuss lifting any potential
+but are instead chosen as a compromise between default precompilation times and
+ease of maintenance. Please open an issue to discuss lifting any potential
 limitations.
 
 * `AutoSpecialize` is only setup to wrap the functions from in-place ODEs. Other
@@ -188,7 +188,7 @@ end
 
 const NONCONFORMING_FUNCTIONS_ERROR_MESSAGE = """
                                               Nonconforming functions detected. If a model function `f` is defined
-                                              as in-place, then all constituant functions like `jac` and `paramjac`
+                                              as in-place, then all constituent functions like `jac` and `paramjac`
                                               must be in-place (and vice versa with out-of-place). Detected that
                                               some overloads did not conform to the same convention as `f`.
                                               """
@@ -303,7 +303,7 @@ The available specialization levels are:
   for the `prob.f` to stay unwrapped for normal usage. This is the default specialization
   level and strikes a balance in compile time vs runtime performance.
 * `SciMLBase.FullSpecialize`: this form fully specializes the `ODEFunction` on the
-  constituant functions that make its fields. As such, each `ODEFunction` in this
+  constituent functions that make its fields. As such, each `ODEFunction` in this
   form is uniquely typed, requiring re-specialization and compilation for each new
   ODE definition. This form has the highest compile-time at the cost of being the
   most optimal in runtime. This form should be preferred for long running calculations
@@ -698,7 +698,7 @@ DDEFunction{iip,specialize}(f;
 
 Note that only the function `f` itself is required. This function should
 be given as `f!(du,u,h,p,t)` or `du = f(u,h,p,t)`. See the section on `iip`
-for more details on in-place vs out-of-place handling. The histroy function
+for more details on in-place vs out-of-place handling. The history function
 `h` acts as an interpolator over time, i.e. `h(t)` with options matching
 the solution interface, i.e. `h(t; save_idxs = 2)`.
 
@@ -815,7 +815,7 @@ DynamicalDDEFunction{iip,specialize}(f1,f2;
 
 Note that only the functions `f_i` themselves are required. These functions should
 be given as `f_i!(du,u,h,p,t)` or `du = f_i(u,h,p,t)`. See the section on `iip`
-for more details on in-place vs out-of-place handling. The histroy function
+for more details on in-place vs out-of-place handling. The history function
 `h` acts as an interpolator over time, i.e. `h(t)` with options matching
 the solution interface, i.e. `h(t; save_idxs = 2)`.
 
@@ -1635,7 +1635,7 @@ SDDEFunction{iip,specialize}(f,g;
 
 Note that only the function `f` itself is required. This function should
 be given as `f!(du,u,h,p,t)` or `du = f(u,h,p,t)`. See the section on `iip`
-for more details on in-place vs out-of-place handling. The histroy function
+for more details on in-place vs out-of-place handling. The history function
 `h` acts as an interpolator over time, i.e. `h(t)` with options matching
 the solution interface, i.e. `h(t; save_idxs = 2)`.
 
@@ -3329,7 +3329,7 @@ function OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
                                       cons_expr, sys)
 end
 
-########## Existance Functions
+########## Existence Functions
 
 # Check that field/property exists (may be nothing)
 __has_jac(f) = isdefined(f, :jac)

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -16,7 +16,7 @@ https://diffeq.sciml.ai/stable/basics/solution/
   corresponds to the solution at time `t[i]`. It is recommended in most cases one does not
   access `sol.u` directly and instead use the array interface described in the Solution 
   Handling page of the DifferentialEquations.jl documentation.
-- `du`: the representation fo the derivatives of the DAE solution.
+- `du`: the representation of the derivatives of the DAE solution.
 - `t`: the time points corresponding to the saved values of the DAE solution.
 - `prob`: the original DAEProblem that was solved.
 - `alg`: the algorithm type used by the solver.

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -24,7 +24,7 @@ These common arguments are:
 - `reltol` (relative tolerance  in changes of the objective value)
 - `callback` (a callback function)
 
-If the chosen global optimzer employs a local optimization method a similiar set of common local optimizer arguments exists.
+If the chosen global optimzer employs a local optimization method a similar set of common local optimizer arguments exists.
 The common local optimizer arguments are:
 
 - `local_method` (optimiser used for local optimization in global method)
@@ -36,7 +36,7 @@ The common local optimizer arguments are:
 
 Some optimizer algorithms have special keyword arguments documented in the
 solver portion of the documentation and their respective documentation.
-These arguments can be passed as `kwargs...` to `solve`. Similiarly, the special
+These arguments can be passed as `kwargs...` to `solve`. Similarly, the special
 keyword arguments for the `local_method` of a global optimizer are passed as a
 `NamedTuple` to `local_options`.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -129,7 +129,7 @@ const TOO_FEW_ARGUMENTS_ERROR_MESSAGE = """
                                         All methods for the model function `f` had too few arguments. For example,
                                         an ODEProblem `f` must define either `f(u,p,t)` or `f(du,u,p,t)`. This error
                                         can be thrown if you define an ODE model for example as `f(u,t)`. The parameters
-                                        `p` are not optional in the defintion of `f`! For more information on the required
+                                        `p` are not optional in the definition of `f`! For more information on the required
                                         number of arguments for the function you were defining, consult the documentation
                                         for the `SciMLProblem` or `SciMLFunction` type that was being constructed.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ end
         @time @safetestset "Ensemble functionality" begin include("ensemble_tests.jl") end
         @time @safetestset "DiffEqOperator tests" begin include("diffeqoperator.jl") end
         @time @safetestset "Solution interface" begin include("solution_interface.jl") end
-        @time @safetestset "DE functon conversion" begin include("convert_tests.jl") end
+        @time @safetestset "DE function conversion" begin include("convert_tests.jl") end
     end
 
     if !is_APPVEYOR && GROUP == "Downstream"


### PR DESCRIPTION
Found and corrected some typos with the help of `codespell`. Could add to CI, would just have to figure out how to configure it to ignore `ND`, which it wants to correct to `AND` or `2ND`.