### PR TITLE
Enable `integ[sys.p]` and `sol[sys.p]`

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -445,6 +445,8 @@ Base.@propagate_inbounds function Base.getindex(A::DEIntegrator, sym)
                 return A.t
             elseif has_sys(A.f) && is_param_sym(A.f.sys, sym)
                 return A.p[param_sym_to_index(A.f.sys, sym)]
+            elseif has_sys(A.f) && Symbol(sym) in Set(Symbol(A.f.sys.name,:₊,x) for x in getparamsyms(A))
+                return A.p[findfirst(x -> isequal(Symbol(A.f.sys.name,:₊,x), Symbol(sym)), getparamsyms(A))]
             elseif has_paramsyms(A.f) && Symbol(sym) in getparamsyms(A)
                 return A.p[findfirst(x -> isequal(x, Symbol(sym)), getparamsyms(A))]
             else

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -93,6 +93,8 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractTimeseriesSolution, s
                 return A.t
             elseif has_sys(A.prob.f) && is_param_sym(A.prob.f.sys, sym)
                 return A.prob.p[param_sym_to_index(A.prob.f.sys, sym)]
+            elseif has_sys(A.prob.f) && Symbol(sym) in Set(Symbol(A.prob.f.sys.name,:₊,x) for x in getparamsyms(A))
+                return A.prob.p[findfirst(x -> isequal(Symbol(A.prob.f.sys.name,:₊,x), Symbol(sym)), getparamsyms(A))]
             elseif has_paramsyms(A.prob.f) && Symbol(sym) in getparamsyms(A)
                 return A.prob.p[findfirst(x -> isequal(x, Symbol(sym)), getparamsyms(A))]
             else


### PR DESCRIPTION
Currently, this does not work:
```julia
using DifferentialEquations, ModelingToolkit, Plots

@parameters t σ ρ β
@variables x(t) y(t) z(t)
D = Differential(t)

eqs = [D(x) ~ σ * (y - x),
    D(y) ~ x * (ρ - z) - y,
    D(z) ~ x * y - β * z]

@named sys = ODESystem(eqs)

u0 = [x => 1.0, y => 0.0, z => 0.0]
p = [σ => 28.0, ρ => 10.0, β => 8 / 3]
tspan = (0.0, 10.0)

oprob = ODEProblem(sys, u0, tspan, p, jac = true)
integ = init(oprob)
sol = solve(oprob)

integ[sys.σ] # Does not work.
sol[sys.σ] # Does not work.
```
(inputting only `σ`, however, does)

With this PR the 
```
Base.getindex(A::AbstractTimeseriesSolution, sym)
Base.getindex(A::DEIntegrator, sym)
```
functions check this type of possibility, and returns the proper output.

