### PR TITLE
allow making and solving DAEs with nothing for u0 and du0

### DIFF
--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -80,12 +80,14 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
                                          du0, u0, tspan, p = NullParameters();
                                          differential_vars = nothing,
                                          kwargs...) where {iip}
-        # Defend against external solvers like Sundials breaking on non-uniform input dimensions.
-        size(du0) == size(u0) ||
-            throw(ArgumentError("Sizes of u0 `$(size(u0))` and du0 `$(size(du0))` must be the same."))
-        if !isnothing(differential_vars)
-            size(u0) == size(differential_vars) ||
-                throw(ArgumentError("Sizes of u0 `$(size(u0))` and differential_vars `$(size(differential_vars))` must be the same."))
+        if !isnothing(u0)
+            # Defend against external solvers like Sundials breaking on non-uniform input dimensions.
+            size(du0) == size(u0) ||
+                throw(ArgumentError("Sizes of u0 and du0 must be the same."))
+            if !isnothing(differential_vars)
+                size(u0) == size(differential_vars) ||
+                    throw(ArgumentError("Sizes of u0 and differential_vars must be the same."))
+            end
         end
         _tspan = promote_tspan(tspan)
         new{typeof(u0), typeof(du0), typeof(_tspan),

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -23,8 +23,8 @@ https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/
 - `destats`: statistics of the solver, such as the number of function evaluations required,
   number of Jacobians computed, and more.
 - `retcode`: the return code from the solver. Used to determine whether the solver solved
-  successfully, whether it terminated early due to a user-defined callback, or whether it 
-  exited due to an error. For more details, see 
+  successfully, whether it terminated early due to a user-defined callback, or whether it
+  exited due to an error. For more details, see
   [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
 """
 struct DAESolution{T, N, uType, duType, uType2, DType, tType, P, A, ID, DE} <:
@@ -63,7 +63,12 @@ function build_solution(prob::AbstractDAEProblem, alg, t, u, du = nothing;
                         destats = nothing,
                         kwargs...)
     T = eltype(eltype(u))
-    N = length((size(prob.u0)..., length(u)))
+
+    if prob.u0 === nothing
+        N = 2
+    else
+        N = length((size(prob.u0)..., length(u)))
+    end
 
     if has_analytic(prob.f)
         u_analytic = Vector{typeof(prob.u0)}()

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -191,7 +191,7 @@ function Base.show(io::IO, m::MIME"text/plain", A::AbstractPDESolution)
     println(io)
     print(io, "u: ")
     show(io, m, A.u)
-end                                                                             
+end
 
 DEFAULT_PLOT_FUNC(x...) = (x...,)
 DEFAULT_PLOT_FUNC(x, y, z) = (x, y, z) # For v0.5.2 bug


### PR DESCRIPTION
This already works for ODEs, but DAEs had some size checks that made this not work. I'll add a downstream test to OrdinaryDiffEq (test needs to be downstream so we can test solving)