### PR TITLE
Deprecate separate lb, ub arguments to IntegralProblem

### DIFF
--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -426,8 +426,8 @@ IntegralProblem(f,lb,ub,p=NullParameters(); nout=nothing, batch=nothing, kwargs.
 - f: the integrand, callable function `y = f(u,p)` for out-of-place (default) or an
   `IntegralFunction` or `BatchIntegralFunction` for inplace and batching optimizations.
 - domain: an object representing an integration domain, i.e. the tuple `(lb, ub)`.
-- lb: Either a number or vector of lower bounds.
-- ub: Either a number or vector of upper bounds.
+- lb: DEPRECATED: Either a number or vector of lower bounds.
+- ub: DEPRECATED: Either a number or vector of upper bounds.
 - p: The parameters associated with the problem.
 - nout: DEPRECATED (see `IntegralFunction`): length of the vector output of the integrand
   (by default the integrand is assumed to be scalar)
@@ -465,13 +465,10 @@ function IntegralProblem(f::AbstractIntegralFunction,
     IntegralProblem{isinplace(f)}(f, domain, p; kwargs...)
 end
 
-function IntegralProblem(f::AbstractIntegralFunction,
-    lb::B,
-    ub::B,
-    p = NullParameters();
-    kwargs...) where {B}
-    IntegralProblem{isinplace(f)}(f, (lb, ub), p; kwargs...)
-end
+@deprecate IntegralProblem(f::AbstractIntegralFunction,
+    lb::Union{Number,AbstractVector{<:Number}},
+    ub::Union{Number,AbstractVector{<:Number}},
+    p = NullParameters(); kwargs...) IntegralProblem(f, promote(lb, ub), p; kwargs...)
 
 function IntegralProblem(f, args...; nout = nothing, batch = nothing, kwargs...)
     if nout !== nothing || batch !== nothing
@@ -615,8 +612,8 @@ They should be an `AbstractArray` matching the geometry of `u`, where `(lcons[i]
 are the lower and upper bounds for `cons[i]`.
 
 The `f` in the `OptimizationProblem` should typically be an instance of [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
-to specify the objective function and its derivatives either by passing 
-predefined functions for them or automatically generated using the [ADType](https://github.com/SciML/ADTypes.jl). 
+to specify the objective function and its derivatives either by passing
+predefined functions for them or automatically generated using the [ADType](https://github.com/SciML/ADTypes.jl).
 
 If `f` is a standard Julia function, it is automatically transformed into an
 `OptimizationFunction` with `NoAD()`, meaning the derivative functions are not

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -468,7 +468,7 @@ end
 @deprecate IntegralProblem(f::AbstractIntegralFunction,
     lb::Union{Number,AbstractVector{<:Number}},
     ub::Union{Number,AbstractVector{<:Number}},
-    p = NullParameters(); kwargs...) IntegralProblem(f, promote(lb, ub), p; kwargs...)
+    p = NullParameters(); kwargs...) IntegralProblem(f, (lb, ub), p; kwargs...)
 
 function IntegralProblem(f, args...; nout = nothing, batch = nothing, kwargs...)
     if nout !== nothing || batch !== nothing

--- a/test/performance_warnings.jl
+++ b/test/performance_warnings.jl
@@ -34,7 +34,7 @@ p = [1, "2"]
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) LinearProblem(f_4, x, p)
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) IntervalNonlinearProblem(f_2, tspan, p)
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) NonlinearProblem(f_3, x, p)
-@test_logs (:warn, WARN_PARAMTYPE_MESSAGE) IntegralProblem(f_3, x, x, p)
+@test_logs (:warn, WARN_PARAMTYPE_MESSAGE) IntegralProblem(f_3, (x, x), p)
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) OptimizationProblem(f_2, x, p)
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) BVProblem(f_4, f_4, x, tspan, p)
 @test_logs (:warn, WARN_PARAMTYPE_MESSAGE) DAEProblem(f_4, x, x, tspan, p)


### PR DESCRIPTION
Fixes https://github.com/SciML/Integrals.jl/issues/198
Fixes https://github.com/SciML/Integrals.jl/issues/208

Specifically, this pr deprecates the following method:
```julia
@deprecate IntegralProblem(f::AbstractIntegralFunction,
    lb::Union{Number,AbstractVector{<:Number}},
    ub::Union{Number,AbstractVector{<:Number}},
    p = NullParameters(); kwargs...) IntegralProblem(f, (lb, ub), p; kwargs...)
```

@ChrisRackauckas this pr could also be a good time to decide on the promotion behavior for the endpoints of the integration domain. I actually think promotion should be handled at solve time since it could interfere with AD, e.g. using ForwardDiff and differentiating just the upper limit of integration.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
