### PR TITLE
Correct syntax coloring for types

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -299,7 +299,7 @@ macro CSI_str(str)
     return :(string("\x1b[", $(esc(str)), "m"))
 end
 
-const TYPE_COLOR = CSI"36"  # Cyan
+const TYPE_COLOR = CSI"38;2;86;182;194"  # Cyan
 const NO_COLOR = CSI"0"
 
 get_colorizers(io::IO) = get(io, :color, false) ? (TYPE_COLOR, NO_COLOR) : ("", "")


### PR DESCRIPTION
This has been bugging me for such a long time now that I thought I'd finally go ahead and file a pull request.

Basically, the ANSI color code attempts to mimic the Juno syntax colors but is somewhat off. Using the ANSI format `38;2;R;G;B` it is possible to specify rgb values which better approximate the Juno hex value for types, which is (I believe?) `0x0056b6c2`.