### PR TITLE
[WIP] Fix Ensemble indexing when `output_func` is used

### DIFF
--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -3,7 +3,11 @@ module EnsembleAnalysis
 using SciMLBase, Statistics, RecursiveArrayTools, StaticArraysCore
 
 # Getters
-get_timestep(sim, i) = (sol.u[i] for sol in sim)
+function get_timestep(sim::EnsembleSolution{T, N, S},
+        i) where {T, N, S <: AbstractVectorOfArray}
+    (sol.u[i] for sol in sim)
+end
+get_timestep(sim, i) = (sol[i] for sol in sim)
 get_timepoint(sim, t) = (sol(t) for sol in sim)
 function componentwise_vectors_timestep(sim, i)
     arr = [get_timestep(sim, i)...]

--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -32,7 +32,7 @@ timestep_mean(sim, ::Colon) = timeseries_steps_mean(sim)
 function timestep_median(sim, i)
     arr = componentwise_vectors_timestep(sim, i)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([median(x) for x in arr], size(sim.u[1].u[i])...)
+        return reshape([median(x) for x in arr], size(sim[1, i])...)
     else
         return median(arr)
     end
@@ -41,7 +41,7 @@ timestep_median(sim, ::Colon) = timeseries_steps_median(sim)
 function timestep_quantile(sim, q, i)
     arr = componentwise_vectors_timestep(sim, i)
     if typeof(first(arr)) <: AbstractArray
-        return reshape([quantile(x, q) for x in arr], size(sim.u[1].u[i])...)
+        return reshape([quantile(x, q) for x in arr], size(sim[1, i])...)
     else
         return quantile(arr, q)
     end


### PR DESCRIPTION
When `output_func` is used, the resulting type in `sim.u[i]` is no longer <: `AbstractVectorOfArray`, so we  need to avoid assuming that like in #599, #602 and #604

I was thinking of the following output functions as tests:

```julia
function output_func(sol, i)
    (x=sol[1, :], t=sol.t), false
end

function output_func(sol, i)
    last(sol), false
end

function output_func(sol, i)
    [first(sol), last(sol)], false
end
```

For the plot recipes I was thinking that we could test if no warnings are thrown by the `plot` calls. That should catch depwarns too and if there's any error in the recipes, the test would error.

This PR is WIP and not yet ready.