### PR TITLE
[RFC] Better integral docs

### DIFF
--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -448,7 +448,7 @@ struct IntegralProblem{isinplace, P, F, T, K} <: AbstractIntegralProblem{isinpla
     p::P
     kwargs::K
     @add_kwonly function IntegralProblem{iip}(f::AbstractIntegralFunction{iip}, domain,
-        p = NullParameters();
+        p = NullParameters(); nout = nothing, batch = nothing,
         kwargs...) where {iip}
         warn_paramtype(p)
         new{iip, typeof(p), typeof(f), typeof(domain), typeof(kwargs)}(f,
@@ -470,12 +470,13 @@ end
     ub::Union{Number,AbstractVector{<:Number}},
     p = NullParameters(); kwargs...) IntegralProblem(f, (lb, ub), p; kwargs...)
 
-function IntegralProblem(f, args...; nout = nothing, batch = nothing, kwargs...)
+IntegralProblem(f, args...; kwargs...) = IntegralProblem{isinplace(f, 3)}(f, args...; kwargs...)
+function IntegralProblem{iip}(f, args...; nout = nothing, batch = nothing, kwargs...) where {iip}
     if nout !== nothing || batch !== nothing
        @warn "`nout` and `batch` keywords are deprecated in favor of inplace `IntegralFunction`s or `BatchIntegralFunction`s. See the updated Integrals.jl documentation for details."
     end
 
-    g = if isinplace(f, 3)
+    g = if iip
         if batch === nothing
             output_prototype = nout === nothing ? Array{Float64, 0}(undef) : Vector{Float64}(undef, nout)
             IntegralFunction(f, output_prototype)

--- a/src/problems/basic_problems.jl
+++ b/src/problems/basic_problems.jl
@@ -465,10 +465,10 @@ function IntegralProblem(f::AbstractIntegralFunction,
     IntegralProblem{isinplace(f)}(f, domain, p; kwargs...)
 end
 
-@deprecate IntegralProblem(f::AbstractIntegralFunction,
+@deprecate IntegralProblem{iip}(f::AbstractIntegralFunction,
     lb::Union{Number,AbstractVector{<:Number}},
     ub::Union{Number,AbstractVector{<:Number}},
-    p = NullParameters(); kwargs...) IntegralProblem(f, (lb, ub), p; kwargs...)
+    p = NullParameters(); kwargs...) where {iip} IntegralProblem{iip}(f, (lb, ub), p; kwargs...)
 
 IntegralProblem(f, args...; kwargs...) = IntegralProblem{isinplace(f, 3)}(f, args...; kwargs...)
 function IntegralProblem{iip}(f, args...; nout = nothing, batch = nothing, kwargs...) where {iip}

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -461,15 +461,27 @@ NonlinearFunction(nfiip, vjp = nvjp)
 NonlinearFunction(nfoop, vjp = nvjp)
 
 # Integrals
-intf(u) = 1.0
-@test_throws SciMLBase.TooFewArgumentsError IntegralProblem(intf, (0.0, 1.0))
+intfew(u) = 1.0
+@test_throws SciMLBase.TooFewArgumentsError IntegralProblem(intfew, (0.0, 1.0))
+@test_throws SciMLBase.TooFewArgumentsError IntegralFunction(intfew)
+@test_throws SciMLBase.TooFewArgumentsError IntegralFunction(intfew, zeros(3))
+@test_throws SciMLBase.TooFewArgumentsError BatchIntegralFunction(intfew)
+@test_throws SciMLBase.TooFewArgumentsError BatchIntegralFunction(intfew, zeros(3))
 intf(u, p) = 1.0
 p = 2.0
+intfiip(y, u, p) = y .= 1.0
 
-IntegralProblem(intf, (0.0, 1.0))
-IntegralProblem(intf, (0.0, 1.0), p)
-IntegralProblem(intf, ([0.0], [1.0]))
-IntegralProblem(intf, ([0.0], [1.0]), p)
+for (f, kws, iip) in (
+    (intf,                                  (;),        false),
+    (IntegralFunction(intf),                (;),        false),
+    (intfiip,                               (; nout=3), true),
+    (IntegralFunction(intfiip, zeros(3)),   (;),        true),
+), domain in (((0.0, 1.0),), (([0.0], [1.0]),), (0.0, 1.0), ([0.0], [1.0],))
+    IntegralProblem(f, domain...; kws...)
+    IntegralProblem(f, domain..., p; kws...)
+    IntegralProblem{iip}(f, domain...; kws...)
+    IntegralProblem{iip}(f, domain..., p; kws...)
+end
 
 x = [1.0, 2.0]
 y = rand(2, 2)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The updates to `IntegralProblem`s in SciML v2 lost the ability to set an in-place `IntegralProblem` for a non-`IntegralFunction`, observed here https://github.com/SciML/SciMLExpectations.jl/pull/148, and inadequate web documentation for the new interface, as in this issue https://github.com/SciML/Integrals.jl/issues/218 and a [discourse post](https://discourse.julialang.org/t/is-there-any-documentation-on-integralfunctions/108970/9). I want to address the following in this pr
- [x] Restore the method to set inplace `IntegralProblem`s for all integrands
- [ ] Publish the `IntegralFunction` and `BatchIntegralFunction` docstrings to the web documentation
- [x] Improve the clarity of the `IntegralFunction` and `BatchIntegralFunction` docstrings

I would appreciate comments on my writing and how we should publish the docstrings. I will also open a pr to Integrals.jl to update the readme and documentation with examples of the new interface.