### PR TITLE
Hook up `NoInit` in scimlBase

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -284,6 +284,8 @@ algorithm to use.
 function initialize_dae!(integrator::DEIntegrator)
     error("initialize_dae!: method has not been implemented for the integrator")
 end
+function initialize_dae!(integrator::DEIntegrator, initializealg::NoInit)
+end
 
 """
     auto_dt_reset!(integrator::DEIntegrator)


### PR DESCRIPTION
When combined with https://github.com/SciML/Sundials.jl/pull/401, this allows IDA to be used with `NoInit`. The test for this will be added to the sundials PR once this is merged.