### PR TITLE
Remove deprecating == conversion of retcode to symbol

### DIFF
--- a/src/retcodes.jl
+++ b/src/retcodes.jl
@@ -345,7 +345,6 @@ EnumX.@enumx ReturnCode begin
     MaxTime
 end
 
-Base.:(==)(retcode::ReturnCode.T, s::Symbol) = Symbol(retcode) == s
 Base.:(!=)(retcode::ReturnCode.T, s::Symbol) = Symbol(retcode) != s
 
 const symtrue = Symbol("true")


### PR DESCRIPTION
This is one of the top invalidators, we've waited, I don't see issues around this anymore, going for it.