### PR TITLE
Rename the extension packages and do RCall as well

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,12 +35,14 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [weakdeps]
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
-PyCallExt = "PyCall"
-PythonCallExt = "PythonCall"
-ZygoteExt = "Zygote"
+SciMLBasePyCallExt = "PyCall"
+SciMLBasePythonCallExt = "PythonCall"
+SciMLBaseRCallExt = "RCall"
+SciMLBaseZygoteExt = "Zygote"
 
 [compat]
 ADTypes = "0.1.3, 0.2"
@@ -55,6 +57,7 @@ FunctionWrappersWrappers = "0.1.3"
 IteratorInterfaceExtensions = "^0.1, ^1"
 PrecompileTools = "1"
 Preferences = "1.3"
+RCall = "0.13.18"
 RecipesBase = "0.7.0, 0.8, 1.0"
 RecursiveArrayTools = "2.33"
 Reexport = "1"

--- a/ext/SciMLBasePyCallExt.jl
+++ b/ext/SciMLBasePyCallExt.jl
@@ -1,4 +1,4 @@
-module PyCallExt
+module SciMLBasePyCallExt
 
 using PyCall: PyCall, PyObject, PyAny, pyfunctionret, pyimport, hasproperty
 using SciMLBase: SciMLBase, solve

--- a/ext/SciMLBasePythonCallExt.jl
+++ b/ext/SciMLBasePythonCallExt.jl
@@ -1,4 +1,4 @@
-module PythonCallExt
+module SciMLBasePythonCallExt
 
 using PythonCall: Py, PyList, pyimport, hasproperty, pyconvert, pyisinstance, pybuiltins
 using SciMLBase: SciMLBase

--- a/ext/SciMLBaseRCallExt.jl
+++ b/ext/SciMLBaseRCallExt.jl
@@ -1,0 +1,11 @@
+module SciMLBaseRCallExt
+
+using RCall: RFunction
+using SciMLBase
+
+# Always assume a function from R is not in-place because copy-on-write disallows it!
+function SciMLBase.isinplace(f::RFunction, args...; kwargs...)
+    false
+end
+
+end

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -1,4 +1,4 @@
-module ZygoteExt
+module SciMLBaseZygoteExt
 
 using Zygote: pullback
 using ZygoteRules: @adjoint


### PR DESCRIPTION
Fixes the name of the extensions so they don't clash elsewhere. Also adds an RCall one which is basic and assumes out of place, which is a fine assumption given that R is copy-on-write and thus mutation of the form of an in-place function is just not possible. This means that we don't get the great error messages, but oh well we can figure that out later.

Fixes https://github.com/SciML/diffeqr/issues/41

Better version requires https://github.com/JuliaInterop/RCall.jl/issues/503
