### PR TITLE
chore: Remove mentions of SDESolution

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -111,15 +111,15 @@ end
 
 function ChainRulesCore.rrule(
         ::Type{
-            <:ODESolution{uType, tType, isinplace, P, NP, F, G, K,
+            <:RODESolution{uType, tType, isinplace, P, NP, F, G, K,
             ND
         }}, u,
         args...) where {uType, tType, isinplace, P, NP, F, G, K, ND}
-    function SDESolutionAdjoint(ȳ)
+    function RODESolutionAdjoint(ȳ)
         (NoTangent(), ȳ, ntuple(_ -> NoTangent(), length(args))...)
     end
 
-    SDESolution{uType, tType, isinplace, P, NP, F, G, K, ND}(u, args...), SDESolutionAdjoint
+    RODESolution{uType, tType, isinplace, P, NP, F, G, K, ND}(u, args...), RODESolutionAdjoint
 end
 
 function ChainRulesCore.rrule(::SciMLBase.EnsembleSolution, sim, time, converged)

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -135,11 +135,11 @@ end
 @adjoint function SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND}(u,
         args...) where
         {uType, tType, isinplace, P, NP, F, G, K, ND}
-    function SDESolutionAdjoint(ȳ)
+    function SDEProblemAdjoint(ȳ)
         (ȳ, ntuple(_ -> nothing, length(args))...)
     end
 
-    SDESolution{uType, tType, isinplace, P, NP, F, G, K, ND}(u, args...), SDESolutionAdjoint
+    SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND}(u, args...), SDEProblemAdjoint
 end
 
 @adjoint function NonlinearSolution{T, N, uType, R, P, A, O, uType2}(u,


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

`SDESolution` doesn't seem to exist anymore. The more appropriate type seems to be `RODESolution`. This PR removes mentions of SDESolution and replaces them with `RODESolution`. Further, one of the adjoints was incorrect. It was definining an adjoint over SDEProblem, but instead tries returning SDESolution in the forwards pass. Not sure how this passed tests though


Add any other context about the problem here.
