### PR TITLE
Standardise docstrings for alg traits

### DIFF
--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -1,5 +1,5 @@
 """
-isautodifferentiable(alg::AbstractDEAlgorithm)
+  isautodifferentiable(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm is compatible with
 direct automatic differentiation, i.e. can have algorithms like
@@ -11,7 +11,7 @@ Defaults to false as only pure-Julia algorithms can have this be true.
 isautodifferentiable(alg::AbstractSciMLAlgorithm) = false
 
 """
-forwarddiffs_model(alg::AbstractDEAlgorithm)
+  forwarddiffs_model(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm uses ForwardDiff.jl
 on the model function is called with ForwardDiff.jl
@@ -21,7 +21,7 @@ Defaults to false as only pure-Julia algorithms can have this be true.
 forwarddiffs_model(alg::AbstractSciMLAlgorithm) = false
 
 """
-forwarddiffs_model_time(alg::AbstractDEAlgorithm)
+  forwarddiffs_model_time(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm uses ForwardDiff.jl
 on the model `f(u,p,t)` function is called with ForwardDiff.jl on the `t` argument.
@@ -32,7 +32,7 @@ have this as true
 forwarddiffs_model_time(alg::AbstractSciMLAlgorithm) = false
 
 """
-allows_arbitrary_number_types(alg::AbstractDEAlgorithm)
+  allows_arbitrary_number_types(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm is compatible with
 direct automatic differentiation, i.e. can have algorithms like
@@ -44,7 +44,7 @@ Defaults to false as only pure-Julia algorithms can have this be true.
 allows_arbitrary_number_types(alg::AbstractSciMLAlgorithm) = false
 
 """
-allowscomplex(alg::AbstractDEAlgorithm)
+  allowscomplex(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm is compatible with
 having complex numbers as the state variables.
@@ -54,7 +54,7 @@ Defaults to false.
 allowscomplex(alg::AbstractSciMLAlgorithm) = false
 
 """
-isadaptive(alg::AbstractDEAlgorithm)
+  isadaptive(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm uses adaptivity,
 i.e. has a non-quasi-static compute graph.
@@ -65,7 +65,7 @@ isadaptive(alg::AbstractDEAlgorithm) = true
 # Default to assuming adaptive, safer error("Adaptivity algorithm trait not set.")
 
 """
-isdiscrete(alg::AbstractDEAlgorithm)
+  isdiscrete(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm allows for
 discrete state values, such as integers.
@@ -75,7 +75,7 @@ Defaults to false.
 isdiscrete(alg::AbstractDEAlgorithm) = false
 
 """
-allowsbounds(opt)
+  allowsbounds(opt)
 
 Trait declaration for whether an optimizer allows for 
 box constraints passed with `lb` and `ub` in 
@@ -86,7 +86,7 @@ Defaults to false.
 allowsbounds(opt) = false
 
 """
-requiresbounds(opt)
+  requiresbounds(opt)
 
 Trait declaration for whether an optimizer requires 
 box constraints passed with `lb` and `ub` in 
@@ -97,7 +97,7 @@ Defaults to false.
 requiresbounds(opt) = false
 
 """
-allowsconstraints(opt)
+  allowsconstraints(opt)
 
 Trait declaration for whether an optimizer allows 
 non-linear constraints specified in `cons` in 
@@ -108,7 +108,7 @@ Defaults to false.
 allowsconstraints(opt) = false
 
 """
-requiresconstraints(opt)
+  requiresconstraints(opt)
 
 Trait declaration for whether an optimizer 
 requires non-linear constraints specified in 
@@ -119,7 +119,7 @@ Defaults to false.
 requiresconstraints(opt) = false
 
 """
-allowscallback(opt)
+  allowscallback(opt)
 
 Trait declaration for whether an optimizer 
 supports passing a `callback` to `solve` 

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -77,7 +77,9 @@ isdiscrete(alg::AbstractDEAlgorithm) = false
 """
 allowsbounds(opt)
 
-Allows box constraints passed with `lb` and `ub` in `OptimizationProblem`.
+Trait declaration for whether an optimizer allows for 
+box constraints passed with `lb` and `ub` in 
+`OptimizationProblem`.
 
 Defaults to false.
 """
@@ -86,25 +88,31 @@ allowsbounds(opt) = false
 """
 requiresbounds(opt)
 
-Requires box constraints passed with `lb` and `ub` in `OptimizationProblem`.
+Trait declaration for whether an optimizer requires 
+box constraints passed with `lb` and `ub` in 
+`OptimizationProblem`.
 
 Defaults to false.
 """
 requiresbounds(opt) = false
 
 """
-allowsconstrains(opt)
+allowsconstraints(opt)
 
-Allows non-linear constraints specified in `cons` in `OptimizationFunction`.
+Trait declaration for whether an optimizer allows 
+non-linear constraints specified in `cons` in 
+`OptimizationFunction`.
 
 Defaults to false.
 """
 allowsconstraints(opt) = false
 
 """
-requiresconstrains(opt)
+requiresconstraints(opt)
 
-Requires non-linear constraints specified in `cons` in `OptimizationFunction`.
+Trait declaration for whether an optimizer 
+requires non-linear constraints specified in 
+`cons` in `OptimizationFunction`.
 
 Defaults to false.
 """
@@ -113,7 +121,9 @@ requiresconstraints(opt) = false
 """
 allowscallback(opt)
 
-Supports passing `callback` to `solve` for optimization.
+Trait declaration for whether an optimizer 
+supports passing a `callback` to `solve` 
+for an `OptimizationProblem`.
 
 Defaults to true.
 """


### PR DESCRIPTION
The first half of the file had docstrings starting with "Trait declaration..." while the latter half for the Optimization algorithms was less specific. Also fixed `constrains` to `constraints` in a couple docstrings.