### PR TITLE
Enable symbol interfacing to solution

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -96,7 +96,11 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractTimeseriesSolution, s
             elseif has_paramsyms(A.prob.f) && Symbol(sym) in getparamsyms(A)
                 return A.prob.p[findfirst(x -> isequal(x, Symbol(sym)), getparamsyms(A))]
             else
-                return observed(A, sym, :)
+                if (sym isa Symbol) && has_sys(A.prob.f) && hasproperty(A.prob.f.sys, sym)
+                    return observed(A, getproperty(A.prob.f.sys, sym), :)
+                else
+                    return observed(A, sym, :)
+                end
             end
         else
             observed(A, sym, :)

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -96,8 +96,12 @@ Base.@propagate_inbounds function Base.getindex(A::AbstractTimeseriesSolution, s
             elseif has_paramsyms(A.prob.f) && Symbol(sym) in getparamsyms(A)
                 return A.prob.p[findfirst(x -> isequal(x, Symbol(sym)), getparamsyms(A))]
             else
-                if (sym isa Symbol) && has_sys(A.prob.f) && hasproperty(A.prob.f.sys, sym)
-                    return observed(A, getproperty(A.prob.f.sys, sym), :)
+                if (sym isa Symbol) && has_sys(A.prob.f)
+                    if hasproperty(A.prob.f.sys, sym)
+                        return observed(A, getproperty(A.prob.f.sys, sym), :)
+                    else
+                        error("Tried to index solution with a Symbol that was not found in the system using `getproperty`.")
+                    end
                 else
                     return observed(A, sym, :)
                 end


### PR DESCRIPTION
Currently, this is possible for accessing values of a solution object:
```julia
using DifferentialEquations, ModelingToolkit, Plots

@parameters t σ ρ β
@variables x(t) y(t) z(t)
D = Differential(t)

eqs = [D(x) ~ σ * (y - x),
    D(y) ~ x * (ρ - z) - y,
    D(z) ~ x * y - β * z]

@named sys = ODESystem(eqs)

u0 = [x => 1.0, y => 0.0, z => 0.0]
p = [σ => 28.0, ρ => 10.0, β => 8 / 3]
tspan = (0.0, 10.0)

oprob = ODEProblem(sys, u0, tspan, p, jac = true)
integ = init(oprob)
sol = solve(oprob)

sol[x]
sol[sys.x]

plot(sol, idxs=x)
plot(sol, idxs=[x])
plot(sol, idxs=sys.x)
plot(sol, idxs=[sys.x])
```

This PR adds a single check, enabling `getindex` on solution objects using Symbols. This enables:
```julia
plot(sol, idxs=:x)
plot(sol, idxs=[:x])
sol[:x]
```

For good measure (I can remove this, or add more), I have also added an error check that gives an error if one try to inde with symbols that have no corresponding property. E.g.
```julia
plot(sol, idxs=:X)
plot(sol, idxs=[:X])
sol[:X]
```
now gives errors:
```
Tried to index solution with a Symbol that was not found in the system using `getproperty`.
```