### PR TITLE
Promote initial state when converting from non-homogeneous python lists.

### DIFF
--- a/test/python/pythoncall.jl
+++ b/test/python/pythoncall.jl
@@ -79,6 +79,6 @@ using DifferentialEquations, PythonCall
 end
 
 @testset "promotion" begin
-    _u0 = pyeval("""de.SciMLBase.prepare_initial_state([1.0, 0, 0])""", @__MODULE__)
+    _u0 = pyconvert(Any, pyeval("""de.SciMLBase.prepare_initial_state([1.0, 0, 0])""", @__MODULE__))
     @test _u0 isa Vector{Float64}
 end

--- a/test/python/pythoncall.jl
+++ b/test/python/pythoncall.jl
@@ -77,3 +77,8 @@ using DifferentialEquations, PythonCall
     sol = de.solve(prob,reltol=1e-3,abstol=1e-3)
     """, @__MODULE__)
 end
+
+@testset "promotion" begin
+    _u0 = pyeval("""de.prepare_initial_state([1.0, 0, 0])""", @__MODULE__)
+    @test _u0 isa Vector{Float64}
+end

--- a/test/python/pythoncall.jl
+++ b/test/python/pythoncall.jl
@@ -79,6 +79,6 @@ using DifferentialEquations, PythonCall
 end
 
 @testset "promotion" begin
-    _u0 = pyeval("""de.prepare_initial_state([1.0, 0, 0])""", @__MODULE__)
+    _u0 = pyeval("""de.SciMLBase.prepare_initial_state([1.0, 0, 0])""", @__MODULE__)
     @test _u0 isa Vector{Float64}
 end


### PR DESCRIPTION
Fixes the problem reported in https://github.com/SciML/diffeqpy/issues/111#issuecomment-1772859284