### PR TITLE
fix: fix `u0` dependent on `p` not working with `remake`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -475,7 +475,10 @@ function _updated_u0_p_symmap(prob, u0, ::Val{true}, p, ::Val{false})
     isdep = any(symbolic_type(v) !== NotSymbolic() for (_, v) in u0)
     isdep || return remake_buffer(prob, state_values(prob), u0), p
 
-    temp_state = ProblemState(; p = p)
+    # FIXME: need to provide `u` since the observed function expects it.
+    # This is sort of an implicit dependency on MTK. The values of `u` won't actually be
+    # used, since any state symbols in the expression were substituted out earlier.
+    temp_state = ProblemState(; u = state_values(prob), p = p)
     u0 = anydict(k => symbolic_type(v) === NotSymbolic() ? v : getu(prob, v)(temp_state)
     for (k, v) in u0)
     return remake_buffer(prob, state_values(prob), u0), p
@@ -492,8 +495,8 @@ function _updated_u0_p_symmap(prob, u0, ::Val{false}, p, ::Val{true})
     isdep || return u0, remake_buffer(prob, parameter_values(prob), p)
 
     # FIXME: need to provide `p` since the observed function expects an `MTKParameters`
-    # this is sort of an implicit dependency on MTK. The values of `p` won't actually be used,
-    # since any parameter symbols in the expression were substituted out earlier.
+    # this is sort of an implicit dependency on MTK. The values of `p` won't actually be
+    # used, since any parameter symbols in the expression were substituted out earlier.
     temp_state = ProblemState(; u = u0, p = parameter_values(prob))
     p = anydict(k => symbolic_type(v) === NotSymbolic() ? v : getu(prob, v)(temp_state)
     for (k, v) in p)

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -123,6 +123,33 @@ for (sys, prob) in zip(syss, probs)
     @test pgetter(prob2) == [0.5, 8 / 3, 10.0]
     prob2 = @inferred baseType remake(prob; p = [:σ => 0.5])
     @test pgetter(prob2) == [0.5, 8 / 3, 10.0]
+
+    # Test p dependent on u0
+    prob2 = @inferred baseType remake(prob; p = [σ => 0.5x + 1])
+    @test pgetter(prob2) ≈ [1.5, 8 / 3, 10.0]
+    prob2 = @inferred baseType remake(prob; p = [sys.σ => 0.5x + 1])
+    @test pgetter(prob2) ≈ [1.5, 8 / 3, 10.0]
+    prob2 = @inferred baseType remake(prob; p = [:σ => 0.5x + 1])
+    @test pgetter(prob2) ≈ [1.5, 8 / 3, 10.0]
+
+    # Test u0 dependent on p
+    prob2 = @inferred baseType remake(prob; u0 = [x => 0.5σ + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+    prob2 = @inferred baseType remake(prob; u0 = [sys.x => 0.5σ + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+    prob2 = @inferred baseType remake(prob; u0 = [:x => 0.5σ + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+
+    # Test u0 dependent on p and p dependent on u0
+    prob2 = @inferred baseType remake(prob; u0 = [x => 0.5σ + 1], p = [β => 0.5x + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+    @test pgeter(prob2) ≈ [28.0, 8.5, 10.0]
+    prob2 = @inferred baseType remake(prob; u0 = [sys.x => 0.5σ + 1], p = [sys.β => 0.5x + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+    @test pgeter(prob2) ≈ [28.0, 8.5, 10.0]
+    prob2 = @inferred baseType remake(prob; u0 = [:x => 0.5σ + 1], p = [:β => 0.5x + 1])
+    @test ugetter(prob2) ≈ [15.0, 0.0, 0.0]
+    @test pgeter(prob2) ≈ [28.0, 8.5, 10.0]
 end
 
 @variables ud(t) xd(t) yd(t)


### PR DESCRIPTION
Close #672 

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
