### PR TITLE
Add ADTypes 1.0 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ SciMLBaseRCallExt = "RCall"
 SciMLBaseZygoteExt = "Zygote"
 
 [compat]
-ADTypes = "0.2.5"
+ADTypes = "0.2.5,1.0.0"
 ArrayInterface = "7.6"
 ChainRules = "1.58.0"
 ChainRulesCore = "1.18"


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

[ADTypes.jl](https://github.com/SciML/ADTypes.jl) is about to release a breaking v1.0, so the task of updating downstream repos begins.
This is a test PR to see if there is anything to change here. From what I can tell, the only use of ADTypes.jl is through `AbstractADType`, which is still available, so we should be good.
