### PR TITLE
Add a nlls trait to BVProblem

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -180,7 +180,7 @@ $(TYPEDEF)
 
 Base for types which define BVP problems.
 """
-abstract type AbstractBVProblem{uType, tType, isinplace} <:
+abstract type AbstractBVProblem{uType, tType, isinplace, nlls} <:
               AbstractODEProblem{uType, tType, isinplace} end
 
 """

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -176,6 +176,16 @@ struct BVProblem{uType, tType, isinplace, nlls, P, F, PT, K} <:
     end
 end
 
+"""
+    isnonlinearleastsquares(prob::BVProblem)
+
+Returns `true` if the underlying problem is a nonlinear least squares problem.
+"""
+@inline function isnonlinearleastsquares(::BVProblem{uType,
+        tType, iip, nlls}) where {uType, tType, iip, nlls}
+    return nlls
+end
+
 struct FakeSolutionObject{U}
     u::U
 end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -159,7 +159,7 @@ struct BVProblem{uType, tType, isinplace, nlls, P, F, PT, K} <:
                     if iip
                         _nlls = false # Should we assume `true` instead?
                     else
-                        _nlls = length(f.bc(FFakeSolutionObject(u0), p, tspan)) != length(_u0)
+                        _nlls = length(f.bc(FakeSolutionObject(u0), p, tspan)) != length(_u0)
                     end
                 end
             end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -181,6 +181,9 @@ struct FakeSolutionObject{U}
 end
 
 (sol::FakeSolutionObject)(t) = sol.u
+Base.length(::FakeSolutionObject) = 1
+Base.firstindex(::FakeSolutionObject) = 1
+Base.lastindex(::FakeSolutionObject) = 1
 Base.getindex(sol::FakeSolutionObject, i::Int) = sol.u
 
 TruncatedStacktraces.@truncate_stacktrace BVProblem 3 1 2

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -45,7 +45,8 @@ function isrecompile(prob::ODEProblem{iip}) where {iip}
     (prob.f isa ODEFunction) ? !isfunctionwrapper(prob.f.f) : true
 end
 
-function remake(prob::AbstractSciMLProblem; u0 = missing, p = missing, interpret_symbolicmap = true, kwargs...)
+function remake(prob::AbstractSciMLProblem; u0 = missing,
+        p = missing, interpret_symbolicmap = true, kwargs...)
     u0, p = updated_u0_p(prob, u0, p; interpret_symbolicmap)
     _remake_internal(prob; kwargs..., u0, p)
 end
@@ -54,7 +55,8 @@ function remake(prob::AbstractNoiseProblem; kwargs...)
     _remake_internal(prob; kwargs...)
 end
 
-function remake(prob::AbstractIntegralProblem; p = missing, interpret_symbolicmap = true, kwargs...)
+function remake(
+        prob::AbstractIntegralProblem; p = missing, interpret_symbolicmap = true, kwargs...)
     p = updated_p(prob, p; interpret_symbolicmap)
     _remake_internal(prob; kwargs..., p)
 end
@@ -129,8 +131,8 @@ end
 Remake the given `BVProblem`.
 """
 function remake(prob::BVProblem{uType, tType, iip, nlls}; f = missing, bc = missing,
-    u0 = missing, tspan = missing, p = missing, kwargs = missing, problem_type = missing,
-    _kwargs...) where {uType, tType, iip, nlls}
+        u0 = missing, tspan = missing, p = missing, kwargs = missing, problem_type = missing,
+        interpret_symbolicmap = true, _kwargs...) where {uType, tType, iip, nlls}
     if tspan === missing
         tspan = prob.tspan
     end
@@ -169,10 +171,11 @@ function remake(prob::BVProblem{uType, tType, iip, nlls}; f = missing, bc = miss
     end
 
     if kwargs === missing
-        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, nlls=Val(nlls), prob.kwargs...,
+        BVProblem{iip}(
+            _f, bc, u0, tspan, p; problem_type, nlls = Val(nlls), prob.kwargs...,
             _kwargs...)
     else
-        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, nlls=Val(nlls), kwargs...)
+        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, nlls = Val(nlls), kwargs...)
     end
 end
 
@@ -254,7 +257,6 @@ function remake(prob::OptimizationProblem;
         kwargs = missing,
         interpret_symbolicmap = true,
         _kwargs...)
-
     u0, p = updated_u0_p(prob, u0, p; interpret_symbolicmap)
     if f === missing
         f = prob.f
@@ -393,10 +395,11 @@ function updated_p(prob, p; interpret_symbolicmap = true)
     end
     if eltype(p) <: Pair
         if interpret_symbolicmap
-            has_sys(prob.f) || throw(ArgumentError("This problem does not support symbolic maps with " *
-                                "`remake`, i.e. it does not have a symbolic origin. Please use `remake`" *
-                                "with the `p` keyword argument as a vector of values (paying attention to" *
-                                "parameter order) or pass `interpret_symbolicmap = false` as a keyword argument"))
+            has_sys(prob.f) ||
+                throw(ArgumentError("This problem does not support symbolic maps with " *
+                                    "`remake`, i.e. it does not have a symbolic origin. Please use `remake`" *
+                                    "with the `p` keyword argument as a vector of values (paying attention to" *
+                                    "parameter order) or pass `interpret_symbolicmap = false` as a keyword argument"))
         else
             return p
         end

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -128,15 +128,14 @@ end
 
 Remake the given `BVProblem`.
 """
