### PR TITLE
make types safe to print when verbose stacktraces are on

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -154,20 +154,9 @@ function ContinuousCallback(condition, affect!;
 end
 
 function Base.show(io::IO,
-                   t::Type{ContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, I, R}}) where {
-                                                                                            F1,
-                                                                                            F2,
-                                                                                            F3,
-                                                                                            F4,
-                                                                                            F5,
-                                                                                            T,
-                                                                                            T2,
-                                                                                            T3,
-                                                                                            I,
-                                                                                            R
-                                                                                            }
+                   t::Type{<:ContinuousCallback})
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "ContinuousCallback{$F1, $F2, $F3, $F4, $F5, $T, $T2, $T3, $I, $R}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ContinuousCallback{…}")
     end
@@ -277,21 +266,9 @@ function VectorContinuousCallback(condition, affect!, len;
                              dtrelax, abstol, reltol, repeat_nudge)
 end
 
-function Base.show(io::IO,
-                   t::Type{VectorContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, I, R}}) where {
-                                                                                                  F1,
-                                                                                                  F2,
-                                                                                                  F3,
-                                                                                                  F4,
-                                                                                                  F5,
-                                                                                                  T,
-                                                                                                  T2,
-                                                                                                  T3,
-                                                                                                  I,
-                                                                                                  R
-                                                                                                  }
+function Base.show(io::IO, t::Type{<:VectorContinuousCallback})
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "VectorContinuousCallback{$F1, $F2, $F3, $F4, $F5, $T, $T2, $T3, $I, $R}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "VectorContinuousCallback{…}")
     end
@@ -346,9 +323,9 @@ function DiscreteCallback(condition, affect!;
     DiscreteCallback(condition, affect!, initialize, finalize, save_positions)
 end
 
-function Base.show(io::IO, t::Type{DiscreteCallback{F1, F2, F3, F4}}) where {F1, F2, F3, F4}
+function Base.show(io::IO, t::Type{<:DiscreteCallback})
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "DiscreteCallback{$F1, $F2, $F3, $F4}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DiscreteCallback{…}")
     end

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -18,10 +18,10 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:AnalyticalProblem{uType, tType, isinplace}}) where {
-                                                                                        uType,
-                                                                                        tType,
-                                                                                        isinplace,
-                                                                                        }
+                                                                                 uType,
+                                                                                 tType,
+                                                                                 isinplace
+                                                                                 }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -17,15 +17,13 @@ struct AnalyticalProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::Type{AnalyticalProblem{uType, tType, isinplace, P, F, K}}) where {
+                   t::Type{<:AnalyticalProblem{uType, tType, isinplace}}) where {
                                                                                         uType,
                                                                                         tType,
                                                                                         isinplace,
-                                                                                        P,
-                                                                                        F, K
                                                                                         }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "AnalyticalProblem{$uType,$tType,$isinplace,$P,$F,$K}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "AnalyticalProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -77,11 +77,9 @@ function LinearProblem(A, b, args...; kwargs...)
 end
 
 function Base.show(io::IO,
-                   t::LinearProblem{uType, isinplace, F, bType, P, K}) where {uType,
-                                                                              isinplace, F,
-                                                                              bType, P, K}
+                   t::Type{<:LinearProblem{uType}}) where {uType}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "LinearProblem{$uType,$isinplace,$F,$bType,$P,$K}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "LinearProblem{$uType,…}")
     end
@@ -173,13 +171,11 @@ struct IntervalNonlinearProblem{isinplace, tType, P, F, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::IntervalNonlinearProblem{isinplace, tType, P, F, K, PT}) where {
-                                                                                      isinplace,
-                                                                                      tType,
-                                                                                      P, F,
-                                                                                      K, PT}
+                   t::IntervalNonlinearProblem{isinplace, tType}) where {
+                                                                         isinplace,
+                                                                         tType}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "IntervalNonlinearProblem{$isinplace,$tType,$P,$F,$K,$PT}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "IntervalNonlinearProblem{$isinplace,$tType,…}")
     end
@@ -276,11 +272,10 @@ struct NonlinearProblem{uType, isinplace, P, F, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::NonlinearProblem{uType, isinplace, P, F, K, PT}) where {uType,
-                                                                              isinplace, P,
-                                                                              F, K, PT}
+                   t::NonlinearProblem{uType, isinplace}) where {uType,
+                                                                 isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "NonlinearProblem{$uType,$isinplace,$P,$F,$K,$PT}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "NonlinearProblem{$isinplace,$uType,…}")
     end
@@ -400,11 +395,11 @@ struct IntegralProblem{isinplace, P, F, B, K} <: AbstractIntegralProblem{isinpla
 end
 
 function Base.show(io::IO,
-                   t::IntegralProblem{isinplace, P, F, B, K}) where {isinplace, P, F, B, K}
+                   t::IntegralProblem{isinplace}) where {isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "IntegralProblem{$uType,$isinplace,$P,$F,$K,$PT}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
-        print(io, "IntegralProblem{$isinplace,$uType,…}")
+        print(io, "IntegralProblem{$isinplace,…}")
     end
 end
 
@@ -471,8 +466,8 @@ optimization. They should be an `AbstractArray` matching the geometry of `u`,
 where `(lcons[I],ucons[I])` is the constraint (lower and upper bounds)
 for `cons[I]`.
 
-If `f` is a standard Julia function, it is automatically transformed into an 
-`OptimizationFunction` with `NoAD()`, meaning the derivative functions are not 
+If `f` is a standard Julia function, it is automatically transformed into an
+`OptimizationFunction` with `NoAD()`, meaning the derivative functions are not
 automatically generated.
 
 Any extra keyword arguments are captured to be sent to the optimizers.
@@ -533,21 +528,13 @@ struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
 end
 
 function Base.show(io::IO,
-                   t::OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K}) where {
+                   t::OptimizationProblem{iip, F, uType}) where {
                                                                                              iip,
                                                                                              F,
                                                                                              uType,
-                                                                                             P,
-                                                                                             LB,
-                                                                                             UB,
-                                                                                             I,
-                                                                                             LC,
-                                                                                             UC,
-                                                                                             S,
-                                                                                             K
                                                                                              }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "OptimizationProblem{$iip,$F,$uType,$P,$LB,$UB,$I,$LC,$UC,$S,$K}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "OptimizationProblem{$iip,$uType,…}")
     end

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -171,11 +171,11 @@ struct IntervalNonlinearProblem{isinplace, tType, P, F, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::IntervalNonlinearProblem{isinplace, tType}) where {
+                   t::Type{<:IntervalNonlinearProblem{isinplace, tType}}) where {
                                                                          isinplace,
                                                                          tType}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "IntervalNonlinearProblem{$isinplace,$tType,…}")
     end
