### PR TITLE
fix: fix `remake` handling identical variables with different names

### DIFF
--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -295,3 +295,22 @@ a = Remake_Test1(p = 1)
 @test @inferred remake(a, p = 2) == Remake_Test1(p = 2)
 @test @inferred remake(a, args = 1) == Remake_Test1(1, p = 1)
 @test @inferred remake(a, kwargs = (; a = 1)) == Remake_Test1(p = 1, a = 1)
+
+@testset "fill_u0 and fill_p ignore identical variables with different names" begin
+    sys = SymbolCache(Dict(:x => 1, :x2 => 1, :y => 2), Dict(:a => 1, :a2 => 1, :b => 2),
+        :t; defaults = Dict(:x => 1, :y => 2, :a => 3, :b => 4))
+    function foo(du, u, p, t)
+        du .= u .* p
+    end
+    prob = ODEProblem(ODEFunction(foo; sys), [1.5, 2.5], (0.0, 1.0), [3.5, 4.5])
+    u0 = Dict(:x2 => 2)
+    newu0 = SciMLBase.fill_u0(prob, u0; defs = default_values(sys))
+    @test length(newu0) == 2
+    @test get(newu0, :x2, 0) == 2
+    @test get(newu0, :y, 0) == 2.5
+    p = Dict(:a2 => 3)
+    newp = SciMLBase.fill_p(prob, p; defs = default_values(sys))
+    @test length(newp) == 2
+    @test get(newp, :a2, 0) == 3
+    @test get(newp, :b, 0) == 4.5
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
