### PR TITLE
Update optimization_problems.jl

### DIFF
--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -49,7 +49,7 @@ where `(lb[i],ub[i])` is the box constraint (lower and upper bounds) for `u[i]`.
 
 `lcons` and `ucons` are the upper and lower bounds in case of inequality constraints on the
 optimization and if they are set to be equal then it represents an equality constraint.
-They should be an `AbstractArray` matching the geometry of `u`, where `(lcons[i],ucons[i])`
+They should be an `AbstractArray`, where `(lcons[i],ucons[i])`
 are the lower and upper bounds for `cons[i]`.
 
 The `f` in the `OptimizationProblem` should typically be an instance of [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)


### PR DESCRIPTION
This is inconsistent with the description below, which states that the array must be sized to match the number of constraints.

I also cannot think of a reason why the constraint expressions should match the geometry of the minimisation variable (and many cases where this would not be true), so I am assuming that this is an erroneous half-sentence that can be removed.
  
## Additional context

This is a little confusing, it also contradicts the documentation lines 74-77 and 81 and following.