### PR TITLE
Add jvp and vjp fields to OptimizationFunction

### DIFF
--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -320,7 +320,8 @@ struct SecondOrderBVProblem{uType, tType, isinplace, nlls, P, F, PT, K} <:
     problem_type::PT
     kwargs::K
 
-    @add_kwonly function SecondOrderBVProblem{iip}(f::DynamicalBVPFunction{iip, TP}, u0, tspan,
+    @add_kwonly function SecondOrderBVProblem{iip}(
+            f::DynamicalBVPFunction{iip, TP}, u0, tspan,
             p = NullParameters(); problem_type = nothing, nlls = nothing,
             kwargs...) where {iip, TP}
         _u0 = prepare_initial_state(u0)
@@ -331,16 +332,19 @@ struct SecondOrderBVProblem{uType, tType, isinplace, nlls, P, F, PT, K} <:
             typeof(problem_type), typeof(kwargs)}(f, _u0, _tspan, p, problem_type, kwargs)
     end
 
-    function SecondOrderBVProblem{iip}(f, bc, u0, tspan, p = NullParameters(); kwargs...) where {iip}
+    function SecondOrderBVProblem{iip}(
+            f, bc, u0, tspan, p = NullParameters(); kwargs...) where {iip}
         SecondOrderBVProblem(DynamicalBVPFunction{iip}(f, bc), u0, tspan, p; kwargs...)
     end
 end
 
 function SecondOrderBVProblem(f, bc, u0, tspan, p = NullParameters(); kwargs...)
     iip = isinplace(f, 5)
-    return SecondOrderBVProblem{iip}(DynamicalBVPFunction{iip}(f, bc), u0, tspan, p; kwargs...)
+    return SecondOrderBVProblem{iip}(
+        DynamicalBVPFunction{iip}(f, bc), u0, tspan, p; kwargs...)
 end
 