@@ -272,10 +272,10 @@ struct NonlinearProblem{uType, isinplace, P, F, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::NonlinearProblem{uType, isinplace}) where {uType,
+                   t::Type{<:NonlinearProblem{uType, isinplace}}) where {uType,
                                                                  isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "NonlinearProblem{$isinplace,$uType,…}")
     end
@@ -395,9 +395,9 @@ struct IntegralProblem{isinplace, P, F, B, K} <: AbstractIntegralProblem{isinpla
 end
 
 function Base.show(io::IO,
-                   t::IntegralProblem{isinplace}) where {isinplace}
+                   t::Type{<:IntegralProblem{isinplace}}) where {isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "IntegralProblem{$isinplace,…}")
     end
@@ -528,13 +528,13 @@ struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
 end
 
 function Base.show(io::IO,
-                   t::OptimizationProblem{iip, F, uType}) where {
+                   t::Type{<:OptimizationProblem{iip, F, uType}}) where {
                                                                 iip,
                                                                 F,
                                                                 uType,
                                                                 }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "OptimizationProblem{$iip,$uType,…}")
     end

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -529,10 +529,10 @@ end
 
 function Base.show(io::IO,
                    t::OptimizationProblem{iip, F, uType}) where {
-                                                                                             iip,
-                                                                                             F,
-                                                                                             uType,
-                                                                                             }
+                                                                iip,
+                                                                F,
+                                                                uType,
+                                                                }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, typeof(t))
     else

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -172,8 +172,8 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:IntervalNonlinearProblem{isinplace, tType}}) where {
-                                                                         isinplace,
-                                                                         tType}
+                                                                                 isinplace,
+                                                                                 tType}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
@@ -273,7 +273,7 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:NonlinearProblem{uType, isinplace}}) where {uType,
-                                                                 isinplace}
+                                                                         isinplace}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
@@ -529,10 +529,10 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:OptimizationProblem{iip, F, uType}}) where {
-                                                                iip,
-                                                                F,
-                                                                uType,
-                                                                }
+                                                                         iip,
+                                                                         F,
+                                                                         uType
+                                                                         }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -96,13 +96,11 @@ struct BVProblem{uType, tType, isinplace, P, F, bF, PT, K} <:
 end
 
 function Base.show(io::IO,
-                   t::BVProblem{uType, tType, isinplace, P, F, bF, PT, K}) where {uType,
-                                                                                  tType,
-                                                                                  isinplace,
-                                                                                  P, F, bF,
-                                                                                  PT, K}
+                   t::BVProblem{uType, tType, isinplace}) where {uType,
+                                                                 tType,
+                                                                 isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "BVProblem{$uType,$tType,$isinplace,$P,$F,$bF,$PT,$K}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "BVProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -96,11 +96,11 @@ struct BVProblem{uType, tType, isinplace, P, F, bF, PT, K} <:
 end
 
 function Base.show(io::IO,
-                   t::BVProblem{uType, tType, isinplace}) where {uType,
+                   t::Type{BVProblem{uType, tType, isinplace}}) where {uType,
                                                                  tType,
                                                                  isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "BVProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -97,8 +97,8 @@ end
 
 function Base.show(io::IO,
                    t::Type{BVProblem{uType, tType, isinplace}}) where {uType,
-                                                                 tType,
-                                                                 isinplace}
+                                                                       tType,
+                                                                       isinplace}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -103,12 +103,12 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
 end
 
 function Base.show(io::IO,
-                   t::DAEProblem{uType, duType, tType, isinplace}) where {uType,
+                   t::Type{<:DAEProblem{uType, duType, tType, isinplace}}) where {uType,
                                                                           duType,
                                                                           tType,
                                                                           isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DAEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -103,14 +103,12 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
 end
 
 function Base.show(io::IO,
-                   t::DAEProblem{uType, duType, tType, isinplace, P, F, K, D}) where {uType,
-                                                                                      duType,
-                                                                                      tType,
-                                                                                      isinplace,
-                                                                                      P, F,
-                                                                                      K, D}
+                   t::DAEProblem{uType, duType, tType, isinplace}) where {uType,
+                                                                          duType,
+                                                                          tType,
+                                                                          isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "DAEProblem{$uType,$duType,$tType,$isinplace,$P,$F,$K,$D}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "DAEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -104,9 +104,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:DAEProblem{uType, duType, tType, isinplace}}) where {uType,
-                                                                          duType,
-                                                                          tType,
-                                                                          isinplace}
+                                                                                  duType,
+                                                                                  tType,
+                                                                                  isinplace}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -252,12 +252,12 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:DDEProblem{uType, tType, lType, lType2, isinplace}}) where {
-                                                                                 uType,
-                                                                                 tType,
-                                                                                 lType,
-                                                                                 lType2,
-                                                                                 isinplace
-                                                                                }
+                                                                                         uType,
+                                                                                         tType,
+                                                                                         lType,
+                                                                                         lType2,
+                                                                                         isinplace
+                                                                                         }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -251,20 +251,15 @@ struct DDEProblem{uType, tType, lType, lType2, isinplace, P, F, H, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::DDEProblem{uType, tType, lType, lType2, isinplace, P, F, H, K, PT}) where {
-                                                                                                 uType,
-                                                                                                 tType,
-                                                                                                 lType,
-                                                                                                 lType2,
-                                                                                                 isinplace,
-                                                                                                 P,
-                                                                                                 F,
-                                                                                                 H,
-                                                                                                 K,
-                                                                                                 PT
-                                                                                                 }
+                   t::DDEProblem{uType, tType, lType, lType2, isinplace}) where {
+                                                                                 uType,
+                                                                                 tType,
+                                                                                 lType,
+                                                                                 lType2,
+                                                                                 isinplace
+                                                                                }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "DDEProblem{$uType,$tType,$lType,$lType2,$isinplace,$P,$F,$H,$K,$PT}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "DDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -251,7 +251,7 @@ struct DDEProblem{uType, tType, lType, lType2, isinplace, P, F, H, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::DDEProblem{uType, tType, lType, lType2, isinplace}) where {
+                   t::Type{<:DDEProblem{uType, tType, lType, lType2, isinplace}}) where {
                                                                                  uType,
                                                                                  tType,
                                                                                  lType,
@@ -259,7 +259,7 @@ function Base.show(io::IO,
                                                                                  isinplace
                                                                                 }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -113,12 +113,12 @@ struct DiscreteProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::DiscreteProblem{uType, tType, isinplace}) where {uType,
+                   t::Type{<:DiscreteProblem{uType, tType, isinplace}}) where {uType,
                                                                        tType,
                                                                        isinplace
                                                                        }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DiscreteProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -114,9 +114,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:DiscreteProblem{uType, tType, isinplace}}) where {uType,
-                                                                       tType,
-                                                                       isinplace
-                                                                       }
+                                                                               tType,
+                                                                               isinplace
+                                                                               }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -113,12 +113,12 @@ struct DiscreteProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::DiscreteProblem{uType, tType, isinplace, P, F, K}) where {uType,
-                                                                                tType,
-                                                                                isinplace,
-                                                                                P, F, K}
+                   t::DiscreteProblem{uType, tType, isinplace}) where {uType,
+                                                                       tType,
+                                                                       isinplace
+                                                                       }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "DiscreteProblem{$uType,$tType,$isinplace,$P,$F,$K}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "DiscreteProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -100,10 +100,10 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:ImplicitDiscreteProblem{uType, tType, isinplace}}) where {
-                                                                               uType,
-                                                                               tType,
-                                                                               isinplace,
-                                                                              }
+                                                                                       uType,
+                                                                                       tType,
+                                                                                       isinplace
+                                                                                       }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -99,15 +99,13 @@ struct ImplicitDiscreteProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::ImplicitDiscreteProblem{uType, tType, isinplace, P, F, K}) where {
-                                                                                        uType,
-                                                                                        tType,
-                                                                                        isinplace,
-                                                                                        P,
-                                                                                        F, K
-                                                                                        }
+                   t::ImplicitDiscreteProblem{uType, tType, isinplace}) where {
+                                                                               uType,
+                                                                               tType,
+                                                                               isinplace,
+                                                                              }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "ImplicitDiscreteProblem{$uType,$tType,$isinplace,$P,$F,$K}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "ImplicitDiscreteProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -99,13 +99,13 @@ struct ImplicitDiscreteProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::ImplicitDiscreteProblem{uType, tType, isinplace}) where {
+                   t::Type{<:ImplicitDiscreteProblem{uType, tType, isinplace}}) where {
                                                                                uType,
                                                                                tType,
                                                                                isinplace,
                                                                               }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ImplicitDiscreteProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -159,7 +159,7 @@ function Base.show(io::IO,
                    t::Type{<:ODEProblem{uType, tType, isinplace}}) where {uType,
                                                                           tType,
                                                                           isinplace}
