### PR TITLE
Fixing "UndefVarError: Θm1 not defined"

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -473,13 +473,13 @@ end
 Linear Interpolation
 """
 @inline function interpolant(Θ, id::LinearInterpolation, dt, y₀, y₁, idxs, T::Type{Val{0}})
+    Θm1 = (1 - Θ)
     if idxs === nothing
-        out = @. (1 - Θ) * y₀ + Θ * y₁
+        out = @. Θm1 * y₀ + Θ * y₁
     elseif idxs isa Number
         out = Θm1 * y₀[idxs] + Θ * y₁[idxs]
     else
         out = similar(y₀, axes(idxs))
-        Θm1 = (1 - Θ)
         @views @. out = Θm1 * y₀[idxs] + Θ * y₁[idxs]
     end
     out


### PR DESCRIPTION
After solving a DAE I get the following error while processing the solution.
I tried to fix that and tested my changes. My code works now as expected.

```
ERROR: LoadError: UndefVarError: Θm1 not defined
Stacktrace:
  [1] interpolant
    @ C:\Users\homer\.julia\packages\SciMLBase\cJ8FF\src\interpolation.jl:479 [inlined]
  [2] interpolation(tval::Float64, id::SciMLBase.LinearInterpolation{Vector{Float64}, Vector{Vector{Float64}}}, idxs::Int64, deriv::Type{Val{0}}, p::Vector{Any}, continuity::Symbol)
    @ SciMLBase C:\Users\homer\.julia\packages\SciMLBase\cJ8FF\src\interpolation.jl:237
  [3] (::SciMLBase.LinearInterpolation{Vector{Float64}, Vector{Vector{Float64}}})(tvals::Float64, idxs::Int64, deriv::Type, p::Vector{Any}, continuity::Symbol)
    @ SciMLBase C:\Users\homer\.julia\packages\SciMLBase\cJ8FF\src\interpolation.jl:61
  [4] #_#394
    @ C:\Users\homer\.julia\packages\SciMLBase\cJ8FF\src\solutions\dae_solutions.jl:47 [inlined]
```