### PR TITLE
Consistent indexing with numbers and symbols, improved tests

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -422,6 +422,9 @@ end
 
 Base.@propagate_inbounds function Base.getindex(A::DEIntegrator, sym)
     if issymbollike(sym)
+        if sym isa AbstractArray
+            return A[collect(sym)]
+        end
         i = sym_to_index(sym, A)
     elseif all(issymbollike, sym)
         return getindex.((A,), sym)

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -73,6 +73,7 @@ integrator2 = init(prob2, Tsit5())
 @test integrator2[q] isa Vector{Float64}
 @test length(integrator2[q]) == length(q)
 @test integrator2[collect(q)] == integrator2[q]
+@test integrator[(q...,)] isa NTuple{length(q),Float64}
 
 @testset "Symbolic set_u!" begin
     @variables u(t)

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -73,7 +73,7 @@ integrator2 = init(prob2, Tsit5())
 @test integrator2[q] isa Vector{Float64}
 @test length(integrator2[q]) == length(q)
 @test integrator2[collect(q)] == integrator2[q]
-@test integrator[(q...,)] isa NTuple{length(q),Float64}
+@test integrator[(q...,)] isa NTuple{length(q), Float64}
 
 @testset "Symbolic set_u!" begin
     @variables u(t)

--- a/test/downstream/symbol_indexing.jl
+++ b/test/downstream/symbol_indexing.jl
@@ -73,7 +73,7 @@ sol = solve(prob, Rodas4())
 @test sol[[lorenz1.x, lorenz2.x]] isa Vector{Vector{Float64}}
 @test length(sol[[lorenz1.x, lorenz2.x]]) == length(sol)
 @test all(length.(sol[[lorenz1.x, lorenz2.x]]) .== 2)
-@test sol[(lorenz1.x, lorenz2.x)] isa Vector{Tuple{Float64,Float64}}
+@test sol[(lorenz1.x, lorenz2.x)] isa Vector{Tuple{Float64, Float64}}
 @test length(sol[(lorenz1.x, lorenz2.x)]) == length(sol)
 @test all(length.(sol[(lorenz1.x, lorenz2.x)]) .== 2)
 
@@ -90,7 +90,7 @@ prob2 = ODEProblem(sys2, [], (0.0, 5.0))
 sol2 = solve(prob2, Tsit5())
 
 @test sol2[q] isa Vector{Vector{Float64}}
-@test sol2[(q...,)] is Vector{NTuple{length(q),Float64}}
+@test sol2[(q...,)] is Vector{NTuple{length(q), Float64}}
 @test length(sol2[q]) == length(sol)
 @test all(length.(sol2[q]) .== 2)
 @test sol2[collect(q)] == sol2[q]

--- a/test/downstream/symbol_indexing.jl
+++ b/test/downstream/symbol_indexing.jl
@@ -70,10 +70,16 @@ sol = solve(prob, Rodas4())
 @test sol[γ] == 2.0
 @test sol[(lorenz1.σ, lorenz1.ρ)] isa Tuple
 
+@test sol[[lorenz1.x, lorenz2.x]] isa Vector{Vector{Float64}}
 @test length(sol[[lorenz1.x, lorenz2.x]]) == length(sol)
 @test all(length.(sol[[lorenz1.x, lorenz2.x]]) .== 2)
-@test sol[[γ, lorenz1.σ]] isa Vector{Vector{Float64}}
-@test length(sol[[γ, lorenz1.σ]]) == length(sol)
+@test sol[(lorenz1.x, lorenz2.x)] isa Vector{Tuple{Float64,Float64}}
+@test length(sol[(lorenz1.x, lorenz2.x)]) == length(sol)
+@test all(length.(sol[(lorenz1.x, lorenz2.x)]) .== 2)
+
+@test sol[[lorenz1.x, lorenz2.x], :] isa Matrix{Float64}
+@test size(sol[[lorenz1.x, lorenz2.x], :]) == (2, length(sol))
+@test size(sol[[lorenz1.x, lorenz2.x], :]) == size(sol[[1, 2], :]) == size(sol[1:2, :])
 
 @variables q(t)[1:2] = [1.0, 2.0]
 eqs = [D(q[1]) ~ 2q[1]
@@ -84,6 +90,7 @@ prob2 = ODEProblem(sys2, [], (0.0, 5.0))
 sol2 = solve(prob2, Tsit5())
 
 @test sol2[q] isa Vector{Vector{Float64}}
+@test sol2[(q...,)] is Vector{NTuple{length(q),Float64}}
 @test length(sol2[q]) == length(sol)
 @test all(length.(sol2[q]) .== 2)
 @test sol2[collect(q)] == sol2[q]


### PR DESCRIPTION
Ref. #301 

Indexing is now consistent between indexes and symbols (`sol[1:2, :]` and `sol[[x, y], :]` return the same shape of data) and is type-stable (`sol[(x, y)]` returns a `Vector{Tuple{...}}`)