### PR TITLE
Add error hints on null parameters in missing functions

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -42,12 +42,32 @@ If one wants way more detail than necessary on why the function wrappers exist a
 
 https://sciml.ai/news/2022/09/21/compile_time/"""
 
+const NO_PARAMETERS_ARITHMETIC_ERROR_MESSAGE = """
+
+                                        An arithmetic operation was performed on a NullParameters object. This means no parameters were passed
+                                        into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an arithmetic
+                                        expression. Two common reasons for this issue are:
+
+                                        1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
+                                        be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
+
+                                        2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
+                                        `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
+                                        will always be in the function signature reguardless of if the problem is defined with parameters!
+                                    """
+
 function __init__()
     Base.Experimental.register_error_hint(DomainError) do io, e
         if e isa DomainError &&
            occursin("will only return a complex result if called with a complex argument. Try ",
                     e.msg)
             println(io, DOMAINERROR_COMPLEX_MSG)
+        end
+    end
+
+    Base.Experimental.register_error_hint(MethodError) do io, e, args, kwargs
+        if e isa MethodError && NullParameters in args
+            println(io, NO_PARAMETERS_ARITHMETIC_ERROR_MESSAGE)
         end
     end
 

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -44,17 +44,17 @@ https://sciml.ai/news/2022/09/21/compile_time/"""
 
 const NO_PARAMETERS_ARITHMETIC_ERROR_MESSAGE = """
 
-                                        An arithmetic operation was performed on a NullParameters object. This means no parameters were passed
-                                        into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an arithmetic
-                                        expression. Two common reasons for this issue are:
+An arithmetic operation was performed on a NullParameters object. This means no parameters were passed
+into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an arithmetic
+expression. Two common reasons for this issue are:
 
-                                        1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
-                                        be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
+1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
+be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
 
-                                        2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
-                                        `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
-                                        will always be in the function signature reguardless of if the problem is defined with parameters!
-                                    """
+2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
+`f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
+will always be in the function signature reguardless of if the problem is defined with parameters!
+"""
 
 function __init__()
     Base.Experimental.register_error_hint(DomainError) do io, e

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -142,11 +142,31 @@ end
 Base.show(io::IO, mime::MIME"text/plain", A::AbstractEnsembleProblem) = summary(io, A)
 
 struct NullParameters end
+
+const NO_PARAMETERS_INDEX_ERROR_MESSAGE = """
+                                        An indexing operation was performed on a NullParameters object. This means no parameters were passed
+                                        into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an indexing
+                                        expression (e.x. `p[i]`, or `x .+ p`). Two common reasons for this issue are:
+
+                                        1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
+                                        be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
+
+                                        2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
+                                        `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
+                                        will always be in the function signature reguardless of if the problem is defined with parameters!
+                                    """
+
+struct NullParameterIndexError <: Exception end
+
+function Base.showerror(io::IO, e::NullParameterIndexError)
+    println(io, NO_PARAMETERS_INDEX_ERROR_MESSAGE)
+end
+
 function Base.getindex(::NullParameters, i...)
-    error("Parameters were indexed but the parameters are `nothing`. You likely forgot to pass in parameters to the DEProblem!")
+    NullParameterIndexError()
 end
 function Base.iterate(::NullParameters)
-    error("Parameters were indexed but the parameters are `nothing`. You likely forgot to pass in parameters to the DEProblem!")
+    NullParameterIndexError()
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", A::AbstractPDEProblem)

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -163,10 +163,10 @@ function Base.showerror(io::IO, e::NullParameterIndexError)
 end
 
 function Base.getindex(::NullParameters, i...)
-    NullParameterIndexError()
+    throw(NullParameterIndexError())
 end
 function Base.iterate(::NullParameters)
-    NullParameterIndexError()
+    throw(NullParameterIndexError())
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", A::AbstractPDEProblem)

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -144,17 +144,17 @@ Base.show(io::IO, mime::MIME"text/plain", A::AbstractEnsembleProblem) = summary(
 struct NullParameters end
 
 const NO_PARAMETERS_INDEX_ERROR_MESSAGE = """
-                                        An indexing operation was performed on a NullParameters object. This means no parameters were passed
-                                        into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an indexing
-                                        expression (e.x. `p[i]`, or `x .+ p`). Two common reasons for this issue are:
+An indexing operation was performed on a NullParameters object. This means no parameters were passed
+into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an indexing
+expression (e.x. `p[i]`, or `x .+ p`). Two common reasons for this issue are:
 
-                                        1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
-                                        be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
+1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
+be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
 
