### PR TITLE
feat: variables with value `nothing` passed to `remake` are ignored

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -570,6 +570,7 @@ function fill_u0(prob, u0; defs = nothing, use_defaults = false)
     idx_to_sym = anydict()
     idx_to_val = anydict()
     for (k, v) in u0
+        v === nothing && continue
         idx = variable_index(prob, k)
         idx === nothing && continue
         if !(idx isa AbstractArray) || symbolic_type(k) != ArraySymbolic()
@@ -614,6 +615,7 @@ function fill_p(prob, p; defs = nothing, use_defaults = false)
     idx_to_sym = anydict()
     idx_to_val = anydict()
     for (k, v) in p
+        v === nothing && continue
         idx = parameter_index(prob, k)
         idx === nothing && continue
         if !(idx isa AbstractArray) || symbolic_type(k) != ArraySymbolic()

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -314,3 +314,13 @@ a = Remake_Test1(p = 1)
     @test get(newp, :a2, 0) == 3
     @test get(newp, :b, 0) == 4.5
 end
+
+@testset "value of `nothing` is ignored" begin
+    sys = SymbolCache(Dict(:x => 1, :x2 => 1, :y => 2), Dict(:a => 1, :a2 => 1, :b => 2),
+        :t; defaults = Dict(:x => 1, :y => 2, :a => 3, :b => 4))
+    function foo(du, u, p, t)
+        du .= u .* p
+    end
+    prob = ODEProblem(ODEFunction(foo; sys), [1.5, 2.5], (0.0, 1.0), [3.5, 4.5])
+    @test_nowarn remake(prob; u0 = [:x => nothing], p = [:a => nothing])
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
