### PR TITLE
fix: fix ambiguity in AbstractEnsembleSolution indexing

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -215,8 +215,8 @@ Base.@propagate_inbounds function Base.getindex(x::AbstractEnsembleSolution, s::
     return x.u[s].u[i]
 end
 
-Base.@propagate_inbounds function Base.getindex(x::AbstractEnsembleSolution, s::Integer, idxs::Integer...)
-    return x.u[s][idxs]
+Base.@propagate_inbounds function Base.getindex(x::AbstractEnsembleSolution, s::Integer, i2::Integer, i3::Integer, idxs::Integer...)
+    return x.u[s][i2, i3, idxs...]
 end
 
 Base.@propagate_inbounds function Base.getindex(x::AbstractEnsembleSolution, s, ::Colon)


### PR DESCRIPTION
- Single integer `getindex` should fallback to RAT and depwarn
- Double integer `getindex` is defined
- 3+ integer `getindex` is what the last method is intended to be, but is implemented wrong for two reasons
  - `idxs` needs to be splatted, since otherwise it passes a `Tuple` to `getindex`
  - It should specifically require 3+ integers to avoid ambiguities

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