-function remake(prob::BVProblem; f = missing, bc = missing, u0 = missing, tspan = missing,
-        p = missing, kwargs = missing, problem_type = missing, interpret_symbolicmap = true, _kwargs...)
+function remake(prob::BVProblem{uType, tType, iip, nlls}; f = missing, bc = missing,
+    u0 = missing, tspan = missing, p = missing, kwargs = missing, problem_type = missing,
+    _kwargs...) where {uType, tType, iip, nlls}
     if tspan === missing
         tspan = prob.tspan
     end
 
     u0, p = updated_u0_p(prob, u0, p; interpret_symbolicmap)
-
-    iip = isinplace(prob)
 
     if problem_type === missing
         problem_type = prob.problem_type
@@ -170,9 +169,10 @@ function remake(prob::BVProblem; f = missing, bc = missing, u0 = missing, tspan 
     end
 
     if kwargs === missing
-        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, prob.kwargs..., _kwargs...)
+        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, nlls=Val(nlls), prob.kwargs...,
+            _kwargs...)
     else
-        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, kwargs...)
+        BVProblem{iip}(_f, bc, u0, tspan, p; problem_type, nlls=Val(nlls), kwargs...)
     end
 end
 

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1929,13 +1929,20 @@ $(TYPEDEF)
 A representation of a BVP function `f`, defined by:
 
 ```math
-\frac{du}{dt}=f(u,p,t)
+\frac{du}{dt} = f(u, p, t)
 ```
 
 and the constraints:
 
 ```math
-\frac{du}{dt}=g(u,p,t)
+g(u, p, t) = 0
+```
+
+If the size of `g(u, p, t)` is different from the size of `u`, then the constraints are
+interpreted as a least squares problem, i.e. the objective function is:
+
+```math
+\min_{u} \| g_i(u, p, t) \|^2
 ```
 
 and all of its related functions, such as the Jacobian of `f`, its gradient
@@ -1943,21 +1950,25 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 `p` are the parameters, and `t` is the independent variable.
 
 ```julia
-BVPFunction{iip,specialize}(f, bc;
-                           mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           bcjac = __has_jac(bc) ? bc.jac : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           bcjac_prototype = __has_jac_prototype(bc) ? bc.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           bccolorvec = __has_colorvec(f) ? bc.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+BVPFunction{iip, specialize}(f, bc;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    bcjac = __has_jac(bc) ? bc.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    bcjac_prototype = __has_jac_prototype(bc) ? bc.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    syms = nothing,
+    indepsym= nothing,
+    paramsyms = nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    bccolorvec = __has_colorvec(f) ? bc.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing,
+    twopoint::Union{Val, Bool} = Val(false)
 ```
 
 Note that both the function `f` and boundary condition `bc` are required. `f` should
@@ -1985,7 +1996,7 @@ the usage of `f` and `bc`. These include:
   sparsity patterns should use a `SparseMatrixCSC` with a correct sparsity pattern for the Jacobian.
   The default is `nothing`, which means a dense Jacobian.
 - `bcjac_prototype`: a prototype matrix matching the type that matches the Jacobian. For example,
- if the Jacobian is tridiagonal, then an appropriately sized `Tridiagonal` matrix can be used
+  if the Jacobian is tridiagonal, then an appropriately sized `Tridiagonal` matrix can be used
   as the prototype and integrators will specialize on this structure where possible. Non-structured
   sparsity patterns should use a `SparseMatrixCSC` with a correct sparsity pattern for the Jacobian.
   The default is `nothing`, which means a dense Jacobian.
@@ -2003,6 +2014,11 @@ the usage of `f` and `bc`. These include:
   internally computed on demand when required. The cost of this operation is highly dependent
   on the sparsity pattern.
 
