### PR TITLE
update ensemble indexing in the plot recipe

### DIFF
--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -28,7 +28,7 @@ timestep_mean(sim, ::Colon) = timeseries_steps_mean(sim)
 function timestep_median(sim, i)
     arr = componentwise_vectors_timestep(sim, i)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([median(x) for x in arr], size(sim.u[1][i])...)
+        return reshape([median(x) for x in arr], size(sim.u[1].u[i])...)
     else
         return median(arr)
     end
@@ -37,7 +37,7 @@ timestep_median(sim, ::Colon) = timeseries_steps_median(sim)
 function timestep_quantile(sim, q, i)
     arr = componentwise_vectors_timestep(sim, i)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([quantile(x, q) for x in arr], size(sim.u[1][i])...)
+        return reshape([quantile(x, q) for x in arr], size(sim.u[1].u[i])...)
     else
         return quantile(arr, q)
     end
@@ -97,7 +97,7 @@ timepoint_mean(sim, t) = componentwise_mean(get_timepoint(sim, t))
 function timepoint_median(sim, t)
     arr = componentwise_vectors_timepoint(sim, t)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([median(x) for x in arr], size(sim.u[1][1])...)
+        return reshape([median(x) for x in arr], size(sim.u[1].u[1])...)
     else
         return median(arr)
     end
@@ -105,7 +105,7 @@ end
 function timepoint_quantile(sim, q, t)
     arr = componentwise_vectors_timepoint(sim, t)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([quantile(x, q) for x in arr], size(sim.u[1][1])...)
+        return reshape([quantile(x, q) for x in arr], size(sim.u[1].u[1])...)
     else
         return quantile(arr, q)
     end
@@ -122,7 +122,7 @@ function timepoint_weighted_meancov(sim, W, t1, t2)
 end
 
 function SciMLBase.EnsembleSummary(sim::SciMLBase.AbstractEnsembleSolution{T, N},
-    t = sim.u[1].t; quantiles = [0.05, 0.95]) where {T, N}
+        t = sim.u[1].t; quantiles = [0.05, 0.95]) where {T, N}
     if sim.u[1] isa SciMLSolution
         m, v = timeseries_point_meanvar(sim, t)
         med = timeseries_point_median(sim, t)

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -143,14 +143,14 @@ end
               nothing,
     trajectories = eachindex(sim))
     for i in trajectories
-        size(sim[i].u, 1) == 0 && continue
+        size(sim.u[i].u, 1) == 0 && continue
         @series begin
             legend := false
             xlims --> (-Inf, Inf)
             ylims --> (-Inf, Inf)
             zlims --> (-Inf, Inf)
             marker_z --> zcolors[i]
-            sim[i]
+            sim.u[i]
         end
     end
 end
@@ -170,12 +170,12 @@ end
                                                       1.96 for i in 1:length(sim.v)]))
             ci_high = ci_low
         else
-            ci_low = [[sqrt(sim.v[i] / length(sim.num_monte)) .* 1.96
+            ci_low = [[sqrt(sim.v.u[i] / length(sim.num_monte)) .* 1.96
                        for i in 1:length(sim.v)]]
             ci_high = ci_low
         end
     elseif ci_type == :quantile
-        if sim.med[1] isa AbstractArray
+        if sim.med.u[1] isa AbstractArray
             u = vecarr_to_vectors(sim.med)
         else
             u = [sim.med.u]


### PR DESCRIPTION
The pot recipes for ensemble still use linear indexing in some places. I've updated the places where I saw warnings from, but I'm not sure if I haven't missed something.