### PR TITLE
improve dtmin and unstable detection

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -634,7 +634,7 @@ function check_error(integrator::DEIntegrator)
             return ReturnCode.Unstable
         end
     end
-    bigtol = max(opts.reltol, opts.abstol)
+    bigtol = max(max(opts.reltol), max(opts.abstol))
     if isdefined(integrator, :EEst) && integrator.EEst * bigtol < .1
         if opts.unstable_check(integrator.dt, integrator.u, integrator.p,
                                           integrator.t)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -604,7 +604,7 @@ function check_error(integrator::DEIntegrator)
     # The last part:
     # Bail out if we take a step with dt less than the minimum value (which may be time dependent)
     # except if we are successfully taking such a small timestep is to hit a tstop exactly
-    # We also exit if the ODE is unstable acording to a user chosen callbakc
+    # We also exit if the ODE is unstable according to a user chosen callback
     # but only if we accepted the step to prevent from bailing out as unstable
     # when we just took way too big a step)
     step_accepted = !hasproperty(integrator, :accept_step) || integrator.accept_step

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -603,7 +603,7 @@ function check_error(integrator::DEIntegrator)
 
     # The last part:
     # Bail out if we take a step with dt less than the minimum value (which may be time dependent)
-    # except if we are sucessfully taking such a small timestep is to hit a tstop exactly
+    # except if we are successfully taking such a small timestep is to hit a tstop exactly
     # We also exit if the ODE is unstable (by default this is the same as nonfinite u)
     # but only consider the ODE unstable if the error is somewhat controlled
     # (to prevent from bailing out as unstable when we just took way too big a step)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -610,7 +610,7 @@ function check_error(integrator::DEIntegrator)
     step_accepted = !hasproperty(integrator, :accept_step) || integrator.accept_step
     if !opts.force_dtmin && opts.adaptive
         if abs(integrator.dt) <= abs(opts.dtmin) &&
-           (!step_accepted || ((hasproperty(integrator, :opts) && hasproperty(opts, :tstops)) ?
+           (!step_accepted || (hasproperty(opts, :tstops) ?
              integrator.t + integrator.dt < integrator.tdir * first(opts.tstops) :
              true))
             if verbose

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -634,7 +634,7 @@ function check_error(integrator::DEIntegrator)
             return ReturnCode.Unstable
         end
     end
-    bigtol = max(max(opts.reltol), max(opts.abstol))
+    bigtol = max(maximum(opts.reltol), maximum(opts.abstol))
     if isdefined(integrator, :EEst) && integrator.EEst * bigtol < .1
         if opts.unstable_check(integrator.dt, integrator.u, integrator.p,
                                           integrator.t)


### PR DESCRIPTION
Followup to https://github.com/SciML/SciMLBase.jl/pull/692. It turns out that OrdinaryDiffEq sets the minimum dt to `eps(t)` which is relatively sensible, but that means that we should be failing with an error if we don't accept a step and we're already at the minimum dt.

This definitely needs some tests, but I think those tests need to be in OrdinaryDiffEq so they will be added as a separate PR once this merges.