### PR TITLE
Fix interpolation for stripped solutions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "2.53.1"
+version = "2.53.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -619,8 +619,6 @@ function Base.showerror(io::IO, e::LazyInterpolationException)
         " uses lazy interpolation, which is incompatible with `strip_solution`.")
 end
 
-struct ODENullFunction <: SciMLBase.AbstractODEFunction{false} end
-
 function strip_solution(sol::ODESolution; strip_alg = false)
     if has_lazy_interpolation(sol.alg)
         throw(LazyInterpolationException(nameof(typeof(sol.alg))))
@@ -630,8 +628,7 @@ function strip_solution(sol::ODESolution; strip_alg = false)
 
     @reset sol.interp = interp
 
-    @reset sol.prob = ODEProblem(ODENullFunction(), sol.prob.u0, sol.prob.tspan, p = sol.prob.p,
-        problem_type = sol.prob.problem_type, sol.prob.kwargs...)
+    @reset sol.prob = (; p = nothing)
 
     if strip_alg
         @reset sol.alg = nothing

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -633,6 +633,6 @@ function strip_solution(sol::ODESolution; strip_alg = false)
     if strip_alg
         @reset sol.alg = nothing
     end
-    
+
     return sol
 end

--- a/test/downstream/ode_stripping.jl
+++ b/test/downstream/ode_stripping.jl
@@ -21,4 +21,3 @@ stripped_sol = SciMLBase.strip_solution(sol)
 @test isnothing(stripped_sol.interp.cache.jac_config)
 
 @test isnothing(stripped_sol.interp.cache.grad_config)
-

--- a/test/downstream/ode_stripping.jl
+++ b/test/downstream/ode_stripping.jl
@@ -14,7 +14,7 @@ sol = solve(prob, Rosenbrock23())
 
 stripped_sol = SciMLBase.strip_solution(sol)
 
-@test stripped_sol.prob.f isa ODENullFunction
+@test stripped_sol.prob.f isa SciMLBase.ODENullFunction
 
 @test isnothing(SciMLBase.strip_solution(sol, strip_alg = true).alg)
 
@@ -24,4 +24,3 @@ stripped_sol = SciMLBase.strip_solution(sol)
 
 @test isnothing(stripped_sol.interp.cache.grad_config)
 
-@test stripped_sol(0.45) isa Number

--- a/test/downstream/ode_stripping.jl
+++ b/test/downstream/ode_stripping.jl
@@ -14,8 +14,6 @@ sol = solve(prob, Rosenbrock23())
 
 stripped_sol = SciMLBase.strip_solution(sol)
 
-@test stripped_sol.prob.f isa SciMLBase.ODENullFunction
-
 @test isnothing(SciMLBase.strip_solution(sol, strip_alg = true).alg)
 
 @test isnothing(stripped_sol.interp.f)

--- a/test/downstream/ode_stripping.jl
+++ b/test/downstream/ode_stripping.jl
@@ -12,9 +12,9 @@ prob = ODEProblem(lorenz!, u0, tspan)
 # implicit solver so we can test cache stripping worked
 sol = solve(prob, Rosenbrock23())
 
-@test isnothing(SciMLBase.strip_solution(sol).prob)
+@test SciMLBase.strip_solution(sol).prob.f isa ODENullFunction
 
-@test isnothing(SciMLBase.strip_solution(sol).alg)
+@test isnothing(SciMLBase.strip_solution(sol, strip_alg = true).alg)
 
 @test isnothing(SciMLBase.strip_solution(sol).interp.f)
 

--- a/test/downstream/ode_stripping.jl
+++ b/test/downstream/ode_stripping.jl
@@ -12,12 +12,16 @@ prob = ODEProblem(lorenz!, u0, tspan)
 # implicit solver so we can test cache stripping worked
 sol = solve(prob, Rosenbrock23())
 
-@test SciMLBase.strip_solution(sol).prob.f isa ODENullFunction
+stripped_sol = SciMLBase.strip_solution(sol)
+
+@test stripped_sol.prob.f isa ODENullFunction
 
 @test isnothing(SciMLBase.strip_solution(sol, strip_alg = true).alg)
 
-@test isnothing(SciMLBase.strip_solution(sol).interp.f)
+@test isnothing(stripped_sol.interp.f)
 
-@test isnothing(SciMLBase.strip_solution(sol).interp.cache.jac_config)
+@test isnothing(stripped_sol.interp.cache.jac_config)
 
-@test isnothing(SciMLBase.strip_solution(sol).interp.cache.grad_config)
+@test isnothing(stripped_sol.interp.cache.grad_config)
+
+@test stripped_sol(0.45) isa Number


### PR DESCRIPTION
## Checklist

- [x ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context
Fixes interpolation for stripped solution objects, i.e. solution objects from `strip_solution`.

I'm not sure about doing `struct ODENullFunction <: SciMLBase.AbstractODEFunction{false} end`, but the inner constructor for ODEProblem doesn't allow `f` to be nothing. And the alternative seems to be changing the functors for ODEProblem. This also allows for stripped_solutions to keep some problem information. It might be good to add taking out the whole problem as an option as well?

