### PR TITLE
improve `Vararg` checking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "1.92.5"
+version = "1.92.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -463,3 +463,13 @@ optf(u) = 1.0
 optf(u, p) = 1.0
 OptimizationFunction(optf)
 OptimizationProblem(optf, 1.0)
+
+# Varargs
+var1(u...) = 1.0
+var2(u::Vararg{Any, N}) where N = 1.0
+var3(u::Vararg{Int, N}) where N = 1.0
+var4(u::Vararg{Vector{T}, N}) where {T, N} = 1.0
+OptimizationFunction(var1)
+OptimizationFunction(var2)
+OptimizationFunction(var3)
+OptimizationFunction(var4)


### PR DESCRIPTION
This code really shouldn't be messing around with function signatures, but if it is, it should do so better. This allows recognizing things like `g(x::Vararg{Vector{T}, N}) where {N, T}`.