### PR TITLE
adds process_p_u0_symbolic

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -133,6 +133,9 @@ function remake(prob::ODEProblem; f = missing,
     end
 end
 
+# overloaded in MTK to intercept symbolic remake
+function process_p_u0_symbolic end
+
 function remake(thing::AbstractJumpProblem; kwargs...)
     parameterless_type(thing)(remake(thing.prob; kwargs...))
 end


### PR DESCRIPTION
In order to be able to move everything related to processing symbolic `p` and `u0` maps to MTK.
- Next step is to implement the interface in MTK:  https://github.com/SciML/ModelingToolkit.jl/pull/1941
- And then to use it instead: https://github.com/SciML/SciMLBase.jl/pull/311