-    if TruncatedStacktraces.VERBOSE[] || !(@isdefined(isinplace) && @isdefined(uType) && @isdefined(tType))
+    if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ODEProblem{$isinplace,$uType,$tType,…}")

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -156,13 +156,11 @@ struct ODEProblem{uType, tType, isinplace, P, F, K, PT} <:
 end
 
 function Base.show(io::IO,
-                   t::Type{ODEProblem{uType, tType, isinplace, P, F, K, PT}}) where {uType,
-                                                                                     tType,
-                                                                                     isinplace,
-                                                                                     P, F,
-                                                                                     K, PT}
-    if TruncatedStacktraces.VERBOSE[]
-        print(io, "ODEProblem{$uType, $tType, $isinplace, $P, $F, $K, $PT}")
+                   t::Type{<:ODEProblem{uType, tType, isinplace}}) where {uType,
+                                                                          tType,
+                                                                          isinplace}
+    if TruncatedStacktraces.VERBOSE[] || !(@isdefined(isinplace) && @isdefined(uType) && @isdefined(tType))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ODEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -82,14 +82,12 @@ mutable struct RODEProblem{uType, tType, isinplace, P, NP, F, K, ND} <:
 end
 
 function Base.show(io::IO,
-                   t::RODEProblem{uType, tType, isinplace, P, NP, F, K, ND}) where {uType,
-                                                                                    tType,
-                                                                                    isinplace,
-                                                                                    P, NP,
-                                                                                    F, K, ND
-                                                                                    }
+                   t::RODEProblem{uType, tType, isinplace}) where {uType,
+                                                                   tType,
+                                                                   isinplace
+                                                                  }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "RODEProblem{$uType,$tType,$isinplace,$P,$NP,$F,$K,$ND}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "RODEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -82,12 +82,12 @@ mutable struct RODEProblem{uType, tType, isinplace, P, NP, F, K, ND} <:
 end
 
 function Base.show(io::IO,
-                   t::RODEProblem{uType, tType, isinplace}) where {uType,
+                   t::Type{<:RODEProblem{uType, tType, isinplace}}) where {uType,
                                                                    tType,
                                                                    isinplace
                                                                   }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "RODEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -83,9 +83,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:RODEProblem{uType, tType, isinplace}}) where {uType,
