### PR TITLE
Lazy interpolation trait, stripping interpolation

### DIFF
--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -74,7 +74,7 @@ Defaults to false.
 """
 isdiscrete(alg::AbstractDEAlgorithm) = false
 
-""" 
+"""
     has_lazy_interpolation(alg::AbstractDEAlgorithm)
 
 Trait declaration for whether an algorithm computes the solution interpolation lazily.
@@ -186,4 +186,3 @@ as the maximum order of the algorithm.
 function alg_order(alg::AbstractODEAlgorithm)
     error("Order is not defined for this algorithm")
 end
-

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -74,6 +74,14 @@ Defaults to false.
 """
 isdiscrete(alg::AbstractDEAlgorithm) = false
 
+""" 
+    has_lazy_interpolation(alg::AbstractDEAlgorithm)
+
+Trait declaration for whether an algorithm computes the solution interpolation lazily.
+
+Defaults to false.
+"""
+has_lazy_interpolation(alg::AbstractDEAlgorithm) = false
 """
     allowsbounds(opt)
 
@@ -178,3 +186,4 @@ as the maximum order of the algorithm.
 function alg_order(alg::AbstractODEAlgorithm)
     error("Order is not defined for this algorithm")
 end
+

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -608,3 +608,14 @@ Constant Interpolation
         @. out = 0
     end
 end
+
+"""
+        strip_interpolation(id::AbstractDiffEqInterpolation)
+
+Returns a copy of the interpolation stripped of its function, to accommodate serialization.
+If the interpolation object has no function, returns the interpolation object as is.
+"""
+strip_interpolation(id::AbstractDiffEqInterpolation) = id
+strip_interpolation(id::HermiteInterpolation) = id 
+strip_interpolation(id::LinearInterpolation) = id
+strip_interpolation(id::ConstantInterpolation) = id

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -540,9 +540,11 @@ prepare_function(f) = f
 
 """
         strip_interpolation(interp::AbstractDiffEqInterpolation)
+
 Returns a copy of the interpolation stripped of its function, to accommodate serialization.
 If the interpolation object has no function, returns the interpolation object as is.
 """
-function strip_interpolation(id::Union{HermiteInterpolation, LinearInterpolation, ConstantInterpolation})
+function strip_interpolation(id::Union{
+        HermiteInterpolation, LinearInterpolation, ConstantInterpolation})
     interp
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -538,13 +538,3 @@ See also: `prepare_initial_state`.
 """
 prepare_function(f) = f
 
-"""
-        strip_interpolation(id::AbstractDiffEqInterpolation)
-
-Returns a copy of the interpolation stripped of its function, to accommodate serialization.
-If the interpolation object has no function, returns the interpolation object as is.
-"""
-strip_interpolation(id::AbstractDiffEqInterpolation) = id
-strip_interpolation(id::HermiteInterpolation) = id 
-strip_interpolation(id::LinearInterpolation) = id
-strip_interpolation(id::ConstantInterpolation) = id

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -543,7 +543,6 @@ prepare_function(f) = f
 Returns a copy of the interpolation stripped of its function, to accommodate serialization.
 If the interpolation object has no function, returns the interpolation object as is.
 """
-
-function strip_interpolation(interp::AbstractDiffEqInterpolation)
+function strip_interpolation(id::Union{HermiteInterpolation, LinearInterpolation, ConstantInterpolation})
     interp
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -539,12 +539,12 @@ See also: `prepare_initial_state`.
 prepare_function(f) = f
 
 """
-        strip_interpolation(interp::AbstractDiffEqInterpolation)
+        strip_interpolation(id::AbstractDiffEqInterpolation)
 
 Returns a copy of the interpolation stripped of its function, to accommodate serialization.
 If the interpolation object has no function, returns the interpolation object as is.
 """
-function strip_interpolation(id::Union{
-        HermiteInterpolation, LinearInterpolation, ConstantInterpolation})
-    interp
-end
+strip_interpolation(id::AbstractDiffEqInterpolation) = id
+strip_interpolation(id::HermiteInterpolation) = id 
+strip_interpolation(id::LinearInterpolation) = id
+strip_interpolation(id::ConstantInterpolation) = id

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -537,3 +537,13 @@ the arity of a function is computed with `numargs`
 See also: `prepare_initial_state`.
 """
 prepare_function(f) = f
+
+"""
+        strip_interpolation(interp::AbstractDiffEqInterpolation)
+Returns a copy of the interpolation stripped of its function, to accommodate serialization.
+If the interpolation object has no function, returns the interpolation object as is.
+"""
+
+function strip_interpolation(interp::AbstractDiffEqInterpolation)
+    interp
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Raises `has_lazy_interpolation` trait to SciMLBase.
Introduces `strip_interpolation` function to strip functions from interpolation objects, to accommodate serialization better. 