### PR TITLE
Implements init dispatch

### DIFF
--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -45,7 +45,8 @@ $(TYPEDEF)
 
 Representation the default cache for an optimization problem defined by an `OptimizationProblem`.
 """
-mutable struct DefaultOptimizationCache{F <: OptimizationFunction, P} <: AbstractOptimizationCache
+mutable struct DefaultOptimizationCache{F <: OptimizationFunction, P} <:
+               AbstractOptimizationCache
     f::F
     p::P
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -10,7 +10,7 @@ end
 
 """
 ```julia
-solve(prob::OptimizationProblem, alg::AbstractOptimizationAlgorithm; kwargs...)
+solve(prob::OptimizationProblem, alg::AbstractOptimizationAlgorithm, args...; kwargs...)
 ```
 
 ## Keyword Arguments
@@ -75,7 +75,8 @@ function callback(p,lossval,x,y,z)
 end
 ```
 """
-function solve(prob::OptimizationProblem, alg, args...; kwargs...)::AbstractOptimizationSolution
+function solve(prob::OptimizationProblem, alg, args...;
+               kwargs...)::AbstractOptimizationSolution
     if supports_opt_cache_interface(alg)
         solve!(init(prob, alg, args...; kwargs...))
     else
@@ -118,12 +119,43 @@ function Base.showerror(io::IO, e::OptimizerMissingError)
     print(e.alg)
 end
 
+"""
+```julia
+init(prob::OptimizationProblem, alg::AbstractOptimizationAlgorithm, args...; kwargs...)
+```
+
+## Keyword Arguments
+
+The arguments to `init` are the same as to `solve` and common across all of the optimizers.
+These common arguments are:
+
+- `maxiters` (the maximum number of iterations)
+- `maxtime` (the maximum of time the optimization runs for)
+- `abstol` (absolute tolerance in changes of the objective value)
+- `reltol` (relative tolerance  in changes of the objective value)
+- `callback` (a callback function)
+
+Some optimizer algorithms have special keyword arguments documented in the
+solver portion of the documentation and their respective documentation.
+These arguments can be passed as `kwargs...` to `init`.
+
+See also [`solve(prob::OptimizationProblem, alg, args...; kwargs...)`](@ref)
+"""
 function init(prob::OptimizationProblem, alg, args...; kwargs...)::AbstractOptimizationCache
     _check_opt_alg(prob::OptimizationProblem, alg; kwargs...)
     cache = __init(prob, alg, args...; kwargs...)
     return cache
 end
 
+"""
+```julia
+solve!(cache::AbstractOptimizationCache)
+```
+
+Solves the given optimization cache.
+
+See also [`init(prob::OptimizationProblem, alg, args...; kwargs...)`](@ref)
+"""
 function solve!(cache::AbstractOptimizationCache)::AbstractOptimizationSolution
     __solve(cache)
 end
@@ -131,7 +163,8 @@ end
 # needs to be defined for each cache
 supports_opt_cache_interface(alg) = false
 function __solve(cache::AbstractOptimizationCache)::AbstractOptimizationSolution end
-function __init(prob::OptimizationProblem, alg, args...; kwargs...)::AbstractOptimizationCache 
+function __init(prob::OptimizationProblem, alg, args...;
+                kwargs...)::AbstractOptimizationCache
     throw(OptimizerMissingError(alg))
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -79,12 +79,12 @@ function solve(prob::OptimizationProblem, alg, args...; kwargs...)::AbstractOpti
     if supports_opt_cache_interface(alg)
         solve!(init(prob, alg, args...; kwargs...))
     else
-        _check_opt_alg(prob, alg)
+        _check_opt_alg(prob, alg; kwargs...)
         __solve(prob, alg, args...; kwargs...)
     end
 end
 
-function _check_opt_alg(prob::OptimizationProblem, alg)
+function _check_opt_alg(prob::OptimizationProblem, alg; kwargs...)
     !allowsbounds(alg) && (!isnothing(prob.lb) || !isnothing(prob.ub)) &&
         throw(IncompatibleOptimizerError("The algorithm $(typeof(alg)) does not support box constraints. Either remove the `lb` or `ub` bounds passed to `OptimizationProblem` or use a different algorithm."))
     requiresbounds(alg) && isnothing(prob.lb) &&
@@ -119,7 +119,7 @@ function Base.showerror(io::IO, e::OptimizerMissingError)
 end
 
 function init(prob::OptimizationProblem, alg, args...; kwargs...)::AbstractOptimizationCache
-    _check_opt_alg(prob::OptimizationProblem, alg)
+    _check_opt_alg(prob::OptimizationProblem, alg; kwargs...)
     cache = __init(prob, alg, args...; kwargs...)
     return cache
 end


### PR DESCRIPTION
The current entrypoint is
```julia
solve(prob::OptimizationProblem, alg, args...; kwargs...)
```
and this method needs to be defined:
```julia
__solve(prob::OptimizationProblem, alg::SomeAlg, args...; kwargs...)
```
which is still possible, if no cache interface is defined.
If a cache interface should be defined the following methods have to be defined:
```julia
supports_opt_cache_interface(alg::SomeAlg) = true
__solve(cache::SomeAlgsOptimizationCache)::AbstractOptimizationSolution
__init(prob::OptimizationProblem, alg::SomeAlg, args...; kwargs...)::SomeAlgsOptimizationCache
```
The entry point is as in `CommonSolve`:
```julia
init(prob::OptimizationProblem, alg, args...; kwargs...)
solve!(cache::AbstractOptimizationCache)
```