-                                                                   tType,
-                                                                   isinplace
-                                                                  }
+                                                                           tType,
+                                                                           isinplace
+                                                                           }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -149,13 +149,9 @@ struct SDDEProblem{uType, tType, lType, lType2, isinplace, P, NP, F, G, H, K, ND
 end
 
 function Base.show(io::IO,
-                   t::SDDEProblem{uType, tType, lType, lType2, isinplace, P, NP, F, G, H, K,
-                                  ND}) where {uType, tType, lType, lType2, isinplace, P, NP,
-                                              F, G, H, K,
-                                              ND}
+                   t::SDDEProblem{uType, tType, lType, lType2, isinplace}) where {uType, tType, lType, lType2, isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SDDEProblem{$uType,$tType,$lType,$lType2,$isinplace,$P,$NP,$F,$G,$H,$K,$ND}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "SDDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -149,9 +149,9 @@ struct SDDEProblem{uType, tType, lType, lType2, isinplace, P, NP, F, G, H, K, ND
 end
 
 function Base.show(io::IO,
-                   t::SDDEProblem{uType, tType, lType, lType2, isinplace}) where {uType, tType, lType, lType2, isinplace}
+                   t::Type{<:SDDEProblem{uType, tType, lType, lType2, isinplace}}) where {uType, tType, lType, lType2, isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SDDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -149,7 +149,13 @@ struct SDDEProblem{uType, tType, lType, lType2, isinplace, P, NP, F, G, H, K, ND
 end
 
 function Base.show(io::IO,
-                   t::Type{<:SDDEProblem{uType, tType, lType, lType2, isinplace}}) where {uType, tType, lType, lType2, isinplace}
+                   t::Type{<:SDDEProblem{uType, tType, lType, lType2, isinplace}}) where {
+                                                                                          uType,
+                                                                                          tType,
+                                                                                          lType,
+                                                                                          lType2,
+                                                                                          isinplace
+                                                                                          }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -117,8 +117,8 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:SDEProblem{uType, tType, isinplace}}) where {uType,
-                                                                  tType,
-                                                                  isinplace}
+                                                                          tType,
+                                                                          isinplace}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -116,15 +116,11 @@ struct SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND} <:
 end
 
 function Base.show(io::IO,
-                   t::SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND}) where {uType,
-                                                                                      tType,
-                                                                                      isinplace,
-                                                                                      P, NP,
-                                                                                      F, G,
-                                                                                      K, ND}
+                   t::SDEProblem{uType, tType, isinplace}) where {uType,
+                                                                  tType,
+                                                                  isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SDEProblem{$uType,$tType,$isinplace,$P,$NP,$F,$G,$K,$ND}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "SDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -116,11 +116,11 @@ struct SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND} <:
 end
 
 function Base.show(io::IO,
-                   t::SDEProblem{uType, tType, isinplace}) where {uType,
+                   t::Type{<:SDEProblem{uType, tType, isinplace}}) where {uType,
                                                                   tType,
                                                                   isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SDEProblem{$isinplace,$uType,$tType,…}")
     end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -100,11 +100,10 @@ struct SteadyStateProblem{uType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::SteadyStateProblem{uType, isinplace, P, F, K}) where {uType,
-                                                                            isinplace, P, F,
-                                                                            K}
+                   t::SteadyStateProblem{uType, isinplace}) where {uType,
+                                                                   isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "SteadyStateProblem{$uType,$isinplace,$P,$F,$K}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "SteadyStateProblem{$isinplace,$uType,…}")
     end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -101,7 +101,7 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:SteadyStateProblem{uType, isinplace}}) where {uType,
-                                                                   isinplace}
+                                                                           isinplace}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -100,10 +100,10 @@ struct SteadyStateProblem{uType, isinplace, P, F, K} <:
 end
 
 function Base.show(io::IO,
-                   t::SteadyStateProblem{uType, isinplace}) where {uType,
+                   t::Type{<:SteadyStateProblem{uType, isinplace}}) where {uType,
                                                                    isinplace}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SteadyStateProblem{$isinplace,$uType,…}")
     end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -934,7 +934,7 @@ end
 function Base.show(io::IO,
                    t::Type{
                            <:DynamicalDDEFunction{iip, specialize}}) where {iip,
-                                                                              specialize}
+                                                                            specialize}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
@@ -1094,7 +1094,8 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           <:ImplicitDiscreteFunction{iip, specialize}}) where {iip, specialize}
+                           <:ImplicitDiscreteFunction{iip, specialize}}) where {iip,
+                                                                                specialize}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
@@ -1354,7 +1355,7 @@ end
 function Base.show(io::IO,
                    t::Type{
                            <:SplitSDEFunction{iip, specialize
-                                            }}) where {iip, specialize}
+                                              }}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else
@@ -2018,7 +2019,7 @@ function Base.show(io::IO,
                    t::Type{
                            <:NonlinearFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-       invoke(show, Tuple{IO, Type}, io, t)
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "NonlinearFunction{$iip,$specialize,…}")
     end
@@ -2092,7 +2093,8 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           <:IntervalNonlinearFunction{iip, specialize}}) where {iip, specialize}
+                           <:IntervalNonlinearFunction{iip, specialize}}) where {iip,
+                                                                                 specialize}
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -414,17 +414,9 @@ struct ODEFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TW
 end
 
 function Base.show(io::IO,
-                   t::Type{
-                           ODEFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP, JP,
-                                       SP, TW, TWt, TPJ, S,
-                                       S2, S3, O, TCV, SYS}}) where {iip, specialize, F,
-                                                                     TMM, Ta, Tt, TJ, JVP,
-                                                                     VJP, JP, SP, TW, TWt,
-                                                                     TPJ, S, S2, S3, O, TCV,
-                                                                     SYS}
+                   t::Type{<:ODEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "ODEFunction{$iip,$specialize,$F,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ODEFunction{$iip,$specialize,…}")
     end
