### PR TITLE
add additative noise trait

### DIFF
--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -247,9 +247,19 @@ end
 """
     allows_non_wiener_noise(alg::AbstractSDEAlgorithm)
 
-Trait declaration for whether an algorithm allows for non-additive wiener noise.
+Trait declaration for whether an algorithm allows for non-wiener noise.
 In general, this is false for any high order (that uses levy areas) or adaptive method.
 
 Defaults to false.
 """
 allows_non_wiener_noise(alg::AbstractSDEAlgorithm) = false
+
+"""
+    requires_additive_noise(alg::AbstractSDEAlgorithm)
+
+Trait declaration for whether an algorithm requires additive noise, i.e. the noise
+function is not a function of `u`.
+
+Defaults to false
+"""
+requires_additive_noise(alg::AbstractSDEAlgorithm) = false

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -243,3 +243,13 @@ as the maximum order of the algorithm.
 function alg_order(alg::AbstractODEAlgorithm)
     error("Order is not defined for this algorithm")
 end
+
+"""
+    allows_non_wiener_noise(alg::AbstractSDEAlgorithm)
+
+Trait declaration for whether an algorithm allows for non-additive wiener noise.
+In general, this is false for any high order (that uses levy areas) or adaptive method.
+
+Defaults to false.
+"""
+allows_non_wiener_noise(alg::AbstractSDEAlgorithm) = false


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
To add errors/warning that additive alg do not work with correlated or non-diagonal sde problems

https://github.com/SciML/StochasticDiffEq.jl/issues/581
https://github.com/SciML/StochasticDiffEq.jl/issues/578