+Additional Options:
+
+- `twopoint`: Specify that the BVP is a two-point boundary value problem. Use `Val(true)` or
+  `Val(false)` for type stability.
+
 ## iip: In-Place vs Out-Of-Place
 
 For more details on this argument, see the ODEFunction documentation.
@@ -2016,8 +2032,8 @@ For more details on this argument, see the ODEFunction documentation.
 The fields of the BVPFunction type directly match the names of the inputs.
 """
 struct BVPFunction{iip, specialize, twopoint, F, BF, TMM, Ta, Tt, TJ, BCTJ, JVP, VJP,
-    JP, BCJP, BCRP, SP, TW, TWt, TPJ, O, TCV, BCTCV,
-    SYS} <: AbstractBVPFunction{iip, twopoint}
+        JP, BCJP, BCRP, SP, TW, TWt, TPJ, O, TCV, BCTCV,
+        SYS} <: AbstractBVPFunction{iip, twopoint}
     f::F
     bc::BF
     mass_matrix::TMM
@@ -2321,7 +2337,11 @@ function ODEFunction{iip, specialize}(f;
             typeof(initializeprobmap)}(_f, mass_matrix, analytic, tgrad, jac,
             jvp, vjp, jac_prototype, sparsity, Wfact,
             Wfact_t, W_prototype, paramjac,
+<<<<<<< HEAD
             observed, _colorvec, sys, initializeprob, initializeprobmap)
+=======
+            observed, _colorvec, sys)
+>>>>>>> 65d8f530 (Add a nlls trait to BVProblem)
     else
         ODEFunction{iip, specialize,
             typeof(_f), typeof(mass_matrix), typeof(analytic), typeof(tgrad),
@@ -2334,7 +2354,11 @@ function ODEFunction{iip, specialize}(f;
             typeof(initializeprobmap)}(_f, mass_matrix, analytic, tgrad, jac,
             jvp, vjp, jac_prototype, sparsity, Wfact,
             Wfact_t, W_prototype, paramjac,
+<<<<<<< HEAD
             observed, _colorvec, sys, initializeprob, initializeprobmap)
+=======
+            observed, _colorvec, sys)
+>>>>>>> 65d8f530 (Add a nlls trait to BVProblem)
     end
 end
 
@@ -3801,7 +3825,7 @@ function BVPFunction{iip, specialize, twopoint}(f, bc;
 
     _f = prepare_function(f)
 
-    sys = sys_or_symbolcache(sys, syms, paramsyms, indepsym)
+    sys = something(sys, SymbolCache(syms, paramsyms, indepsym))
 
     if specialize === NoSpecialize
         BVPFunction{iip, specialize, twopoint, Any, Any, Any, Any, Any,
@@ -3813,9 +3837,9 @@ function BVPFunction{iip, specialize, twopoint}(f, bc;
             sparsity, Wfact, Wfact_t, paramjac, observed,
             _colorvec, _bccolorvec, sys)
     else
-        BVPFunction{iip, specialize, twopoint, typeof(_f), typeof(bc), typeof(mass_matrix),
-            typeof(analytic), typeof(tgrad), typeof(jac), typeof(bcjac), typeof(jvp),
-            typeof(vjp), typeof(jac_prototype),
+        BVPFunction{iip, specialize, twopoint, typeof(_f), typeof(bc),
+            typeof(mass_matrix), typeof(analytic), typeof(tgrad), typeof(jac),
+            typeof(bcjac), typeof(jvp), typeof(vjp), typeof(jac_prototype),
             typeof(bcjac_prototype), typeof(bcresid_prototype), typeof(sparsity),
             typeof(Wfact), typeof(Wfact_t), typeof(paramjac), typeof(observed),
             typeof(_colorvec), typeof(_bccolorvec), typeof(sys)}(

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2032,8 +2032,8 @@ For more details on this argument, see the ODEFunction documentation.
 The fields of the BVPFunction type directly match the names of the inputs.
 """
 struct BVPFunction{iip, specialize, twopoint, F, BF, TMM, Ta, Tt, TJ, BCTJ, JVP, VJP,
-        JP, BCJP, BCRP, SP, TW, TWt, TPJ, O, TCV, BCTCV,
-        SYS} <: AbstractBVPFunction{iip, twopoint}
+    JP, BCJP, BCRP, SP, TW, TWt, TPJ, O, TCV, BCTCV,
+    SYS} <: AbstractBVPFunction{iip, twopoint}
     f::F
     bc::BF
     mass_matrix::TMM
