### PR TITLE
fix plotting of analytic ODE solution

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -686,7 +686,9 @@ Base.length(iter::TimeChoiceIterator) = length(iter.ts)
         plott = collect(range(integrator.tprev; step = integrator.t, length = plotdensity))
         plot_timeseries = integrator(plott)
         if plot_analytic
-            plot_analytic_timeseries = [integrator.sol.prob.f.analytic(integrator.sol.prob.u0, integrator.sol.prob.p, t) for t in plott]
+            plot_analytic_timeseries = [integrator.sol.prob.f.analytic(integrator.sol.prob.u0,
+                                                                       integrator.sol.prob.p,
+                                                                       t) for t in plott]
         end
     end # if not denseplot, we'll just get the values right from the integrator.
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -686,9 +686,7 @@ Base.length(iter::TimeChoiceIterator) = length(iter.ts)
         plott = collect(range(integrator.tprev; step = integrator.t, length = plotdensity))
         plot_timeseries = integrator(plott)
         if plot_analytic
-            plot_analytic_timeseries = [integrator.sol.prob.f(Val{:analytic}, t,
-                                                              integrator.sol.prob.u0)
-                                        for t in plott]
+            plot_analytic_timeseries = [integrator.sol.prob.f.analytic(integrator.sol.prob.u0, integrator.sol.prob.p, t) for t in plott]
         end
     end # if not denseplot, we'll just get the values right from the integrator.
 

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -428,11 +428,9 @@ function diffeq_to_arrays(sol, plot_analytic, denseplot, plotdensity, tspan, axi
         plot_timeseries = sol(plott)
         if plot_analytic
             if typeof(sol.prob.f) <: Tuple
-                plot_analytic_timeseries = [sol.prob.f[1](Val{:analytic}, t, sol.prob.u0)
-                                            for t in plott]
+                plot_analytic_timeseries = [sol.prob.f[1].analytic(sol.prob.u0, sol.prob.p, t) for t in plott]
             else
-                plot_analytic_timeseries = [sol.prob.f(Val{:analytic}, t, sol.prob.u0)
-                                            for t in plott]
+                plot_analytic_timeseries = [sol.prob.f.analytic(sol.prob.u0, sol.prob.p, t) for t in plott]
             end
         else
             plot_analytic_timeseries = nothing

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -428,9 +428,11 @@ function diffeq_to_arrays(sol, plot_analytic, denseplot, plotdensity, tspan, axi
         plot_timeseries = sol(plott)
         if plot_analytic
             if typeof(sol.prob.f) <: Tuple
-                plot_analytic_timeseries = [sol.prob.f[1].analytic(sol.prob.u0, sol.prob.p, t) for t in plott]
+                plot_analytic_timeseries = [sol.prob.f[1].analytic(sol.prob.u0, sol.prob.p,
+                                                                   t) for t in plott]
             else
-                plot_analytic_timeseries = [sol.prob.f.analytic(sol.prob.u0, sol.prob.p, t) for t in plott]
+                plot_analytic_timeseries = [sol.prob.f.analytic(sol.prob.u0, sol.prob.p, t)
+                                            for t in plott]
             end
         else
             plot_analytic_timeseries = nothing

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -6,16 +6,16 @@ using Test, SciMLBase
 end
 
 @testset "plot ODE solution" begin
-    f = ODEFunction((u, p, t) -> -u, analytic=(u0, p, t) -> u0 * exp(-t))
+    f = ODEFunction((u, p, t) -> -u, analytic = (u0, p, t) -> u0 * exp(-t))
     ode = ODEProblem(f, 1.0, (0.0, 1.0))
     sol = SciMLBase.build_solution(ode, :NoAlgorithm, [ode.tspan[begin]], [ode.u0])
-    for t in Iterators.drop(range(ode.tspan..., length=5), 1)
+    for t in Iterators.drop(range(ode.tspan..., length = 5), 1)
         push!(sol.t, t)
         push!(sol.u, ode.u0)
     end
 
     syms = SciMLBase.interpret_vars(nothing, sol, SciMLBase.getsyms(sol))
-    int_vars = SciMLBase.interpret_vars(nothing #= idxs =#, sol, syms)
+    int_vars = SciMLBase.interpret_vars(nothing, sol, syms) # nothing = idxs
     plot_vecs, labels = SciMLBase.diffeq_to_arrays(sol,
                                                    true, # plot_analytic
                                                    true, # denseplot
@@ -25,6 +25,6 @@ end
                                                    nothing, # idxs
                                                    int_vars,
                                                    :identity, # tscale
-                                                   nothing #= strs =#)
+                                                   nothing) # strs
     @test plot_vecs[2][:, 2] ≈ @. exp(-plot_vecs[1][:, 2])
 end

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -4,3 +4,27 @@ using Test, SciMLBase
     u = rand(1)
     @test SciMLBase.build_linear_solution(nothing, u, zeros(1), nothing)[] == u[]
 end
+
+@testset "plot ODE solution" begin
+    f = ODEFunction((u, p, t) -> -u, analytic=(u0, p, t) -> u0 * exp(-t))
+    ode = ODEProblem(f, 1.0, (0.0, 1.0))
+    sol = SciMLBase.build_solution(ode, :NoAlgorithm, [ode.tspan[begin]], [ode.u0])
+    for t in Iterators.drop(range(ode.tspan..., length=5), 1)
+        push!(sol.t, t)
+        push!(sol.u, ode.u0)
+    end
+
+    syms = SciMLBase.interpret_vars(nothing, sol, SciMLBase.getsyms(sol))
+    int_vars = SciMLBase.interpret_vars(nothing #= idxs =#, sol, syms)
+    plot_vecs, labels = SciMLBase.diffeq_to_arrays(sol,
+                                                   true, # plot_analytic
+                                                   true, # denseplot
+                                                   10, # plotdensity
+                                                   ode.tspan,
+                                                   0.1, # axis_safety
+                                                   nothing, # idxs
+                                                   int_vars,
+                                                   :identity, # tscale
+                                                   nothing #= strs =#)
+    @test plot_vecs[2][:, 2] ≈ @. exp(-plot_vecs[1][:, 2])
+end


### PR DESCRIPTION
Before this PR (reported by @SKopecz):
```julia
julia> using Plots, OrdinaryDiffEq

julia> f = ODEFunction((u, p, t) -> -u, analytic=(u0, p, t) -> u0 * exp(-t))

julia> ode = ODEProblem(f, 1.0, (0.0, 1.0))

julia> sol = solve(ode, Tsit5())

julia> plot(sol, plot_analytic=true)
ERROR: MethodError: no method matching -(::Type{Val{:analytic}})
Closest candidates are:
  -(::Any, ::ChainRulesCore.AbstractThunk) at ~/.julia/packages/ChainRulesCore/C73ay/src/tangent_types/thunks.jl:35
  -(::Any, ::VectorizationBase.CartesianVIndex) at ~/.julia/packages/VectorizationBase/e4FnQ/src/cartesianvindex.jl:68
  -(::Any, ::ChainRulesCore.ZeroTangent) at ~/.julia/packages/ChainRulesCore/C73ay/src/tangent_arithmetic.jl:102
  ...
Stacktrace:
  [1] (::var"#1#3")(u::Type, p::Float64, t::Float64)
    @ Main ./REPL[1]:1
  [2] (::ODEFunction{false, SciMLBase.FullSpecialize, var"#1#3", LinearAlgebra.UniformScaling{Bool}, var"#2#4", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing})(::Type, ::Vararg{Any})
    @ SciMLBase ~/.julia/packages/SciMLBase/0IYdl/src/scimlfunctions.jl:2028
  [3] (::SciMLBase.var"#448#452"{ODESolution{Float64, 1, Vector{Float64}, Vector{Float64}, Dict{Symbol, Float64}, Vector{Float64}, Vector{Vector{Float64}}, ODEProblem{Float64, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, SciMLBase.FullSpecialize, var"#1#3", LinearAlgebra.UniformScaling{Bool}, var"#2#4", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, Tsit5{typeof(OrdinaryDiffEq.trivial_limiter!), typeof(OrdinaryDiffEq.trivial_limiter!), Static.False}, OrdinaryDiffEq.InterpolationData{ODEFunction{false, SciMLBase.FullSpecialize, var"#1#3", LinearAlgebra.UniformScaling{Bool}, var"#2#4", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, OrdinaryDiffEq.Tsit5ConstantCache{Float64, Float64}}, DiffEqBase.DEStats, Nothing}})(t::Float64)
    @ SciMLBase ./none:0
  [4] iterate
    @ ./generator.jl:47 [inlined]
  [5] collect
    @ ./array.jl:787 [inlined]
  [6] diffeq_to_arrays(sol::ODESolution{Float64, 1, Vector{Float64}, Vector{Float64}, Dict{Symbol, Float64}, Vector{Float64}, Vector{Vector{Float64}}, ODEProblem{Float64, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, SciMLBase.FullSpecialize, var"#1#3", LinearAlgebra.UniformScaling{Bool}, var"#2#4", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, Tsit5{typeof(OrdinaryDiffEq.trivial_limiter!), typeof(OrdinaryDiffEq.trivial_limiter!), Static.False}, OrdinaryDiffEq.InterpolationData{ODEFunction{false, SciMLBase.FullSpecialize, var"#1#3", LinearAlgebra.UniformScaling{Bool}, var"#2#4", Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, OrdinaryDiffEq.Tsit5ConstantCache{Float64, Float64}}, DiffEqBase.DEStats, Nothing}, plot_analytic::Bool, denseplot::Bool, plotdensity::Int64, tspan::Nothing, axis_safety::Float64, vars::Nothing, int_vars::Vector{Tuple}, tscale::Symbol, strs::Nothing)
    @ SciMLBase ~/.julia/packages/SciMLBase/0IYdl/src/solutions/solution_interface.jl:434
  [7] macro expansion
    @ ~/.julia/packages/SciMLBase/0IYdl/src/solutions/solution_interface.jl:218 [inlined]
  [8] apply_recipe(plotattributes::AbstractDict{Symbol, Any}, sol::SciMLBase.AbstractTimeseriesSolution)
    @ SciMLBase ~/.julia/packages/RecipesBase/6AijY/src/RecipesBase.jl:299
  [9] _process_userrecipes!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/XxUHt/src/user_recipe.jl:38
 [10] recipe_pipeline!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/XxUHt/src/RecipesPipeline.jl:72
 [11] _plot!(plt::Plots.Plot, plotattributes::Any, args::Any)
    @ Plots ~/.julia/packages/Plots/Pn7Zn/src/plot.jl:223
 [12] plot(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
    @ Plots ~/.julia/packages/Plots/Pn7Zn/src/plot.jl:102
 [13] top-level scope
    @ REPL[4]:1
```
This PR fixes this problem.