@@ -560,19 +552,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           SplitFunction{iip, specialize, F1, F2, TMM, Ta, Tt, TJ, JVP, VJP,
-                                         JP,
-                                         SP, TW, TWt, TPJ, S,
-                                         S2, S3, O, TCV, SYS}}) where {iip, specialize, F1,
-                                                                       F2,
-                                                                       TMM, Ta, Tt, TJ, JVP,
-                                                                       VJP, JP, SP, TW, TWt,
-                                                                       TPJ, S, S2, S3, O,
-                                                                       TCV,
-                                                                       SYS}
+                           <:SplitFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SplitFunction{$iip,$specialize,$F1,$F2,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SplitFunction{$iip,$specialize,…}")
     end
@@ -697,22 +679,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DynamicalODEFunction{iip, specialize, F1, F2, TMM, Ta, Tt, TJ,
-                                                JVP, VJP, JP,
-                                                SP, TW, TWt, TPJ, S,
-                                                S2, S3, O, TCV, SYS}}) where {iip,
-                                                                              specialize,
-                                                                              F1, F2,
-                                                                              TMM, Ta, Tt,
-                                                                              TJ, JVP,
-                                                                              VJP, JP, SP,
-                                                                              TW, TWt,
-                                                                              TPJ, S, S2,
-                                                                              S3, O, TCV,
-                                                                              SYS}
+                           <:DynamicalODEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DynamicalODEFunction{$iip,$specialize,$F1,$F2,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DynamicalODEFunction{$iip,$specialize,…}")
     end
@@ -835,16 +804,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DDEFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP, JP,
-                                       SP, TW, TWt, TPJ, S,
-                                       S2, S3, O, TCV, SYS}}) where {iip, specialize, F,
-                                                                     TMM, Ta, Tt, TJ, JVP,
-                                                                     VJP, JP, SP, TW, TWt,
-                                                                     TPJ, S, S2, S3, O, TCV,
-                                                                     SYS}
+                           <:DDEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DDEFunction{$iip,$specialize,$F,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DDEFunction{$iip,$specialize,…}")
     end
@@ -971,22 +933,10 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DynamicalDDEFunction{iip, specialize, F1, F2, TMM, Ta, Tt, TJ,
-                                                JVP, VJP, JP,
-                                                SP, TW, TWt, TPJ, S,
-                                                S2, S3, O, TCV, SYS}}) where {iip,
-                                                                              specialize,
-                                                                              F1, F2,
-                                                                              TMM, Ta, Tt,
-                                                                              TJ, JVP,
-                                                                              VJP, JP, SP,
-                                                                              TW, TWt,
-                                                                              TPJ, S, S2,
-                                                                              S3, O, TCV,
-                                                                              SYS}
+                           <:DynamicalDDEFunction{iip, specialize}}) where {iip,
+                                                                              specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DynamicalDDEFunction{$iip,$specialize,$F1,$F2,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DynamicalDDEFunction{$iip,$specialize,…}")
     end
@@ -1064,20 +1014,11 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DiscreteFunction{iip, specialize, F, Ta, S, S2, S3, O, SYS}}) where {
-                                                                                                iip,
-                                                                                                specialize,
-                                                                                                F,
-                                                                                                Ta,
-                                                                                                S,
-                                                                                                S2,
-                                                                                                S3,
-                                                                                                O,
-                                                                                                SYS
-                                                                                                }
+                           <:DiscreteFunction{iip, specialize}}) where {
+                                                                        iip,
+                                                                        specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DiscreteFunction{$iip,$specialize,$F,$Ta,$S,$S2,$S3,$O,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DiscreteFunction{$iip,$specialize,…}")
     end
@@ -1153,12 +1094,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           ImplicitDiscreteFunction{iip, specialize, F, Ta, S, S2, S3, O,
-                                                    SYS}}) where {iip, specialize, F, Ta, S,
-                                                                  S2, S3, O, SYS}
+                           <:ImplicitDiscreteFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "ImplicitDiscreteFunction{$iip,$specialize,$F,$Ta,$S,$S2,$S3,$O,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "ImplicitDiscreteFunction{$iip,$specialize,…}")
     end
@@ -1284,18 +1222,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           SDEFunction{iip, specialize, F, G, TMM, Ta, Tt, TJ, JVP, VJP, JP,
-                                       SP, TW, TWt, TPJ,
-                                       GG, S, S2, S3, O,
-                                       TCV, SYS
-                                       }}) where {iip, specialize, F, G, TMM, Ta, Tt, TJ,
-                                                  JVP, VJP, JP, SP, TW, TWt, TPJ,
-                                                  GG, S, S2, S3, O,
-                                                  TCV, SYS
-                                                  }
+                           <:SDEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SDEFunction{$iip,$specialize,$F,$G,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$GG,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SDEFunction{$iip,$specialize,…}")
     end
@@ -1424,19 +1353,10 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           SplitSDEFunction{iip, specialize, F1, F2, G, TMM, Ta, Tt, TJ,
-                                            JVP, VJP, JP, SP, TW, TWt, TPJ,
-                                            GG, S, S2, S3, O,
-                                            TCV, SYS
-                                            }}) where {iip, specialize, F1, F2, G, TMM, Ta,
-                                                       Tt, TJ, JVP, VJP, JP, SP, TW, TWt,
-                                                       TPJ,
-                                                       GG, S, S2, S3, O,
-                                                       TCV, SYS
-                                                       }
+                           <:SplitSDEFunction{iip, specialize
+                                            }}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SplitSDEFunction{$iip,$specialize,$F1,$F2,$G,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$GG,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SplitSDEFunction{$iip,$specialize,…}")
     end
@@ -1565,19 +1485,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DynamicalSDEFunction{iip, specialize, F1, F2, G, TMM, Ta, Tt, TJ,
-                                                JVP, VJP, JP, SP, TW, TWt, TPJ,
-                                                GG, S, S2, S3, O,
-                                                TCV, SYS
-                                                }}) where {iip, specialize, F1, F2, G, TMM,
-                                                           Ta, Tt, TJ, JVP, VJP, JP, SP, TW,
-                                                           TWt, TPJ,
-                                                           GG, S, S2, S3, O,
-                                                           TCV, SYS
-                                                           }
+                           <:DynamicalSDEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DynamicalSDEFunction{$iip,$specialize,$F1,$F2,$G,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$GG,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DynamicalSDEFunction{$iip,$specialize,…}")
     end
@@ -1706,16 +1616,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           RODEFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP, JP,
-                                        SP, TW, TWt, TPJ, S,
-                                        S2, S3, O, TCV, SYS
-                                        }}) where {iip, specialize, F, TMM, Ta, Tt, TJ, JVP,
-                                                   VJP, JP, SP, TW, TWt, TPJ, S,
-                                                   S2, S3, O, TCV, SYS
-                                                   }
+                           <:RODEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "RODEFunction{$iip,$specialize,$F,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "RODEFunction{$iip,$specialize,…}")
     end
