### PR TITLE
fix: fix symbolic idxs interpolation for RODESolution

### DIFF
--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -63,7 +63,7 @@ end
 
 function (sol::RODESolution)(t, ::Type{deriv} = Val{0}; idxs = nothing,
         continuity = :left) where {deriv}
-    sol.interp(t, idxs, deriv, sol.prob.p, continuity)
+    sol(t, deriv, idxs, continuity)
 end
 function (sol::RODESolution)(v, t, ::Type{deriv} = Val{0}; idxs = nothing,
         continuity = :left) where {deriv}

--- a/test/downstream/solution_interface.jl
+++ b/test/downstream/solution_interface.jl
@@ -62,6 +62,7 @@ sol = solve(sprob, ImplicitEM())
 @test_throws Exception sol[a]
 @test_throws Exception sol[noisy_population_model.a]
 @test_throws Exception sol[:a]
+@test_nowarn sol(0.5, idxs = noisy_population_model.s1)
 ### Tests on layered model (some things should not work). ###
 
 @parameters σ ρ β


### PR DESCRIPTION
Close #580

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
