### PR TITLE
Throw appropriate error when analytic is not given

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -672,6 +672,7 @@ function solplot_vecs_and_labels(dims, vars, plot_timeseries, plott, sol, plot_a
     end
 
     if plot_analytic
+        @assert sol.u_analytic !== Nothing
         analytic_plot_vecs = []
         for x in vars
             tmp = []


### PR DESCRIPTION
This is just a minor fix, when we are plotting a solution **without an analytical solution** but we set ```plot_analytic=true```, the error is weird:

![image](https://github.com/SciML/SciMLBase.jl/assets/52615090/965e67b2-7e15-48b0-8b55-37631c9a1be3)