### PR TITLE
Prepare for `AdjointFactorization`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.81.0"
+version = "1.81.1"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -156,8 +156,9 @@ Base.convert(::Type{AbstractMatrix}, L::FactorizedDiffEqArrayOperator{<:Any,<:Un
 
 Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Factorization,AbstractMatrix}}) =
     Matrix(L.F)
-Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:AdjointFact}) = Matrix(L.F')'
-Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:TransposeFact}) =
+Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Adjoint,AdjointFact}}) =
+    adjoint(Matrix(adjoint(L.F)))
+Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Transpose,TransposeFact}}) =
     transpose(Matrix(transpose(L.F)))
 
 Base.adjoint(L::FactorizedDiffEqArrayOperator) = FactorizedDiffEqArrayOperator(L.F')

--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -127,6 +127,9 @@ function Base.copy(L::DiffEqArrayOperator)
     DiffEqArrayOperator(copy(L.A); update_func = L.update_func)
 end
 
+const AdjointFact = isdefined(LinearAlgebra, :AdjointFactorization) ? LinearAlgebra.AdjointFactorization : Adjoint
+const TransposeFact = isdefined(LinearAlgebra, :TransposeFactorization) ? LinearAlgebra.TransposeFactorization : Transpose
+
 """
     FactorizedDiffEqArrayOperator(F)
 
@@ -137,26 +140,26 @@ Supports left division and `ldiv!` when applied to an array.
 struct FactorizedDiffEqArrayOperator{T <: Number,
                                      FType <: Union{
                                            Factorization{T}, Diagonal{T}, Bidiagonal{T},
-                                           Adjoint{T, <:Factorization{T}}
+                                           AdjointFact{T, <:Factorization{T}},
+                                           TransposeFact{T, <:Factorization{T}}
                                            }
                                      } <: AbstractDiffEqLinearOperator{T}
     F::FType
 end
 
-function Base.convert(::Type{AbstractMatrix}, L::FactorizedDiffEqArrayOperator)
-    if L.F isa Adjoint
-        convert(AbstractMatrix, L.F')'
-    else
-        convert(AbstractMatrix, L.F)
-    end
-end
-function Base.Matrix(L::FactorizedDiffEqArrayOperator)
-    if L.F isa Adjoint
-        Matrix(L.F')'
-    else
-        Matrix(L.F)
-    end
-end
+Base.convert(::Type{AbstractMatrix}, L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Factorization,AbstractMatrix}}) =
+    convert(AbstractMatrix, L.F)
+Base.convert(::Type{AbstractMatrix}, L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Adjoint,AdjointFact}}) =
+    adjoint(convert(AbstractMatrix, adjoint(L.F)))
+Base.convert(::Type{AbstractMatrix}, L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Transpose,TransposeFact}}) =
+    transpose(convert(AbstractMatrix, transpose(L.F)))
+
+Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:Union{Factorization,AbstractMatrix}}) =
+    Matrix(L.F)
+Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:AdjointFact}) = Matrix(L.F')'
+Base.Matrix(L::FactorizedDiffEqArrayOperator{<:Any,<:TransposeFact}) =
+    transpose(Matrix(transpose(L.F)))
+
 Base.adjoint(L::FactorizedDiffEqArrayOperator) = FactorizedDiffEqArrayOperator(L.F')
 Base.size(L::FactorizedDiffEqArrayOperator, args...) = size(L.F, args...)
 function LinearAlgebra.ldiv!(Y::AbstractVecOrMat, L::FactorizedDiffEqArrayOperator,


### PR DESCRIPTION
This prepares the ground for https://github.com/JuliaLang/julia/pull/46874. The addition of handling of transpose factorizations seems desirable (and necessary in the above mentioned PR) because real `LU` prefers transpose over adjoints, in contrast to other factorizations.