### PR TITLE
fix: handle edge case when `()` as parameters triggers error

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -534,13 +534,13 @@ function updated_u0_p(prob, u0, p; interpret_symbolicmap = true, use_defaults = 
         return state_values(prob), parameter_values(prob)
     end
     if !has_sys(prob.f)
-        if interpret_symbolicmap && eltype(p) <: Pair
+        if interpret_symbolicmap && eltype(p) !== Union{} && eltype(p) <: Pair
             throw(ArgumentError("This problem does not support symbolic maps with " *
                                 "`remake`, i.e. it does not have a symbolic origin. Please use `remake`" *
                                 "with the `p` keyword argument as a vector of values (paying attention to" *
                                 "parameter order) or pass `interpret_symbolicmap = false` as a keyword argument"))
         end
-        if eltype(u0) <: Pair
+        if eltype(u0) !== Union{} && eltype(u0) <: Pair
             throw(ArgumentError("This problem does not support symbolic maps with" *
                                 " remake, i.e. it does not have a symbolic origin. Please use `remake`" *
                                 "with the `u0` keyword argument as a vector of values, paying attention to the order."))

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -254,3 +254,14 @@ for prob in deepcopy(probs)
         ForwardDiff.derivative(fakeloss!, 1.0)
     end
 end
+
+# eltype(()) <: Pair, so ensure that this doesn't error
+function lorenz!(du, u, _, t)
+    du[1] = 1 * (u[2] - u[1])
+    du[2] = u[1] * (2 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - 3 * u[3]
+end
+u0 = [1.0; 2.0; 3.0]
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz!, u0, tspan, nothing)
+@test_nowarn remake(prob, p = (), interpret_symbolicmap = true)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
