### PR TITLE
Fix bcresid_prototype in TwoPointBVPFunction

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -4067,8 +4067,8 @@ function BVPFunction{iip, specialize, twopoint}(f, bc;
     end
 
     if twopoint
-        if iip && (bcresid_prototype === nothing || length(bcresid_prototype) != 2)
-            error("bcresid_prototype must be a tuple / indexable collection of length 2 for a inplace TwoPointBVPFunction")
+        if iip && bcresid_prototype !== nothing
+            @assert length(bcresid_prototype) == 2 error("bcresid_prototype must be a tuple / indexable collection of length 2 for an inplace TwoPointBVPFunction")
         end
         if bcresid_prototype !== nothing && length(bcresid_prototype) == 2
             bcresid_prototype = ArrayPartition(first(bcresid_prototype),

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -618,6 +618,14 @@ BVPFunction(bfiip, bciip, vjp = bvjp)
 
 @test_throws SciMLBase.NonconformingFunctionsError BVPFunction(bfoop, bciip, vjp = bvjp)
 
+# TwoPointBVPFunction
+
+tpbvpf(du, u, p, t) = du .= u
+tpbvpbca(resa, ua, p) = resa .= ua
+tpbvpbcb(resb, ub, p) = resb .= ub
+SciMLBase.TwoPointBVPFunction(tpbvpf, (tpbvpbca, tpbvpbcb))
+@test_throws ErrorException SciMLBase.TwoPointBVPFunction(tpbvpf, (tpbvpbca, tpbvpbcb), bcresid_prototype = (1, 1, 1))
+
 # IntegralFunction
 
 ioop(u, p) = p * u


### PR DESCRIPTION
When trying to construct a ```TwoPointBVPFunction``` without specifying ```bcresid_prototype```, it throws errors

```julia
julia> f1 = SciMLBase.TwoPointBVPFunction(ex7_f!, (ex7_2pbc1!, ex7_2pbc2!))
ERROR: bcresid_prototype must be a tuple / indexable collection of length 2 for a inplace TwoPointBVPFunction
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] (BVPFunction{true, SciMLBase.FullSpecialize, true})(f::typeof(ex7_f!), bc::Tuple{typeof(ex7_2pbc1!), typeof(ex7_2pbc2!)}; mass_matrix::LinearAlgebra.UniformScaling{Bool}, analytic::Nothing, tgrad::Nothing, jac::Nothing, bcjac::Nothing, jvp::Nothing, vjp::Nothing, jac_prototype::Nothing, bcjac_prototype::Nothing, bcresid_prototype::Nothing, sparsity::Nothing, Wfact::Nothing, Wfact_t::Nothing, paramjac::Nothing, syms::Nothing, indepsym::Nothing, paramsyms::Nothing, observed::typeof(SciMLBase.DEFAULT_OBSERVED), colorvec::Nothing, bccolorvec::Nothing, sys::Nothing)
   @ SciMLBase ~/.julia/packages/SciMLBase/N8cDr/src/scimlfunctions.jl:4071
 [3] (BVPFunction{true, SciMLBase.FullSpecialize, true})(f::Function, bc::Tuple{typeof(ex7_2pbc1!), typeof(ex7_2pbc2!)})
   @ SciMLBase ~/.julia/packages/SciMLBase/N8cDr/src/scimlfunctions.jl:3966
 [4] BVPFunction(f::Function, bc::Tuple{typeof(ex7_2pbc1!), typeof(ex7_2pbc2!)}; twopoint::Val{true}, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ SciMLBase ~/.julia/packages/SciMLBase/N8cDr/src/scimlfunctions.jl:4122
 [5] SciMLBase.TwoPointBVPFunction(::Function, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ SciMLBase ~/.julia/packages/SciMLBase/N8cDr/src/problems/bvp_problems.jl:154
 [6] SciMLBase.TwoPointBVPFunction(::Function, ::Vararg{Any})
   @ SciMLBase ~/.julia/packages/SciMLBase/N8cDr/src/problems/bvp_problems.jl:153
 [7] top-level scope
   @ REPL[10]:1
```