### PR TITLE
Fix docstring refrences optfun and optprob

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "2.11.1"
+version = "2.11.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -613,7 +613,7 @@ are the lower and upper bounds for `cons[i]`.
 
 The `f` in the `OptimizationProblem` should typically be an instance of [`OptimizationFunction`](@ref)
 to specify the objective function and its derivatives either by passing 
-predefined functions for them or automatically generated using the [`ADType`](@ref). 
+predefined functions for them or automatically generated using the [ADType](https://github.com/SciML/ADTypes.jl). 
 
 If `f` is a standard Julia function, it is automatically transformed into an
 `OptimizationFunction` with `NoAD()`, meaning the derivative functions are not
@@ -639,7 +639,7 @@ Any extra keyword arguments are captured to be sent to the optimizers.
 
 ## Inequality and Equality Constraints
 
-Both inequality and equality constraints are defined by the `f.cons` function in the [`OptimizationFunction`](@ref)
+Both inequality and equality constraints are defined by the `f.cons` function in the [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
 description of the problem structure. This `f.cons` is given as a function `f.cons(u,p)` which computes
 the value of the constraints at `u`. For example, take `f.cons(u,p) = u[1] - u[2]`.
 With these definitions, `lcons` and `ucons` define the bounds on the constraint that the solvers try to satisfy.

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1988,8 +1988,8 @@ the objective, even if no such parameters are used in the objective it should be
 any additional arguments that are relevant to the objective function, for example minibatches used in machine learning,
 take a look at the minibatching tutorial [here](https://docs.sciml.ai/Optimization/stable/tutorials/minibatch/). This should return
 a scalar, the loss value, as the first return output and if any additional outputs are returned, they will be passed to the `callback`
-function described in [Callback Functions](@ref).
-- `adtype`: see the section [Defining Optimization Functions via AD](@ref)
+function described in [Callback Functions](https://docs.sciml.ai/Optimization/stable/API/solve/#Common-Solver-Options-(Solve-Keyword-Arguments)).
+- `adtype`: see the Defining Optimization Functions via AD section below.
 
 ## Keyword Arguments
 
@@ -2034,7 +2034,7 @@ function described in [Callback Functions](@ref).
 - `cons_hess_colorvec`: an array of color vector according to the SparseDiffTools.jl definition for
   the sparsity pattern of the `cons_hess_prototype`.
 
-When [Symbolic Problem Building with ModelingToolkit](@ref) interface is used the following arguments are also relevant:
+When [Symbolic Problem Building with ModelingToolkit](https://docs.sciml.ai/Optimization/stable/tutorials/symbolic/) interface is used the following arguments are also relevant:
 
 - `syms`: the symbol names for the elements of the equation. This should match `u0` in size. For
   example, if `u = [0.0,1.0]` and `syms = [:x, :y]`, this will apply a canonical naming to the


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
