### PR TITLE
start fixing LinearProblem docstring

### DIFF
--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -32,8 +32,8 @@ Optionally, an initial guess ``u₀`` can be supplied which is used for iterativ
 methods.
 
 ```julia
-LinearProblem{isinplace}(A,x,p=NullParameters();u0=nothing,kwargs...)
-LinearProblem(f::AbstractDiffEqOperator,u0,p=NullParameters();u0=nothing,kwargs...)
+LinearProblem(A::AbstractMatrix,b::AbstractVector;u0=nothing,kwargs...)
+LinearProblem{isinplace}(f::AbstractSciMLOperator,u0,p=NullParameters();u0=nothing,kwargs...)
 ```
 
 `isinplace` optionally sets whether the function is in-place or not, i.e. whether


### PR DESCRIPTION
There is still something more wrong with `u0`, it is used both as positional and keyword argument.