### PR TITLE
add optional `continuous_modification` argument to `reeval_internals_due_to_modification!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "2.25.0"
+version = "2.26.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -313,10 +313,16 @@ end
 addsteps!(i::DEIntegrator, args...) = nothing
 
 """
-    reeval_internals_due_to_modification!(integrator::DDEIntegrator)
+    reeval_internals_due_to_modification!(integrator::DEIntegrator, continuous_modification=true)
 
-Recalculate interpolation data and update ODE integrator after changes by callbacks.
+Update DE integrator after changes by callbacks.
+For DAEs (either implicit or semi-explicit), this requires re-solving alebraic variables.
+If continuous_modification is true (or unspecified), this should also recalculate interpolation data.
+Otherwise the integrator is allowed to skip recalculating the interpolation.
 """
+function reeval_internals_due_to_modification!(integrator::DEIntegrator, continuous_modification)
+    reeval_internals_due_to_modification!(integrator::DEIntegrator)
+end
 reeval_internals_due_to_modification!(integrator::DEIntegrator) = nothing
 
 """


### PR DESCRIPTION
When set to false allows the integrator to skip recalculating the interpolation data. This is a prereq to https://github.com/SciML/OrdinaryDiffEq.jl/pull/2141 being finished.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
