### PR TITLE
Prepare `DAESolution` for interpolation

### DIFF
--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -56,7 +56,7 @@ end
 
 TruncatedStacktraces.@truncate_stacktrace DAESolution 1 2
 
-function build_solution(prob::AbstractDAEProblem, alg, t, u, du;
+function build_solution(prob::AbstractDAEProblem, alg, t, u, du = nothing;
     timeseries_errors = length(u) > 2,
     dense = false,
     dense_errors = dense,


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
This adds the `k` field to `DAESolution` which will allow for a future PR to OrdinaryDiffEq to make DAEs save their k's which is necessary to interpolate their solutions.