-                                        2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
-                                        `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
-                                        will always be in the function signature reguardless of if the problem is defined with parameters!
-                                    """
+2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
+`f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
+will always be in the function signature reguardless of if the problem is defined with parameters!
+"""
 
 struct NullParameterIndexError <: Exception end
 


### PR DESCRIPTION
Current error message:

```julia
ERROR: MethodError: no method matching *(::Float64, ::SciMLBase.NullParameters)

Some of the types have been truncated in the stacktrace for improved reading. To emit complete information
in the stack trace, evaluate `TruncatedStacktraces.VERBOSE[] = true` and re-run the code.

    An arithmetic operation was performed on a NullParameters object. This means no parameters were passed
    into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an arithmetic
    expression. Two common reasons for this issue are:

    1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
    be `ODEProblem(f,u0,tspan,p)` in order to use parameters.

    2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
    `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
    will always be in the function signature reguardless of if the problem is defined with parameters!



Closest candidates are:
  *(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:578
  *(::T, ::T) where T<:Union{Float16, Float32, Float64}
   @ Base float.jl:410
  *(::Union{Float16, Float32, Float64}, ::BigFloat)
   @ Base mpfr.jl:414
  ...

Stacktrace:
  [1] *
    @ .\operators.jl:578 [inlined]
  [2] lorenz!(du::Vector{Float64}, u::Vector{Float64}, p::SciMLBase.NullParameters, t::Float64)
    @ Main c:\Users\accou\OneDrive\Computer\Desktop\test.jl:43
  [3] (::SciMLBase.Void{typeof(lorenz!)})(::Vector{Float64}, ::Vararg{Any})
    @ SciMLBase C:\Users\accou\.julia\dev\SciMLBase\src\utils.jl:468
  [4] (::FunctionWrappers.CallWrapper{Nothing})(f::SciMLBase.Void{typeof(lorenz!)}, arg1::Vector{Float64}, arg2::Vector{Float64}, arg3::SciMLBase.NullParameters, arg4::Float64)
    @ FunctionWrappers C:\Users\accou\.julia\packages\FunctionWrappers\Q5cBx\src\FunctionWrappers.jl:65
  [5] macro expansion
    @ C:\Users\accou\.julia\packages\FunctionWrappers\Q5cBx\src\FunctionWrappers.jl:137 [inlined]
  [6] do_ccall
    @ C:\Users\accou\.julia\packages\FunctionWrappers\Q5cBx\src\FunctionWrappers.jl:125 [inlined]
  [7] FunctionWrapper
    @ C:\Users\accou\.julia\packages\FunctionWrappers\Q5cBx\src\FunctionWrappers.jl:144 [inlined]
  [8] _call
    @ C:\Users\accou\.julia\packages\FunctionWrappersWrappers\9XR0m\src\FunctionWrappersWrappers.jl:12 [inlined]
  [9] FunctionWrappersWrapper
    @ C:\Users\accou\.julia\packages\FunctionWrappersWrappers\9XR0m\src\FunctionWrappersWrappers.jl:10 [inlined]
 [10] ODEFunction
    @ C:\Users\accou\.julia\dev\SciMLBase\src\scimlfunctions.jl:2404 [inlined]
 [11] initialize!(integrator::ODEIntegrator{true, Tsit5{Static.False,…}, Vector{Float64}, Float64,…}, cache::Tsit5Cache{Vector{Float64},…})
    @ OrdinaryDiffEq C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\perform_step\low_order_rk_perform_step.jl:766
 [12] __init(prob::ODEProblem{true,Vector{Float64},Tuple{Float64, Float64},…}, alg::Tsit5{Static.False,…}, timeseries_init::Tuple{}, ts_init::Tuple{}, ks_init::Tuple{}, recompile::Type{Val{true}}; saveat::Tuple{}, tstops::Tuple{}, d_discontinuities::Tuple{}, save_idxs::Nothing, save_everystep::Bool, save_on::Bool, save_start::Bool, save_end::Nothing, callback::Nothing, dense::Bool, calck::Bool, dt::Float64, dtmin::Nothing, dtmax::Float64, force_dtmin::Bool, adaptive::Bool, gamma::Rational{Int64}, abstol::Nothing, reltol::Nothing, qmin::Rational{Int64}, qmax::Int64, qsteady_min::Int64, qsteady_max::Int64, beta1::Nothing, beta2::Nothing, qoldinit::Rational{Int64}, controller::Nothing, fullnormalize::Bool, failfactor::Int64, maxiters::Int64, internalnorm::typeof(DiffEqBase.ODE_DEFAULT_NORM), internalopnorm::typeof(LinearAlgebra.opnorm), isoutofdomain::typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN), unstable_check::typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK), verbose::Bool, timeseries_errors::Bool, dense_errors::Bool, advance_to_tstop::Bool, stop_at_next_tstop::Bool, initialize_save::Bool, progress::Bool, progress_steps::Int64, progress_name::String, progress_message::typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE), userdata::Nothing, allow_extrapolation::Bool, initialize_integrator::Bool, alias_u0::Bool, alias_du0::Bool, initializealg::OrdinaryDiffEq.DefaultInit, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ OrdinaryDiffEq C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\solve.jl:499
 [13] __init (repeats 5 times)
    @ C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\solve.jl:10 [inlined]
 [14] #__solve#626
    @ C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\solve.jl:5 [inlined]
 [15] __solve
    @ C:\Users\accou\.julia\dev\OrdinaryDiffEq\src\solve.jl:1 [inlined]
 [16] #solve_call#22
    @ C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:496 [inlined]
 [17] solve_call
    @ C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:466 [inlined]
 [18] #solve_up#29
    @ C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:919 [inlined]
 [19] solve_up
    @ C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:892 [inlined]
 [20] #solve#27
    @ C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:829 [inlined]
 [21] solve(prob::ODEProblem{true,Vector{Float64},Tuple{Float64, Float64},…}, args::Tsit5{Static.False,…})
    @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\jSoyI\src\solve.jl:819
 [22] top-level scope
    @ c:\Users\accou\OneDrive\Computer\Desktop\test.jl:48
```