### PR TITLE
fix: fix `remake` changing specialization of `ODEFunction`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -125,8 +125,20 @@ function remake(prob::ODEProblem; f = missing,
             end
         else
             _f = prob.f
-            @reset _f.initializeprob = initializeprob
-            @reset _f.initializeprobmap = initializeprobmap
+            if __has_initializeprob(_f)
+                props = getproperties(_f)
+                @reset props.initializeprob = initializeprob
+                props = values(props)
+                _f = parameterless_type(_f){
+                    iip, specialization(_f), map(typeof, props)...}(props...)
+            end
+            if __has_initializeprobmap(_f)
+                props = getproperties(_f)
+                @reset props.initializeprobmap = initializeprobmap
+                props = values(props)
+                _f = parameterless_type(_f){
+                    iip, specialization(_f), map(typeof, props)...}(props...)
+            end
         end
     elseif f isa AbstractODEFunction
         _f = f


### PR DESCRIPTION
A "proper" fix for this would be making it so https://github.com/SciML/SciMLBase.jl/blob/9978e5bf498badac05ff4db606322fa9bf9dffc7/src/scimlfunctions.jl#L4378-L4381 didn't always do `FullSpecialize` but changing that is breaking.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
