### PR TITLE
[URGENT] Unbreak Precompilation of SciMLBase on 1.9 with TruncatedStacktraces enabled!

### DIFF
--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -459,7 +459,7 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
     end
 end
 
-TruncatedStacktraces.@truncate_stacktrace SampledIntegralProblem 1 4
+TruncatedStacktraces.@truncate_stacktrace SampledIntegralProblem
 
 @doc doc"""
 


### PR DESCRIPTION
I have no clue which ones need to be displayed. I am just unbreaking the precompilation