### PR TITLE
Add NLStats struct for nonlinear solver stat tracking

### DIFF
--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -4,14 +4,16 @@ $(TYPEDEF)
 Statistics from the nonlinear equation solver about the solution process.
 ## Fields
 - nf: Number of function evaluations.
-- nsolve: The number of linear solves `W\b` required for the integration.
-- njacs: Number of Jacobians calculated during the integration.
-- nsteps: Total number of iterations for the nonlinear solvers.
+- njacs: Number of Jacobians created during the solve.
+- nfactors: Number of factorzations of the jacobian required for the solve.
+- nsolve: Number of linear solves `W\b` required for the solve.
+- nsteps: Total number of iterations for the nonlinear solver.
 """
 mutable struct NLStats
     nf::Int
-    nsolve::Int
     njacs::Int
+    nfactors::Int
+    nsolve::Int
     nsteps::Int
 end
 

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -1,3 +1,21 @@
+
+"""
+$(TYPEDEF)
+Statistics from the nonlinear equation solver about the solution process.
+## Fields
+- nf: Number of function evaluations.
+- nsolve: The number of linear solves `W\b` required for the integration.
+- njacs: Number of Jacobians calculated during the integration.
+- nnonliniter: Total number of iterations for the nonlinear solvers.
+"""
+mutable struct NLStats
+    nf::Int
+    nsolve::Int
+    njacs::Int
+    nnonliniter::Int
+    nsteps::Int
+end
+
 """
 $(TYPEDEF)
 

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -6,13 +6,12 @@ Statistics from the nonlinear equation solver about the solution process.
 - nf: Number of function evaluations.
 - nsolve: The number of linear solves `W\b` required for the integration.
 - njacs: Number of Jacobians calculated during the integration.
-- nnonliniter: Total number of iterations for the nonlinear solvers.
+- nsteps: Total number of iterations for the nonlinear solvers.
 """
 mutable struct NLStats
     nf::Int
     nsolve::Int
     njacs::Int
-    nnonliniter::Int
     nsteps::Int
 end
 


### PR DESCRIPTION
This will make it possible for nonlinear solvers to keep track of their statistics which (among other things) will make it so DAE solvers don't skip counting the cost of initialization.