### PR TITLE
fix segfault when interpolating on failed solution

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -83,6 +83,8 @@ end
     u = id.u
     typeof(id) <: HermiteInterpolation && (du = id.du)
     tdir = sign(t[end] - t[1])
+    t[end] == t[1] && tval != t[end] &&
+        error("Solution interpolation cannot extrapolate from a single timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     idx = sortperm(tvals, rev = tdir < 0)
     i = 2 # Start the search thinking it's between t[1] and t[2]
     tdir * tvals[idx[end]] > tdir * t[end] &&
@@ -143,6 +145,8 @@ times t (sorted), with values u and derivatives ks
     u = id.u
     typeof(id) <: HermiteInterpolation && (du = id.du)
     tdir = sign(t[end] - t[1])
+    t[end] == t[1] && tval != t[end] &&
+        error("Solution interpolation cannot extrapolate from a single timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     idx = sortperm(tvals, rev = tdir < 0)
     i = 2 # Start the search thinking it's between t[1] and t[2]
     tdir * tvals[idx[end]] > tdir * t[end] &&
@@ -204,6 +208,8 @@ times t (sorted), with values u and derivatives ks
     u = id.u
     typeof(id) <: HermiteInterpolation && (du = id.du)
     tdir = sign(t[end] - t[1])
+    t[end] == t[1] && tval != t[end] &&
+        error("Solution interpolation cannot extrapolate from a single timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval > tdir * t[end] &&
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&
@@ -252,6 +258,8 @@ times t (sorted), with values u and derivatives ks
     u = id.u
     typeof(id) <: HermiteInterpolation && (du = id.du)
     tdir = sign(t[end] - t[1])
+    t[end] == t[1] && tval != t[end] &&
+        error("Solution interpolation cannot extrapolate from a single timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval > tdir * t[end] &&
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -28,3 +28,13 @@ end
         nothing) # strs
     @test plot_vecs[2][:, 2] ≈ @. exp(-plot_vecs[1][:, 2])
 end
+
+@testset "interpolate empty ODE solution" begin
+    f = (u, p, t) -> -u
+    ode = ODEProblem(f, 1.0, (0.0, 1.0))
+    sol = SciMLBase.build_solution(ode, :NoAlgorithm, [ode.tspan[begin]], [ode.u0])
+    @test sol(0.0) == 1.0
+    # test that indexing out of bounds doesn't segfault
+    @test_throws ErrorException sol(1.0)
+    @test_throws ErrorException sol(-0.5)
+end


### PR DESCRIPTION
Fixes https://github.com/SciML/SciMLBase.jl/issues/458
Previously the check for whether the interpolation was being asked to extrapolate outside the time range assumed that at least two steps were taken. (otherwise `t[end]-t[1] == 0`).  This would then cause a segfault when you actually try to do the interpolation.