### PR TITLE
allow different number of out-of-place args for isinplace

### DIFF
--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -245,16 +245,17 @@ function alg_order(alg::AbstractODEAlgorithm)
 end
 
 """
-Integral interpolation for the SDE solver algorithm. SDEs solutions depend on the chosen definition of the stochastic integral. In the Ito calculus, 
-the left-hand rule is taken, while Stratonovich calculus uses the right-hand rule. Unlike in standard Riemannian integration, these integral rules do 
-not converge to the same answer. In the context of a stochastic differential equation, the underlying solution (and its mean, variance, etc.) is dependent 
-on the integral rule that is chosen. This trait describes which interpretation the solver algorithm subscribes to, and thus whether the solution should 
+Integral interpolation for the SDE solver algorithm. SDEs solutions depend on the chosen definition of the stochastic integral. In the Ito calculus,
+the left-hand rule is taken, while Stratonovich calculus uses the right-hand rule. Unlike in standard Riemannian integration, these integral rules do
+not converge to the same answer. In the context of a stochastic differential equation, the underlying solution (and its mean, variance, etc.) is dependent
+on the integral rule that is chosen. This trait describes which interpretation the solver algorithm subscribes to, and thus whether the solution should
 be interpreted as the solution to the SDE under the Ito or Stratonovich interpretation.
 
 For more information, see https://oatml.cs.ox.ac.uk/blog/2022/03/22/ito-strat.html as a good high-level explanation.
 
 !!! note
-    The expected solution statistics are dependent on this output. Solutions from solvers with different 
+
+    The expected solution statistics are dependent on this output. Solutions from solvers with different
     interpretations are expected to have different answers on almost all SDEs without additive noise.
 """
 function alg_interpretation end

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -249,7 +249,7 @@ Integral interpolation for the SDE solver algorithm. SDEs solutions depend on th
 the left-hand rule is taken, while Stratonovich calculus uses the right-hand rule. Unlike in standard Riemannian integration, these integral rules do 
 not converge to the same answer. In the context of a stochastic differential equation, the underlying solution (and its mean, variance, etc.) is dependent 
 on the integral rule that is chosen. This trait describes which interpretation the solver algorithm subscribes to, and thus whether the solution should 
-be interpretated as the solution to the SDE under the Ito or Stratonovich interpretation.
+be interpreted as the solution to the SDE under the Ito or Stratonovich interpretation.
 
 For more information, see https://oatml.cs.ox.ac.uk/blog/2022/03/22/ito-strat.html as a good high-level explanation.
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -216,7 +216,9 @@ function Base.showerror(io::IO, e::FunctionArgumentsError)
 end
 
 """
-    isinplace(f, inplace_param_number[,fname="f"])
+    isinplace(f, inplace_param_number, fname = "f", iip_preferred = true;
+              has_two_dispatches = true,
+              outofplace_param_number = inplace_param_number - 1)
     isinplace(f::AbstractSciMLFunction[, inplace_param_number])
 
 Check whether a function operates in place by comparing its number of arguments
@@ -224,7 +226,8 @@ to the expected number. If `f` is an `AbstractSciMLFunction`, then the type
 parameter is assumed to be correct and is used. Otherwise `inplace_param_number`
 is checked against the methods table, where `inplace_param_number` is the number
 of arguments for the in-place dispatch. The out-of-place dispatch is assumed
-to have one less. If neither of these dispatches exist, an error is thrown.
+to have `outofplace_param_number` parameters (one less than the inplace version
+by default). If neither of these dispatches exist, an error is thrown.
 If the error is thrown, `fname` is used to tell the user which function has the
 incorrect dispatches.
 
@@ -238,22 +241,23 @@ form is disabled and the 2-argument signature is ensured to be matched.
 
 # See also
 
-  - [`numargs`](@ref numargs)
+- [`numargs`](@ref numargs)
 """
 function isinplace(f, inplace_param_number, fname = "f", iip_preferred = true;
-        has_two_dispatches = true, isoptimization = false)
+        has_two_dispatches = true, isoptimization = false,
+        outofplace_param_number = inplace_param_number - 1)
     nargs = numargs(f)
     iip_dispatch = any(x -> x == inplace_param_number, nargs)
-    oop_dispatch = any(x -> x == inplace_param_number - 1, nargs)
+    oop_dispatch = any(x -> x == outofplace_param_number, nargs)
 
     if length(nargs) == 0
         throw(NoMethodsError(fname))
     end
 
     if !iip_dispatch && !oop_dispatch && !isoptimization
-        if all(x -> x > inplace_param_number, nargs)
+        if all(>(inplace_param_number), nargs)
             throw(TooManyArgumentsError(fname, f))
-        elseif all(x -> x < inplace_param_number - 1, nargs) && has_two_dispatches
+        elseif all(<(outofplace_param_number), nargs) && has_two_dispatches
             # Possible extra safety?
             # Find if there's a `f(args...)` dispatch
             # If so, no error

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -241,7 +241,7 @@ form is disabled and the 2-argument signature is ensured to be matched.
 
 # See also
 
-- [`numargs`](@ref numargs)
+  - [`numargs`](@ref numargs)
 """
 function isinplace(f, inplace_param_number, fname = "f", iip_preferred = true;
         has_two_dispatches = true, isoptimization = false,

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -24,6 +24,13 @@ f = Foo{1}()
 (this::Foo{T})(args...) where {T} = 1
 @test SciMLBase.isinplace(Foo{Int}(), 4)
 
+@testset "isinplace accepts an out-of-place version with different numbers of parameters " begin
+    f1(u) = 2 * u
+    @test !isinplace(f1, 2)
+    @test_throws SciMLBase.TooFewArgumentsError SciMLBase.isinplace(f1, 4)
+    @test !isinplace(f1, 4; outofplace_param_number = 1)
+end
+
 ## Problem argument tests
 
 ftoomany(u, p, t, x, y) = 2u


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This helps us at https://github.com/SKopecz/PositiveIntegrators.jl
