### PR TITLE
Fix `EnsembleSummary` plot recipe kwarg #697 

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -344,7 +344,7 @@ end
 # TODO: should `error_style` be Makie plot types instead?  I.e. `Band`, `Errorbar`, etc
 function Makie.convert_arguments(::Type{<:Lines},
         sim::SciMLBase.EnsembleSummary;
-        trajectories = sim.u.u[1] isa AbstractArray ? eachindex(sim.u.u[1]) :
+        idxs = sim.u.u[1] isa AbstractArray ? eachindex(sim.u.u[1]) :
                        1,
         error_style = :ribbon, ci_type = :quantile,
         kwargs...)
@@ -384,7 +384,7 @@ function Makie.convert_arguments(::Type{<:Lines},
 
     makie_plotlist = Makie.PlotSpec[]
 
-    for (count, idx) in enumerate(trajectories)
+    for (count, idx) in enumerate(idxs)
         push!(makie_plotlist,
             S.Lines(sim.t, u[idx]; color = Makie.Cycled(count), label = "u[$idx]"))
         if error_style == :ribbon

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -158,7 +158,7 @@ end
 end
 
 @recipe function f(sim::EnsembleSummary;
-        trajectories = sim.u.u[1] isa AbstractArray ? eachindex(sim.u.u[1]) :
+        idxs = sim.u.u[1] isa AbstractArray ? eachindex(sim.u.u[1]) :
                        1,
         error_style = :ribbon, ci_type = :quantile)
     if ci_type == :SEM
@@ -192,7 +192,7 @@ end
     else
         error("ci_type choice not valid. Must be `:SEM` or `:quantile`")
     end
-    for i in trajectories
+    for i in idxs
         @series begin
             legend --> false
             linewidth --> 3


### PR DESCRIPTION
# In reference to #697:
- Updated the `trajectories` kwarg to `idxs` in the `EnsembleSummary` recipes for both `Plots` and `Makie`. 
- Should now allow users to select which variables to show summary line series of, in line with what the documentation shows. 

### Tests
- Wasn't sure where to put tests for this, or where plotting tests are kept. Should be something like:
```julia
idxs = (2, 3)
ensemble_summary_plot = plot(ensemble_summary; idxs)
@test ensemble_summary_plot.n == length(idxs)
``` 

## Further considerations or to-dos
1. Was the original intention of the `EnsembleSummary` recipes to allow users to choose/truncate the amount of trajectories that statistics are plotted over, similar to `EnsembleSimulation`? (Explains the mixup with `idxs`)
   - If so, that functionality is missing and should be added

2. Symbolic indexing does not work any of the recipes for either `EnsembleSimulation` or `EnsembleSummary`. 
    - Should be added to match the recipe of `AbstractSolution`.

3. Plotting state spaces via giving `idxs` as a `Tuple` rather than a `Vector` does not work. 
    - Should also be added to match the non-ensemble solution plotting recipes, if intended by the maintainers. 

4. `Makie` `EnsembleSummary` recipe doesn't show transparent ranges:
![image](https://github.com/SciML/SciMLBase.jl/assets/69228453/32aee5bb-a4ec-4e6f-bcc7-a8122c6a55bf)
Shown are 100 trajectories.

5. No user-exposed way to set the color map of `EnsembleSimulation` trajectories? Would like an easy way to set it to something other than random, like this:
<img width="1297" alt="image" src="https://github.com/SciML/SciMLBase.jl/assets/69228453/9323f649-97e4-4698-ab6b-f90d314d9318">
