### PR TITLE
use custom exception for lazy interpolation

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -609,7 +609,7 @@ struct LazyInterpolationException <: Exception
     var::Symbol
 end
 
-Base.showerror(io::IO, e::LazyInterpolationException) = print(io, "the algorithm", e.var, " uses lazy interpolation, which is incompatible with `strip_solution`.")
+Base.showerror(io::IO, e::LazyInterpolationException) = print(io, "The algorithm", e.var, " uses lazy interpolation, which is incompatible with `strip_solution`.")
 
 function strip_solution(sol::ODESolution)
     if has_lazy_interpolation(sol.alg)

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -605,10 +605,15 @@ function sensitivity_solution(sol::ODESolution, u, t)
     return @set sol.interp = interp
 end
 
+struct LazyInterpolationException <: Exception 
+    var::Symbol
+end
+
+Base.showerror(io::IO, e::LazyInterpolationException) = print(io, "the algorithm", e.var, " uses lazy interpolation, which is incompatible with `strip_solution`.")
+
 function strip_solution(sol::ODESolution)
     if has_lazy_interpolation(sol.alg)
-        error("The algorithm $(sol.alg) uses lazy interpolation, which is incompatible with
-        solution stripping.")
+        throw(LazyInterpolationException(nameof(typeof(sol.alg))))
     end
 
     interp = strip_interpolation(sol.interp)


### PR DESCRIPTION
## Checklist

- [x ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context

Changes `strip_solution` to use a custom exception type.