### PR TITLE
Fix calculate_ensemble_errors' error vector types.

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -86,9 +86,10 @@ end
 function calculate_ensemble_errors(u; elapsedTime = 0.0, converged = false,
         weak_timeseries_errors = false,
         weak_dense_errors = false)
-    errors = Dict{Symbol, Vector{eltype(u[1].u[1])}}() #Should add type information
-    error_means = Dict{Symbol, eltype(u[1].u[1])}()
-    error_medians = Dict{Symbol, eltype(u[1].u[1])}()
+    err_type = typeof(collect(u[1].errors)[1][2])
+    errors = Dict{Symbol, Vector{err_type}}() #Should add type information
+    error_means = Dict{Symbol, err_type}()
+    error_medians = Dict{Symbol, err_type}()
 
     analyticvoa = u[1].u_analytic isa AbstractVectorOfArray ? true : false
 
@@ -98,7 +99,7 @@ function calculate_ensemble_errors(u; elapsedTime = 0.0, converged = false,
         error_medians[k] = median(errors[k])
     end
     # Now Calculate Weak Errors
-    weak_errors = Dict{Symbol, eltype(u[1].u[1])}()
+    weak_errors = Dict{Symbol, err_type}()
     # Final
     m_final = mean([s.u[end] for s in u])
 


### PR DESCRIPTION
Context explained in this PR: https://github.com/SciML/DiffEqDevTools.jl/pull/145

"The current version of SciMLBase's calculate_ensemble_errors returns errors that have the same number type as the solution vector. So, for complex solutions it returns ComplexF64 type errors (with zero imaginary part) and then the plotter will refused to plot them."

I am have precompilation errors with some of the test on my machine, so I was not able to run all tests. However, the change is so minor it is hard to imagine that it broke anything.

## Checklist
- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