@@ -2337,11 +2337,7 @@ function ODEFunction{iip, specialize}(f;
             typeof(initializeprobmap)}(_f, mass_matrix, analytic, tgrad, jac,
             jvp, vjp, jac_prototype, sparsity, Wfact,
             Wfact_t, W_prototype, paramjac,
-<<<<<<< HEAD
             observed, _colorvec, sys, initializeprob, initializeprobmap)
-=======
-            observed, _colorvec, sys)
->>>>>>> 65d8f530 (Add a nlls trait to BVProblem)
     else
         ODEFunction{iip, specialize,
             typeof(_f), typeof(mass_matrix), typeof(analytic), typeof(tgrad),
@@ -2354,11 +2350,7 @@ function ODEFunction{iip, specialize}(f;
             typeof(initializeprobmap)}(_f, mass_matrix, analytic, tgrad, jac,
             jvp, vjp, jac_prototype, sparsity, Wfact,
             Wfact_t, W_prototype, paramjac,
-<<<<<<< HEAD
             observed, _colorvec, sys, initializeprob, initializeprobmap)
-=======
-            observed, _colorvec, sys)
->>>>>>> 65d8f530 (Add a nlls trait to BVProblem)
     end
 end
 
@@ -3921,7 +3913,9 @@ end
 function sys_or_symbolcache(sys, syms, paramsyms, indepsym = nothing)
     if sys === nothing &&
        (syms !== nothing || paramsyms !== nothing || indepsym !== nothing)