@@ -1875,16 +1778,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           DAEFunction{iip, specialize, F, Ta, Tt, TJ, JVP, VJP, JP, SP, TW,
-                                       TWt, TPJ, S, S2,
-                                       S3, O, TCV,
-                                       SYS}}) where {iip, specialize, F, Ta, Tt, TJ, JVP,
-                                                     VJP, JP, SP, TW, TWt, TPJ, S, S2,
-                                                     S3, O, TCV,
-                                                     SYS}
+                           <:DAEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "DAEFunction{$iip,$specialize,$F,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DAEFunction{$iip,$specialize,…}")
     end
@@ -2008,17 +1904,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           SDDEFunction{iip, specialize, F, G, TMM, Ta, Tt, TJ, JVP, VJP,
-                                        JP, SP, TW, TWt, TPJ,
-                                        GG, S, S2, S3, O,
-                                        TCV, SYS}}) where {iip, specialize, F, G, TMM, Ta,
-                                                           Tt, TJ, JVP, VJP, JP, SP, TW,
-                                                           TWt, TPJ,
-                                                           GG, S, S2, S3, O,
-                                                           TCV, SYS}
+                           <:SDDEFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "SDDEFunction{$iip,$specialize,$F,$G,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$GG,$S,$S2,$S3,$O,$TCV,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "SDDEFunction{$iip,$specialize,…}")
     end
@@ -2128,20 +2016,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           NonlinearFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP,
-                                             JP, SP, TW, TWt,
-                                             TPJ,
-                                             S, S2, O, TCV,
-                                             SYS
-                                             }}) where {iip, specialize, F, TMM, Ta, Tt, TJ,
-                                                        JVP, VJP, JP, SP, TW, TWt,
-                                                        TPJ,
-                                                        S, S2, O, TCV,
-                                                        SYS
-                                                        }
+                           <:NonlinearFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "NonlinearFunction{$iip,$specialize,$F,$TMM,$Ta,$Tt,$TJ,$JVP,$VJP,$JP,$SP,$TW,$TWt,$TPJ,$S,$S2,$O,$TCV,$SYS}")
+       invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "NonlinearFunction{$iip,$specialize,…}")
     end
@@ -2215,14 +2092,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           IntervalNonlinearFunction{iip, specialize, F, Ta,
-                                                     S, S2, O, SYS
-                                                     }}) where {iip, specialize, F, Ta,
-                                                                S, S2, O, SYS
-                                                                }
+                           <:IntervalNonlinearFunction{iip, specialize}}) where {iip, specialize}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "IntervalNonlinearFunction{$iip,$specialize,$F,$Ta,$S,$S2,$O,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "IntervalNonlinearFunction{$iip,$specialize,…}")
     end
@@ -2374,26 +2246,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{
-                           OptimizationFunction{iip, AD, F, G, H, HV, C, CJ, CH, LH, HP,
-                                                CJP, CHP, LHP, S, S2,
-                                                O, HCV,
-                                                CJCV,
-                                                CHCV, LHCV, EX, CEX, SYS}}) where {iip, AD,
-                                                                                   F, G, H,
-                                                                                   HV, C,
-                                                                                   CJ, CH,
-                                                                                   LH, HP,
-                                                                                   CJP, CHP,
-                                                                                   LHP, S,
-                                                                                   S2,
-                                                                                   O, HCV,
-                                                                                   CJCV,
-                                                                                   CHCV,
-                                                                                   LHCV, EX,
-                                                                                   CEX, SYS}
+                           <:OptimizationFunction{iip, AD}}) where {iip, AD}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "OptimizationFunction{$iip,$AD,$F,$G,$H,$HV,$C,$CJ,$CH,$LH,$HP,$CJP,$CHP,$LHP,$S,$S2,$O,$HCV,$CJCV,$CHCV,$LHCV,$EX,$CEX,$SYS}")
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "OptimizationFunction{$iip,$AD,…}")
     end

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -11,7 +11,7 @@ Representation of the solution to an linear system Ax=b defined by a LinearProbl
 - `iters`: the number of iterations used to solve the equation, if the method is an iterative
   method.
 - `retcode`: the return code from the solver. Used to determine whether the solver solved
