### PR TITLE
fix remake when args is a field of the struct

### DIFF
--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -290,7 +290,7 @@ struct Remake_Test1
    args
    kwargs
 end
-Remake_Test1(args...; p, kwargs...) = A(p, args, kwargs)
+Remake_Test1(args...; p, kwargs...) = Remake_Test1(p, args, kwargs)
 a = Remake_Test1(p=1)
 @test remake(a, p=2) == Remake_Test1(p=2)
 @test remake(a, args=1) == Remake_Test1(1, p=1)

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -284,3 +284,14 @@ newprob = remake(sdeprob; g = noise2!)
 @test newprob.f isa SDEFunction
 tmp = newprob.g([0.0, 0.0, 0.0], [1.0, 2.0, 3.0], nothing, 0.0)
 @test tmp≈[0.2, 0.4, 0.6] atol=1e-6
+
+struct Remake_Test1
+   p
+   args
+   kwargs
+end
+Remake_Test1(args...; p, kwargs...) = A(p, args, kwargs)
+a = Remake_Test1(p=1)
+@test remake(a, p=2) == Remake_Test1(p=2)
+@test remake(a, args=1) == Remake_Test1(1, p=1)
+@test remake(a, kwargs=(;a=1)) == Remake_Test1(p=1, a=1)

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -292,6 +292,6 @@ struct Remake_Test1
 end
 Remake_Test1(args...; p, kwargs...) = Remake_Test1(p, args, kwargs)
 a = Remake_Test1(p=1)
-@test remake(a, p=2) == Remake_Test1(p=2)
-@test remake(a, args=1) == Remake_Test1(1, p=1)
-@test remake(a, kwargs=(;a=1)) == Remake_Test1(p=1, a=1)
+@test @inferred remake(a, p=2) == Remake_Test1(p=2)
+@test @inferred remake(a, args=1) == Remake_Test1(1, p=1)
+@test @inferred remake(a, kwargs=(;a=1)) == Remake_Test1(p=1, a=1)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
