### PR TITLE
reexport SciMLOperators

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -34,19 +34,7 @@ import SciMLOperators:
                        has_adjoint, has_expmv, has_expmv!, has_exp,
                        has_mul, has_mul!, has_ldiv, has_ldiv!
 
-### wait for https://github.com/SciML/LinearSolve.jl/issues/268
-
-#@reexport using SciMLOperators
-
-###
-export ScalarOperator, MatrixOperator, DiagonalOperator, AffineOperator,
-       AddVector, FunctionOperator, TensorProductOperator
-export update_coefficients!, update_coefficients,
-       isconstant, iscached, cache_operator,
-       islinear, #issquare,
-       has_adjoint, has_expmv, has_expmv!, has_exp,
-       has_mul, has_mul!, has_ldiv, has_ldiv!
-###
+@reexport using SciMLOperators
 
 function __solve end
 function __init end


### PR DESCRIPTION
reexport scimlops now that `issquare` name conflict is fixed in https://github.com/SciML/LinearSolve.jl/pull/270