### PR TITLE
getindex for ensembles to use symbolic indexing interface

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -48,6 +48,15 @@ function Base.reverse(sim::EnsembleSolution)
     EnsembleSolution(reverse(sim.u), sim.elapsedTime, sim.converged)
 end
 
+Base.@propagate_inbounds function Base.getindex(A::SciMLBase.AbstractEnsembleSolution, sym)
+    map(sol -> getindex(sol, sym), A.u)
+end
+
+Base.@propagate_inbounds function Base.getindex(A::SciMLBase.AbstractEnsembleSolution{T, N},
+                                                i::Int) where {T, N}
+    A.u[i]
+end
+
 """
 $(TYPEDEF)
 """


### PR DESCRIPTION

* todo: add test
* probably need to also only have this work when the EnsembleProblem.prob field is Array of problem. but if you pass EnsembleProblem a list of problems, could we create a default `prob_func=(probs, i, reset) -> probs[i]`? 
