### PR TITLE
add `_unwrap_val` to `SciMLBase`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -479,3 +479,6 @@ function mergedefaults(defaults, varmap, vars)
         defaults
     end
 end
+
+_unwrap_val(::Val{B}) where {B} = B
+_unwrap_val(B) = B


### PR DESCRIPTION
This fixes a bug in `NonlinearSolve` and allows us to remove duplicated code from `OrdinaryDiffEq` and `LinearSolve` @YingboMa