### PR TITLE
fix: fix `setindex!` not erroring appropriately for integrators

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -445,8 +445,6 @@ SymbolicIndexingInterface.parameter_values(A::DEIntegrator) = A.p
 SymbolicIndexingInterface.state_values(A::DEIntegrator) = A.u
 SymbolicIndexingInterface.current_time(A::DEIntegrator) = A.t
 function SymbolicIndexingInterface.set_state!(A::DEIntegrator, val, idx)
-    # So any error checking happens to ensure we actually _can_ set state
-    set_u!(A, A.u)
     A.u[idx] = val
     u_modified!(A, true)
 end
@@ -528,8 +526,7 @@ function Base.setindex!(A::DEIntegrator, val, sym)
         error("Invalid indexing of integrator: Integrator does not support indexing without a system")
     if symbolic_type(sym) == ScalarSymbolic()
         if is_variable(A, sym)
-            A.u[variable_index(A, sym)] = val
-            u_modified!(A, true)
+            set_state!(A, val, variable_index(A, sym))
         elseif is_parameter(A, sym)
             error("Parameter indexing is deprecated. Use `setp(sys, $sym)(integrator, $val)` to set parameter value.")
         else

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -367,3 +367,11 @@ setp(sys, p)(integrator, [4, 5, 6])
 @test getp(sys, p)(integrator) == integrator.ps[p] == [4, 5, 6]
 integrator.ps[p] = [7, 8, 9]
 @test getp(sys, p)(integrator) == integrator.ps[p] == [7, 8, 9]
+
+# Issue#653
+@parameters p
+@variables X(t)
+
+eq = D(X) ~ p - X
+@mtkbuild osys = ODESystem([eq], t)
+oprob = ODEProblem(osys, [X => 0.1], (0.0, 1.0), [p => 1.0])


### PR DESCRIPTION
Close #653 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