-        Base.depwarn("The use of keyword arguments `syms`, `paramsyms` and `indepsym` for `SciMLFunction`s is deprecated. Pass `sys = SymbolCache(syms, paramsyms, indepsym)` instead.", :syms)
+        Base.depwarn(
+            "The use of keyword arguments `syms`, `paramsyms` and `indepsym` for `SciMLFunction`s is deprecated. Pass `sys = SymbolCache(syms, paramsyms, indepsym)` instead.",
+            :syms)
         sys = SymbolCache(syms, paramsyms, indepsym)
     end
     return sys

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -137,8 +137,8 @@ end
 
 # FIXME: Remove the defaults for resid and original on a breaking release
 function ODESolution{T, N}(u, u_analytic, errors, t, k, prob, alg, interp, dense,
-    tslocation, stats, alg_choice, retcode, resid = nothing,
-    original = nothing) where {T, N}
+        tslocation, stats, alg_choice, retcode, resid = nothing,
+        original = nothing) where {T, N}
     return ODESolution{T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
         typeof(k), typeof(prob), typeof(alg), typeof(interp),
         typeof(stats), typeof(alg_choice), typeof(resid),

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -242,6 +242,10 @@ function build_solution(prob::Union{AbstractODEProblem, AbstractDDEProblem},
 
     if prob.u0 === nothing
         N = 2
+    elseif prob isa BVProblem && !hasmethod(size, Tuple{typeof(prob.u0)})
+        __u0 = hasmethod(prob.u0, Tuple{typeof(prob.p), typeof(first(prob.tspan))}) ?
+               prob.u0(prob.p, first(prob.tspan)) : prob.u0(first(prob.tspan))
+        N = length((size(__u0)..., length(u)))
     else
         N = length((size(prob.u0)..., length(u)))
     end

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -101,11 +101,11 @@ sprob3 = remake(sprob; u0 = [x => 3.0], p = [σ => 30.0]) # partial update
 
 # NonlinearProblem
 @named ns = NonlinearSystem(
-    [0 ~ σ*(y-x),
-    0 ~ x*(ρ-z)-y,
-    0 ~ x*y - β*z],
-    [x,y,z],
-    [σ,ρ,β]
+    [0 ~ σ * (y - x),
+        0 ~ x * (ρ - z) - y,
+        0 ~ x * y - β * z],
+    [x, y, z],
+    [σ, ρ, β]
 )
 ns = complete(ns)
 nlprob = NonlinearProblem(ns, u0, p)
@@ -131,14 +131,14 @@ nlprob3 = remake(nlprob; u0 = [x => 3.0], p = [σ => 30.0]) # partial update
 
 @parameters β γ
 @variables S(t) I(t) R(t)
-rate₁   = β*S*I
+rate₁ = β * S * I
 affect₁ = [S ~ S - 1, I ~ I + 1]
-rate₂   = γ*I
+rate₂ = γ * I
 affect₂ = [I ~ I - 1, R ~ R + 1]
-j₁      = ConstantRateJump(rate₁,affect₁)
-j₂      = ConstantRateJump(rate₂,affect₂)
-j₃      = MassActionJump(2*β+γ, [R => 1], [S => 1, R => -1])
-@named js      = JumpSystem([j₁,j₂,j₃], t, [S,I,R], [β,γ])
+j₁ = ConstantRateJump(rate₁, affect₁)
+j₂ = ConstantRateJump(rate₂, affect₂)
+j₃ = MassActionJump(2 * β + γ, [R => 1], [S => 1, R => -1])
+@named js = JumpSystem([j₁, j₂, j₃], t, [S, I, R], [β, γ])
 js = complete(js)
 u₀map = [S => 999, I => 1, R => 0.0]
 parammap = [β => 0.1 / 1000, γ => 0.01]

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -2,14 +2,14 @@ using SciMLBase
 using SymbolicIndexingInterface
 
 # ODE
-function lorenz!(du,u,p,t)
- du[1] = p[1] * (u[2]-u[1])
- du[2] = u[1]*(p[2]-u[3]) - u[2]
- du[3] = u[1]*u[2] - p[3]*u[3]
+function lorenz!(du, u, p, t)
+    du[1] = p[1] * (u[2] - u[1])
+    du[2] = u[1] * (p[2] - u[3]) - u[2]
+    du[3] = u[1] * u[2] - p[3] * u[3]
 end
-u0 = [1.0;0.0;0.0]
-tspan = (0.0,100.0)
-p = [10.0, 28.0, 8/3]
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 100.0)
+p = [10.0, 28.0, 8 / 3]
 fn = ODEFunction(lorenz!; sys = SymbolCache([:x, :y, :z], [:a, :b, :c], :t))
 prob = ODEProblem(fn, u0, tspan, p)
 
@@ -21,7 +21,7 @@ prob = ODEProblem(fn, u0, tspan, p)
 @test remake(prob; p = [:a => 11.0, :c => 13.0, :b => 12.0]).p == [11.0, 12.0, 13.0]
 @test remake(prob; p = (11.0, 12.0, 13)).p == (11.0, 12.0, 13)
 @test remake(prob; u0 = [:x => 2.0]).u0 == [2.0, 0.0, 0.0]
-@test remake(prob; p = [:b => 11.0]).p == [10.0, 11.0, 8/3]
+@test remake(prob; p = [:b => 11.0]).p == [10.0, 11.0, 8 / 3]
 
 # BVP
 g = 9.81
@@ -39,7 +39,7 @@ function bc1!(residual, u, p, t)
 end
 u0 = [pi / 2, pi / 2]
 p = [g, L]
-fn = BVPFunction(simplependulum!, bc1!; sys = SymbolCache([:x, :y], [:a, :b], :t) )
+fn = BVPFunction(simplependulum!, bc1!; sys = SymbolCache([:x, :y], [:a, :b], :t))
 prob = BVProblem(fn, u0, tspan, p)
 
 @test remake(prob).u0 == u0
@@ -80,11 +80,11 @@ prob = SDEProblem(fn, u0, tspan, p)
 
 # OptimizationProblem
 function loss(u, p)
-    return (p[1] - u[1]) ^ 2 + p[2] * (u[2] - u[1] ^ 2) ^ 2
+    return (p[1] - u[1])^2 + p[2] * (u[2] - u[1]^2)^2
 end
 u0 = [1.0, 2.0]
 p = [1.0, 100.0]
-fn = OptimizationFunction(loss; sys = SymbolCache([:x, :y], [:a, :b], :t) )
+fn = OptimizationFunction(loss; sys = SymbolCache([:x, :y], [:a, :b], :t))
 prob = OptimizationProblem(fn, u0, p)
 @test remake(prob).u0 == u0
 @test remake(prob).p == p
@@ -128,4 +128,3 @@ prob = NonlinearLeastSquaresProblem(fn, u0, p)
 @test remake(prob; p = (11.0, 12.0, 13)).p == (11.0, 12.0, 13)
 @test remake(prob; u0 = [:x => 2.0]).u0 == [2.0, 0.0, 0.0]
 @test remake(prob; p = [:b => 11.0]).p == [10.0, 11.0, 26.0]
-

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -10,7 +10,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 @test !SciMLBase.Tables.isrowtable(SciMLBase.QuadratureSolution)
 @test !SciMLBase.Tables.isrowtable(SciMLBase.OptimizationSolution)
 
-@variables x(t)=1
+@variables x(t) = 1
 eqs = [D(x) ~ -x]
 @named sys = ODESystem(eqs, t)
 sys = complete(sys)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The main compilation cost for BVDiffEq is coming from solving NLLS problems. Having this allows us to have a type stable path for NLLS BVPs.