-  successfully or whether it exited due to an error. For more details, see 
+  successfully or whether it exited due to an error. For more details, see
   [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
 - `cache`: the `LinearCache` object containing the solver's internal cached variables. This
   is given to allow continuation of solver usage, for example, solving `Ax=b` with the same
@@ -39,9 +39,9 @@ function build_linear_solution(alg, u, resid, cache;
 end
 
 function Base.show(io::IO,
-                   t::LinearSolution{T, N, uType, R, A, C}) where {T, N, uType, R, A, C}
+                   t::LinearSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "LinearSolution{$T,$N,$uType,$R,$A,$C}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "LinearSolution{$T,$N,…}")
     end
@@ -58,7 +58,7 @@ Representation of the solution to an quadrature integral_lb^ub f(x) dx defined b
 - `resid`: the residual of the solver.
 - `alg`: the algorithm type used by the solver.
 - `retcode`: the return code from the solver. Used to determine whether the solver solved
-   successfully or whether it exited due to an error. For more details, see 
+   successfully or whether it exited due to an error. For more details, see
    [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
 - `chi`: the variance estimate of the estimator from Monte Carlo quadrature methods.
 - `stats`: statistics of the solver, such as the number of function evaluations required.
@@ -74,10 +74,9 @@ struct IntegralSolution{T, N, uType, R, P, A, C, S} <: AbstractIntegralSolution{
 end
 
 function Base.show(io::IO,
-                   t::IntegralSolution{T, N, uType, R, P, A, C}) where {T, N, uType, R, P,
-                                                                        A, C}
+                   t::IntegralSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "IntegralSolution{$T,$N,$uType,$R,$P,$A,$C}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "IntegralSolution{$T,$N,…}")
     end

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -39,9 +39,9 @@ function build_linear_solution(alg, u, resid, cache;
 end
 
 function Base.show(io::IO,
-                   t::LinearSolution{T, N}) where {T, N}
+                   t::Type{<:LinearSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "LinearSolution{$T,$N,…}")
     end
@@ -74,9 +74,9 @@ struct IntegralSolution{T, N, uType, R, P, A, C, S} <: AbstractIntegralSolution{
 end
 
 function Base.show(io::IO,
-                   t::IntegralSolution{T, N}) where {T, N}
+                   t::Type{<:IntegralSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "IntegralSolution{$T,$N,…}")
     end

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -52,21 +52,12 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractDAESolution, s::Sy
 end
 
 function Base.show(io::IO,
-                   t::DAESolution{T, N, uType, duType, uType2, DType, tType, P, A, ID, DE}) where {
-                                                                                                   T,
-                                                                                                   N,
-                                                                                                   uType,
-                                                                                                   duType,
-                                                                                                   uType2,
-                                                                                                   DType,
-                                                                                                   tType,
-                                                                                                   P,
-                                                                                                   A,
-                                                                                                   ID,
-                                                                                                   DE
-                                                                                                   }
+                   t::DAESolution{T, N}) where {
+                                                T,
+                                                N
+                                                }
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "DAESolution{$T,$N,$uType,$duType,$uType2,$DType,$tType,$P,$A,$ID,$DE}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "DAESolution{$T,$N,…}")
     end

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -52,12 +52,12 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractDAESolution, s::Sy
 end
 
 function Base.show(io::IO,
-                   t::DAESolution{T, N}) where {
+                   t::Type{<:DAESolution{T, N}}) where {
                                                 T,
                                                 N
                                                 }
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "DAESolution{$T,$N,…}")
     end

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -53,9 +53,9 @@ end
 
 function Base.show(io::IO,
                    t::Type{<:DAESolution{T, N}}) where {
-                                                T,
-                                                N
-                                                }
+                                                        T,
+                                                        N
+                                                        }
     if TruncatedStacktraces.VERBOSE[]
         invoke(show, Tuple{IO, Type}, io, t)
     else

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -13,7 +13,7 @@ or the steady state solution to a differential equation defined by a SteadyState
 - `original`: if the solver is wrapped from an alternative solver ecosystem, such as
   NLsolve.jl, then this is the original return from said solver library.
 - `retcode`: the return code from the solver. Used to determine whether the solver solved
-  successfully or whether it exited due to an error. For more details, see 
+  successfully or whether it exited due to an error. For more details, see
   [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
 - `left`: if the solver is bracketing method, this is the final left bracket value.
 - `right`: if the solver is bracketing method, this is the final right bracket value.
@@ -33,12 +33,9 @@ struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S} <:
 end
 
 function Base.show(io::IO,
-                   t::NonlinearSolution{T, N, uType, R, P, A, O, uType2}) where {T, N,
-                                                                                 uType, R,
-                                                                                 P, A, O,
-                                                                                 uType2}
+                   t::NonlinearSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "NonlinearSolution{$T,$N,$uType,$R,$P,$A,$O,$uType2}")
+      invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "NonlinearSolution{$T,$N,…}")
     end

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -33,9 +33,9 @@ struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S} <:
 end
 
 function Base.show(io::IO,
-                   t::NonlinearSolution{T, N}) where {T, N}
+                   t::Type{<:NonlinearSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-      invoke(show, Tuple{IO, Type}, io, typeof(t))
+      invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "NonlinearSolution{$T,$N,…}")
     end

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -35,7 +35,7 @@ end
 function Base.show(io::IO,
                    t::Type{<:NonlinearSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-      invoke(show, Tuple{IO, Type}, io, t)
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "NonlinearSolution{$T,$N,…}")
     end

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -49,11 +49,9 @@ function build_solution(cache::AbstractOptimizationCache,
 end
 
 function Base.show(io::IO,
-                   t::OptimizationSolution{T, N, uType, C, A, OV, O, S}) where {T, N, uType,
-                                                                                C, A, OV, O,
-                                                                                S}
+                   t::OptimizationSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io, "OptimizationSolution{$T,$N,$uType,$C,$A,$OV,$O,$S}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "OptimizationSolution{$T,$N,…}")
     end

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -49,9 +49,9 @@ function build_solution(cache::AbstractOptimizationCache,
 end
 
 function Base.show(io::IO,
-                   t::OptimizationSolution{T, N}) where {T, N}
+                   t::Type{<:OptimizationSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "OptimizationSolution{$T,$N,…}")
     end

--- a/src/solutions/pde_solutions.jl
+++ b/src/solutions/pde_solutions.jl
@@ -51,9 +51,9 @@ struct PDETimeSeriesSolution{T, N, uType, Disc, Sol, DType, tType, domType, ivTy
 end
 
 function Base.show(io::IO,
-                   t::PDETimeSeriesSolution{T, N}) where {T, N}
+                   t::Type{<:PDETimeSeriesSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-      invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "PDETimeSeriesSolution{$T,$N,…}")
     end
@@ -104,9 +104,9 @@ struct PDENoTimeSolution{T, N, uType, Disc, Sol, domType, ivType, dvType, P, A,
 end
 
 function Base.show(io::IO,
-                   t::PDENoTimeSolution{T, N}) where {T, N}
+                   t::Type{<:PDENoTimeSolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "PDENoTimeSolution{$T,$N,…}")
     end

--- a/src/solutions/pde_solutions.jl
+++ b/src/solutions/pde_solutions.jl
@@ -51,19 +51,9 @@ struct PDETimeSeriesSolution{T, N, uType, Disc, Sol, DType, tType, domType, ivTy
 end
 
 function Base.show(io::IO,
-                   t::PDETimeSeriesSolution{T, N, uType, Disc, Sol, DType, tType, domType,
-                                            ivType, dvType, P, A, IType}) where {T, N,
-                                                                                 uType,
-                                                                                 Disc, Sol,
-                                                                                 DType,
-                                                                                 tType,
-                                                                                 domType,
-                                                                                 ivType,
-                                                                                 dvType, P,
-                                                                                 A, IType}
+                   t::PDETimeSeriesSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "PDETimeSeriesSolution{$T,$N,$uType,$Disc,$Sol,$DType,$tType,$domType,$ivType,$dvType,$P,$A,$IType}")
+      invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "PDETimeSeriesSolution{$T,$N,…}")
     end
@@ -114,12 +104,9 @@ struct PDENoTimeSolution{T, N, uType, Disc, Sol, domType, ivType, dvType, P, A,
 end
 
 function Base.show(io::IO,
-                   t::PDENoTimeSolution{T, N, uType, Disc, Sol, domType, ivType, dvType, P,
-                                        A, IType}) where {T, N, uType, Disc, Sol, domType,
-                                                          ivType, dvType, P, A, IType}
+                   t::PDENoTimeSolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "PDENoTimeSolution{$T,$N,$uType,$Disc,$Sol,$domType,$ivType,$dvType,$P,$A,$IType}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "PDENoTimeSolution{$T,$N,…}")
     end

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -60,9 +60,9 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractRODESolution, s::S
 end
 
 function Base.show(io::IO,
-                   t::RODESolution{T, N}) where {T, N}
+                   t::Type{<:RODESolution{T, N}}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        invoke(show, Tuple{IO, Type}, io, typeof(t))
+        invoke(show, Tuple{IO, Type}, io, t)
     else
         print(io, "RODESolution{$T,$N,…}")
     end

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -60,12 +60,9 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractRODESolution, s::S
 end
 
 function Base.show(io::IO,
-                   t::RODESolution{T, N, uType, uType2, DType, tType, randType, P, A, IType,
-                                   DE, AC}) where {T, N, uType, uType2, DType, tType,
-                                                   randType, P, A, IType, DE, AC}
+                   t::RODESolution{T, N}) where {T, N}
     if TruncatedStacktraces.VERBOSE[]
-        print(io,
-              "RODESolution{$T,$N,$uType,$uType2,$DType,$tType,$randType,$P,$A,$IType,$DE,$AC}")
+        invoke(show, Tuple{IO, Type}, io, typeof(t))
     else
         print(io, "RODESolution{$T,$N,…}")
     end


### PR DESCRIPTION
The first commit invokes the show method for general `Type`s in order for it to be safe. So at least people that hit https://github.com/SciML/TruncatedStacktraces.jl/issues/18 can now disable it and get working code:

```julia
julia> using SnoopCompileCore; invalidations = @snoopr(using SciMLBase); using SnoopCompile


julia> trees = invalidation_trees(invalidations)
3-element Vector{SnoopCompile.MethodInvalidations}:
Error showing value of type Vector{SnoopCompile.MethodInvalidations}:
ERROR: UndefVarError: `T` not defined
Stacktrace:
  [1] show(io::IOContext{IOBuffer}, t::
SYSTEM (REPL): showing an error caused an error
ERROR: UndefVarError: `T` not defined
Stacktrace:
  [1] show(io::IOContext{IOBuffer}, t::
SYSTEM (REPL): caught exception of type UndefVarError while trying to handle a nested exception; giving up

julia> SciMLBase.TruncatedStacktraces.VERBOSE[] = true
true

julia> trees = invalidation_trees(invalidations)
3-element Vector{SnoopCompile.MethodInvalidations}:
 inserting print_matrix_row(io::IO, X::Union{FillArrays.AbstractFill{<:Any, 1}, FillArrays.AbstractFill{<:Any, 2}, FillArrays.RectDiagonal, LinearAlgebra.AbstractTriangular{<:Any, <:FillArrays.AbstractFill{<:Any, 2}}, LinearAlgebra.Diagonal{<:Any, <:FillArrays.AbstractFill{<:Any, 1}}}, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer) @ FillArrays ~/.julia/packages/FillArrays/xqile/src/FillArrays.jl:688 invalidated:
   backedges: 1: superseding print_matrix_row(io::IO, X::AbstractVecOrMat, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer) @ Base arrayshow.jl:97 with MethodInstance for Base.print_matrix_row(::IOContext{Base.TTY}, ::AbstractVecOrMat, ::Vector{Tuple{Int64, Int64}}, ::Int64, ::Vector{Int64}, ::String, ::Int64) (13 children)
   8 mt_cache

 inserting broadcasted(::Base.Broadcast.DefaultArrayStyle{N}, op, r::FillArrays.AbstractFill{T, N}) where {T, N} @ FillArrays ~/.julia/packages/FillArrays/xqile/src/fillbroadcast.jl:78 invalidated:
   mt_backedges: 1: signature broadcasted(::S, f, args...) where S<:BroadcastStyle @ Base.Broadcast broadcast.jl:1319 (formerly broadcasted(::S, f, args...) where S<:BroadcastStyle @ Base.Broadcast broadcast.jl:1319) triggered MethodInstance for Base.Broadcast.broadcasted(::typeof(esc), ::Any) (20 children)
   9 mt_cache

 inserting show(io::IO, t::Type{<:SciMLBase.IntegralSolution{T, N}}) where {T, N} @ SciMLBase ~/JuliaPkgs/SciMLBase.jl/src/solutions/basic_solutions.jl:76 invalidated:
   backedges: 1: superseding show(io::IO, x::Type) @ Base show.jl:950 with MethodInstance for show(::IOContext{IOBuffer}, ::Type) (107 children)
              2: superseding show(io::IO, x::Type) @ Base show.jl:950 with MethodInstance for show(::IOBuffer, ::Type) (3104 children)
   4 mt_cache
``` 

The second commit was made by "pattern recognition". I am not sure, but it looks like a typo that those `show` methods were defined on the instance of the struct and not the type. But I might be wrong.