### PR TITLE
Add Catalyst as a downstream test

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -49,6 +49,7 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core3}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core4}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core5}
+          - {user: SciML, repo: Catalyst.jl, group: All}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I'm not sure I've done this right, but I'd like to propose adding Catalyst as a downstream test. We have very comprehensive tests with V14, including for all kinds of symbolic indexing and plotting courtesy of @TorkelE, and I think some of the issues with stuff inadvertently getting broken might get caught if Catalyst was tested on such PRs to SciMLBase (and MTK, but Catalyst is already downstream there). It would also be very helpful to us in trying to diagnose sudden Catalyst breakages to be able to see if it had already broken in a merged SciMLBase PR.