### PR TITLE
only bail out as instable when dt is small or error is somewhat conrtolled

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -619,10 +619,15 @@ function check_error(integrator::DEIntegrator)
     end
     if integrator.opts.unstable_check(integrator.dt, integrator.u, integrator.p,
         integrator.t)
-        if integrator.opts.verbose
-            @warn("Instability detected. Aborting")
+        bigtol = max(integrator.opts.reltol, integrator.opts.abstol)
+        # only declare instability if the dt is very small
+        # or we have at least one digit of accuracy in the solution
+        if integrator.dt<eps(integrator.t) || isdefined(integrator, :EEst) && integrator.EEst * bigtol < .1
+            if integrator.opts.verbose
+                @warn("Instability detected. Aborting")
+            end
+            return ReturnCode.Unstable
         end
-        return ReturnCode.Unstable
     end
     if last_step_failed(integrator)
         if integrator.opts.verbose


### PR DESCRIPTION
Previously, we would run the instability check no matter how badly the integrator had controlled the error. This caused issues, especially for the first timestep where the dt chosen was fairly arbitrary. We could end up in a situation very easily where the first timestep was big enough that the step would result in incredibly large (or NaN) u values. This step would get rejected, but because the values were incorrectly really big, we would get killed by instability detection. This is silly because just shrinking the `dt` would have made it stable, but we didn't get a chance to do so.
```
function rober(du, u, p, t)
    y₁, y₂, y₃ = u
    k₁, k₂, k₃ = p
    du .= [-k₁ * y₁ + k₃ * y₂ * y₃,
    k₁ * y₁ - k₃ * y₂ * y₃ - k₂ * y₂^2,
    k₂ * y₂^2]
end
prob = ODEProblem(rober, [1.0,0.0,0.0],(0.0,1e5),(0.04,3e7,1e4))
solve(prob, Rodas5P()) #fails
solve(prob, Rodas5P(), dt=1e-3) #works
```

With this PR, we will only do the instability check in the first place if we either roughly have the error controlled or the dt is already pretty small.