-function SecondOrderBVProblem(f::DynamicalBVPFunction, u0, tspan, p = NullParameters(); kwargs...)
+function SecondOrderBVProblem(
+        f::DynamicalBVPFunction, u0, tspan, p = NullParameters(); kwargs...)
     return SecondOrderBVProblem{isinplace(f)}(f, u0, tspan, p; kwargs...)
 end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1789,7 +1789,8 @@ and more. For all cases, `u` is the state and `p` are the parameters.
 ```julia
 OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
                           grad = nothing, hess = nothing, hv = nothing,
-                          cons = nothing, cons_j = nothing, cons_h = nothing,
+                          cons = nothing, cons_j = nothing, cons_jvp = nothing,
+                          cons_vjp = nothing, cons_h = nothing,
                           hess_prototype = nothing,
                           cons_jac_prototype = nothing,
                           cons_hess_prototype = nothing,
@@ -1827,6 +1828,8 @@ function described in [Callback Functions](https://docs.sciml.ai/Optimization/st
     bounds passed as `lcons` and `ucons` to [`OptimizationProblem`](@ref), in case of equality
     constraints `lcons` and `ucons` should be passed equal values.
 - `cons_j(J,x,p)` or `J=cons_j(x,p)`: the Jacobian of the constraints.
+- `cons_jvp(Jv,v,x,p)` or `Jv=cons_jvp(v,x,p)`: the Jacobian-vector product of the constraints.
+- `cons_vjp(Jv,v,x,p)` or `Jv=cons_vjp(v,x,p)`: the Jacobian-vector product of the constraints.
 - `cons_h(H,x,p)` or `H=cons_h(x,p)`: the Hessian of the constraints, provided as
    an array of Hessians with `res[i]` being the Hessian with respect to the `i`th output on `cons`.
 - `hess_prototype`: a prototype matrix matching the type that matches the Hessian. For example,
@@ -1892,7 +1895,7 @@ For more details on this argument, see the ODEFunction documentation.
 
 The fields of the OptimizationFunction type directly match the names of the inputs.
 """
-struct OptimizationFunction{iip, AD, F, G, H, HV, C, CJ, CH, HP, CJP, CHP, O,
+struct OptimizationFunction{iip, AD, F, G, H, HV, C, CJ, CJV, CVJ, CH, HP, CJP, CHP, O,
     EX, CEX, SYS, LH, LHP, HCV, CJCV, CHCV, LHCV} <:
        AbstractOptimizationFunction{iip}
     f::F
@@ -1902,6 +1905,8 @@ struct OptimizationFunction{iip, AD, F, G, H, HV, C, CJ, CH, HP, CJP, CHP, O,
     hv::HV
     cons::C
     cons_j::CJ
+    cons_jvp::CJV
+    cons_vjp::CVJ
     cons_h::CH
     hess_prototype::HP
     cons_jac_prototype::CJP

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -706,24 +706,35 @@ DynamicalBVPFunction(dbfiip, dbciip, jac = dbjac, bcjac = dbcjac)
 DynamicalBVPFunction(dbfoop, dbcoop, jac = dbjac, bcjac = dbcjac)
 
 dbWfact(du, u, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, Wfact = dbWfact)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact = dbWfact)
 dbWfact(du, u, p, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, Wfact = dbWfact)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact = dbWfact)
 dbWfact(du, u, p, gamma, t) = [1.0]
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip, dbciip, Wfact = dbWfact)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfiip, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact = dbWfact)
 dbWfact(ddu, du, u, p, gamma, t) = [1.0]
 DynamicalBVPFunction(dbfiip, dbciip, Wfact = dbWfact)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, Wfact = dbWfact)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact = dbWfact)
 
 dbWfact_t(du, u, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, Wfact_t = dbWfact_t)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, Wfact_t = dbWfact_t)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, Wfact_t = dbWfact_t)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact_t = dbWfact_t)
 dbWfact_t(du, u, p, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, Wfact_t = dbWfact_t)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, Wfact_t = dbWfact_t)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, Wfact_t = dbWfact_t)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, Wfact_t = dbWfact_t)
 dbWfact_t(du, u, p, gamma, t) = [1.0]
 @test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip,
     dbciip,
@@ -738,18 +749,25 @@ DynamicalBVPFunction(dbfiip, dbciip, Wfact_t = dbWfact_t)
     Wfact_t = dbWfact_t)
 
 dbtgrad(du, u, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, tgrad = dbtgrad)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, tgrad = dbtgrad)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, tgrad = dbtgrad)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, tgrad = dbtgrad)
 dbtgrad(du, u, p, t) = [1.0]
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip, dbciip, tgrad = dbtgrad)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, tgrad = dbtgrad)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfiip, dbciip, tgrad = dbtgrad)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, tgrad = dbtgrad)
 dbtgrad(ddu, du, u, p, t) = [1.0]
 DynamicalBVPFunction(dbfiip, dbciip, tgrad = dbtgrad)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, tgrad = dbtgrad)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, tgrad = dbtgrad)
 
 dbparamjac(du, u, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, paramjac = dbparamjac)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, paramjac = dbparamjac)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, paramjac = dbparamjac)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, paramjac = dbparamjac)
 dbparamjac(du, u, p, t) = [1.0]
 @test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip,
     dbciip,
@@ -764,25 +782,35 @@ DynamicalBVPFunction(dbfiip, dbciip, paramjac = dbparamjac)
     paramjac = dbparamjac)
 
 dbjvp(du, u, p, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, jvp = dbjvp)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, jvp = dbjvp)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, jvp = dbjvp)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, jvp = dbjvp)
 dbjvp(du, u, v, p, t) = [1.0]
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip, dbciip, jvp = dbjvp)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, jvp = dbjvp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfiip, dbciip, jvp = dbjvp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, jvp = dbjvp)
 dbjvp(ddu, du, u, v, p, t) = [1.0]
 DynamicalBVPFunction(dbfiip, dbciip, jvp = dbjvp)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, jvp = dbjvp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, jvp = dbjvp)
 
 dbvjp(du, u, p, t) = [1.0]
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfiip, dbciip, vjp = dbvjp)
-@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(dbfoop, dbciip, vjp = dbvjp)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfiip, dbciip, vjp = dbvjp)
+@test_throws SciMLBase.TooFewArgumentsError DynamicalBVPFunction(
+    dbfoop, dbciip, vjp = dbvjp)
 dbvjp(du, u, v, p, t) = [1.0]
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfiip, dbciip, vjp = dbvjp)
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, vjp = dbvjp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfiip, dbciip, vjp = dbvjp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, vjp = dbvjp)
 dbvjp(ddu, du, u, v, p, t) = [1.0]
 DynamicalBVPFunction(dbfiip, dbciip, vjp = dbvjp)
 
-@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(dbfoop, dbciip, vjp = dbvjp)
+@test_throws SciMLBase.NonconformingFunctionsError DynamicalBVPFunction(
+    dbfoop, dbciip, vjp = dbvjp)
 
 # IntegralFunction
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
