### PR TITLE
print maxeig as a float

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -56,7 +56,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::DEStats)
     @printf io "%-50s %-d\n" "Number of rootfind condition calls:" s.ncondition
     @printf io "%-50s %-d\n" "Number of accepted steps:" s.naccept
     @printf io "%-50s %-d" "Number of rejected steps:" s.nreject
-    iszero(s.maxeig) || @printf io "\n%-50s %-d" "Maximum eigenvalue recorded:" s.maxeig
+    iszero(s.maxeig) || @printf io "\n%-50s %-e" "Maximum eigenvalue recorded:" s.maxeig
 end
 
 function Base.merge(a::DEStats, b::DEStats)


### PR DESCRIPTION
This was likely just a copy paste bug. Since it's an estimate, and the main thing we care about is whether it's .5 or 1e20 it's very silly to print this value as an int.