### PR TITLE
Add aliasing API types

### DIFF
--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -102,7 +102,8 @@ Note that if a method does not have adaptivity, the following rules apply:
 ## Memory Optimizations
 
   - `alias`: an `ODEAliases` object that holds the field `alias_u0`, which allows the solver to alias the 
-    initial condition array that is contained in the problem struct. Defaults to false.
+    initial condition array that is contained in the problem struct. For example, tell the solver to alias `u0`,
+    `solve(prob,alias = ODEAliases(alias_u0 = true))`. Defaults to `ODEAliases(alias_u0 = false)`.
   - `cache`: pass a solver cache to decrease the construction time. This is not implemented
     for any of the problem interfaces at this moment.
 

--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -101,9 +101,12 @@ Note that if a method does not have adaptivity, the following rules apply:
 
 ## Memory Optimizations
 
-  - `alias`: an `ODEAliases` object that holds the field `alias_u0`, which allows the solver to alias the 
-    initial condition array that is contained in the problem struct. For example, tell the solver to alias `u0`,
-    `solve(prob,alias = ODEAliases(alias_u0 = true))`. Defaults to `ODEAliases(alias_u0 = false)`.
+  - `alias`: an `AbstractAliasSpecifier` object that holds fields specifying which variables to alias
+    when solving. For example, to tell an ODE solver to alias the `u0` array, you can use an `ODEAliases` object, 
+    and the `alias_u0` keyword argument, e.g. `solve(prob,alias = ODEAliases(alias_u0 = true))`. The fields of 
+    every `AbstractAliasSpecifier` default to `nothing`, which tells the solver to use its default behavior. 
+    For more information on what can be aliased for each problem type, see the documentation for the `AbstractAliasSpecifier`
+    associated with that problem type. 
   - `cache`: pass a solver cache to decrease the construction time. This is not implemented
     for any of the problem interfaces at this moment.
 

--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -103,10 +103,10 @@ Note that if a method does not have adaptivity, the following rules apply:
 
   - `alias`: an `AbstractAliasSpecifier` object that holds fields specifying which variables to alias
     when solving. For example, to tell an ODE solver to alias the `u0` array, you can use an `ODEAliases` object, 
-    and the `alias_u0` keyword argument, e.g. `solve(prob,alias = ODEAliases(alias_u0 = true))`. The fields of 
-    every `AbstractAliasSpecifier` default to `nothing`, which tells the solver to use its default behavior. 
+    and the `alias_u0` keyword argument, e.g. `solve(prob,alias = ODEAliases(alias_u0 = true))`. 
     For more information on what can be aliased for each problem type, see the documentation for the `AbstractAliasSpecifier`
-    associated with that problem type. 
+    associated with that problem type. Set to `true` to alias every variable possible, or to `false` to disable aliasing.
+    Defaults to an `AbstractAliasSpecifier` instance with `nothing` for all fields, which tells the solver to use the default behavior.
   - `cache`: pass a solver cache to decrease the construction time. This is not implemented
     for any of the problem interfaces at this moment.
 

--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -101,8 +101,8 @@ Note that if a method does not have adaptivity, the following rules apply:
 
 ## Memory Optimizations
 
-  - `alias_u0`: allows the solver to alias the initial condition array that is contained
-    in the problem struct. Defaults to false.
+  - `alias`: an `ODEAliases` object that holds the field `alias_u0`, which allows the solver to alias the 
+    initial condition array that is contained in the problem struct. Defaults to false.
   - `cache`: pass a solver cache to decrease the construction time. This is not implemented
     for any of the problem interfaces at this moment.
 

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -642,7 +642,7 @@ abstract type ADOriginator end
 """
 $(TYPEDEF)
 
-Used to specify which elements can be aliased in a solve. 
+Used to specify which variables can be aliased in a solve. 
 Every concrete AbstractAliasSpecifier should have at least the fields `alias_p` and `alias_f`. 
 """
 abstract type AbstractAliasSpecifier end

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -870,6 +870,6 @@ export ContinuousCallback, DiscreteCallback, CallbackSet, VectorContinuousCallba
 
 export Clocks, TimeDomain, is_discrete_time_domain, isclock, issolverstepclock, iscontinuous
 
-export ODEAliases, LinearAliases
+export ODEAliasSpecifier, LinearAliases
 
 end

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -870,6 +870,6 @@ export ContinuousCallback, DiscreteCallback, CallbackSet, VectorContinuousCallba
 
 export Clocks, TimeDomain, is_discrete_time_domain, isclock, issolverstepclock, iscontinuous
 
-export ODEAliasSpecifier, LinearAliases
+export ODEAliasSpecifier, LinearAliasSpecifier
 
 end

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -642,7 +642,8 @@ abstract type ADOriginator end
 """
 $(TYPEDEF)
 
-Used to specify which elements can be aliased in a solve.
+Used to specify which elements can be aliased in a solve. 
+Every concrete AbstractAliasSpecifier should have at least the fields `alias_p` and `alias_f`. 
 """
 abstract type AbstractAliasSpecifier end
 

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -642,6 +642,13 @@ abstract type ADOriginator end
 """
 $(TYPEDEF)
 
+Used to specify which elements can be aliased in a solve.
+"""
+abstract type AbstractAliasSpecifier end
+
+"""
+$(TYPEDEF)
+
 Internal. Used for signifying the AD context comes from a ChainRules.jl definition.
 """
 struct ChainRulesOriginator <: ADOriginator end

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -870,4 +870,6 @@ export ContinuousCallback, DiscreteCallback, CallbackSet, VectorContinuousCallba
 
 export Clocks, TimeDomain, is_discrete_time_domain, isclock, issolverstepclock, iscontinuous
 
+export ODEAliases, LinearAliases
+
 end

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -28,3 +28,37 @@ function AnalyticalProblem(f, u0, tspan, p = NullParameters(); kwargs...)
 end
 
 export AnalyticalProblem, AbstractAnalyticalProblem
+
+struct AnalyticalAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+end
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an AnalyticalProblem. Conforms to the AbstractAliasSpecifier interface. 
+    AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`
+
+"""
+function AnalyticalAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        AnalyticalAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        AnalyticalAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        AnalyticalAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
+end

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -29,13 +29,6 @@ end
 
 export AnalyticalProblem, AbstractAnalyticalProblem
 
-struct AnalyticalAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-end
 
 @doc doc"""
 
@@ -54,13 +47,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`
 
 """
-function AnalyticalAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        AnalyticalAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        AnalyticalAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        AnalyticalAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+struct AnalyticalAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function AnalyticalAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -41,12 +41,14 @@ end
 
 Holds information on what variables to alias
 when solving an AnalyticalProblem. Conforms to the AbstractAliasSpecifier interface. 
-    AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
+    
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array.
 * `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
 * `alias::Union{Bool, Nothing}`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -439,16 +439,6 @@ function TwoPointSecondOrderBVProblem(
     return TwoPointSecondOrderBVProblem(f, bc, u0, (tspan[1], tspan[end]), p; kwargs...)
 end
 
-
-struct BVPAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -466,13 +456,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `BVPAliasSpecifier` to `alias`
 
 """
-function BVPAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        BVPAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        BVPAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        BVPAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+struct BVPAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function BVPAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+
+

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -438,3 +438,39 @@ function TwoPointSecondOrderBVProblem(
     u0 = [initialGuess(i) for i in tspan]
     return TwoPointSecondOrderBVProblem(f, bc, u0, (tspan[1], tspan[end]), p; kwargs...)
 end
+
+
+struct BVPAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an BVP. Conforms to the AbstractAliasSpecifier interface. 
+    BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `BVPAliasSpecifier` to `alias`
+
+"""
+function BVPAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        BVPAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        BVPAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        BVPAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
+end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -453,7 +453,9 @@ end
 
 Holds information on what variables to alias
 when solving an BVP. Conforms to the AbstractAliasSpecifier interface. 
-    BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -134,7 +134,9 @@ end
 
 Holds information on what variables to alias
 when solving a DAE. Conforms to the AbstractAliasSpecifier interface. 
-    DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -120,16 +120,6 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
     end
 end
 
-
-struct DAEAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -147,13 +137,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `DAEAliasSpecifier` to `alias`
 
 """
-function DAEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        DAEAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        DAEAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        DAEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+struct DAEAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function DAEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+
+

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -119,3 +119,39 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
         return DAEProblem{iip}(f, du0, u0, tspan, p; differential_vars = dv, kw...)
     end
 end
+
+
+struct DAEAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving a DAE. Conforms to the AbstractAliasSpecifier interface. 
+    DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false.
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `DAEAliasSpecifier` to `alias`
+
+"""
+function DAEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        DAEAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        DAEAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        DAEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
+end

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -397,13 +397,6 @@ function SecondOrderDDEProblem(f::DynamicalDDEFunction, args...; kwargs...)
     end
 end
 
-struct DDEAliasSpecifier
-    alias_p
-    alias_f
-    alias_u0
-    alias_tstops
-end
-
 
 @doc doc"""
 
@@ -422,13 +415,22 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `DDEAliasSpecifier` to `alias`
 
 """
-function DDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        DDEAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        DDEAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        DDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+struct DDEAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function DDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -409,7 +409,9 @@ end
 
 Holds information on what variables to alias
 when solving a DDE. Conforms to the AbstractAliasSpecifier interface. 
-    DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -396,3 +396,37 @@ function SecondOrderDDEProblem(f::DynamicalDDEFunction, args...; kwargs...)
             kwargs...)
     end
 end
+
+struct DDEAliasSpecifier
+    alias_p
+    alias_f
+    alias_u0
+    alias_tstops
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving a DDE. Conforms to the AbstractAliasSpecifier interface. 
+    DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `DDEAliasSpecifier` to `alias`
+
+"""
+function DDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        DDEAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        DDEAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        DDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
+end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -165,7 +165,9 @@ end
 
 Holds information on what variables to alias
 when solving a DiscreteProblem. Conforms to the AbstractAliasSpecifier interface. 
-    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    `DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -153,3 +153,34 @@ function DiscreteProblem(u0::Union{AbstractArray, Number}, tspan::Tuple,
     end
     DiscreteProblem(f, u0, tspan, p; kwargs...)
 end
+
+struct DiscreteAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving a DiscreteProblem. Conforms to the AbstractAliasSpecifier interface. 
+    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias::Union{Bool, Nothing}`: sets all fields of the `DiscreteAliasSpecifier` to `alias`
+
+"""
+function DiscreteAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias = nothing)
+    if alias == true
+        DiscreteAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        DiscreteAliasAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        DiscreteAliasSpecifier(alias_p, alias_f, alias_u0)
+    end
+end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -154,13 +154,6 @@ function DiscreteProblem(u0::Union{AbstractArray, Number}, tspan::Tuple,
     DiscreteProblem(f, u0, tspan, p; kwargs...)
 end
 
-struct DiscreteAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -176,13 +169,23 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `DiscreteAliasSpecifier` to `alias`
 
 """
-function DiscreteAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias = nothing)
-    if alias == true
-        DiscreteAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        DiscreteAliasAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        DiscreteAliasSpecifier(alias_p, alias_f, alias_u0)
+struct DiscreteAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+
+    function DiscreteAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0)
+        end
     end
 end
+
+
+

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -119,3 +119,34 @@ function ImplicitDiscreteProblem(f, u0, tspan, p = NullParameters();
     iip = isinplace(f, 6)
     ImplicitDiscreteProblem(ImplicitDiscreteFunction{iip}(f), u0, tspan, p; kwargs...)
 end
+
+
+struct ImplicitDiscreteAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+end
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
+    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias::Union{Bool, Nothing}`: sets all fields of the `ImplicitDiscreteAliasSpecifier` to `alias`
+
+"""
+function ImplicitDiscreteAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias = nothing)
+    if alias == true
+        ImplicitDiscreteAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        ImplicitDiscreteAliasAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        ImplicitDiscreteAliasSpecifier(alias_p, alias_f, alias_u0)
+    end
+end

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -131,7 +131,9 @@ end
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
-    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    `DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -120,13 +120,6 @@ function ImplicitDiscreteProblem(f, u0, tspan, p = NullParameters();
     ImplicitDiscreteProblem(ImplicitDiscreteFunction{iip}(f), u0, tspan, p; kwargs...)
 end
 
-
-struct ImplicitDiscreteAliasSpecifier
-    alias_p::Union{Bool,Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-end
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -142,13 +135,22 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `ImplicitDiscreteAliasSpecifier` to `alias`
 
 """
-function ImplicitDiscreteAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias = nothing)
-    if alias == true
-        ImplicitDiscreteAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        ImplicitDiscreteAliasAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        ImplicitDiscreteAliasSpecifier(alias_p, alias_f, alias_u0)
+struct ImplicitDiscreteAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+
+    function ImplicitDiscreteAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0)
+        end
     end
 end
+
+

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -167,3 +167,8 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
         new{typeof(y), typeof(x), typeof(kwargs)}(y, x, dim, kwargs)
     end
 end
+
+struct IntegralAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -173,6 +173,18 @@ struct IntegralAliasSpecifier <: AbstractAliasSpecifier
     alias_f
 end
 
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an IntegralProblem. Conforms to the AbstractAliasSpecifier interface. 
+    IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias::Union{Bool, Nothing}`: sets all fields of the `IntegralAliasSpecifier` to `alias`
+
+"""
 function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
     if alias == true
         IntegralAliasSpecifier(true, true)

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -168,11 +168,6 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
     end
 end
 
-struct IntegralAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
-end
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -187,12 +182,19 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `IntegralAliasSpecifier` to `alias`
 
 """
-function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
-    if alias == true
-        IntegralAliasSpecifier(true, true)
-    elseif alias == false
-        IntegralAliasSpecifier(false, false)
-    elseif isnothing(alias)
-        IntegralAliasSpecifier(alias_p, alias_f)
+struct IntegralAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+
+    function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
+        if alias == true
+            new(true, true)
+        elseif alias == false
+            new(false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f)
+        end
     end
 end
+
+

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -172,3 +172,13 @@ struct IntegralAliasSpecifier <: AbstractAliasSpecifier
     alias_p
     alias_f
 end
+
+function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
+    if alias == true
+        IntegralAliasSpecifier(true, true)
+    elseif alias == false
+        IntegralAliasSpecifier(false, false)
+    elseif isnothing(alias)
+        IntegralAliasSpecifier(alias_p, alias_f)
+    end
+end

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -177,7 +177,9 @@ end
 
 Holds information on what variables to alias
 when solving an IntegralProblem. Conforms to the AbstractAliasSpecifier interface. 
-    IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    `IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)``
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -77,11 +77,6 @@ function LinearProblem(A, b, args...; kwargs...)
     end
 end
 
-struct LinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_A::Union{Bool,Nothing}
-    alias_b::Union{Bool,Nothing}
-end
-
 @doc doc"""
 Holds information on what variables to alias
 when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -100,12 +95,20 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothing`.
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.
 """
-function LinearAliasSpecifier(;alias_A = nothing, alias_b = nothing, alias_p = nothing, alias_f = nothing, alias = nothing)
-    if alias == true 
-        LinearAliasSpecifier(true,true,true,true)
-    elseif alias == false
-        LinearAliasSpecifier(false,false,false,false)
-    elseif isnothing(alias)
-        LinearAliasSpecifier(alias_p, alias_f, alias_A, alias_b)
+struct LinearAliasSpecifier <: AbstractAliasSpecifier
+    alias_A::Union{Bool,Nothing}
+    alias_b::Union{Bool,Nothing}
+
+    function LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing,
+            alias_p = nothing, alias_f = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_A, alias_b)
+        end
     end
 end
+
+

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -77,11 +77,22 @@ function LinearProblem(A, b, args...; kwargs...)
     end
 end
 
+@doc doc"""
+
+Holds `alias_A` and `alias_b` which determine whether 
+to alias `A` and `b` when solving a `LinearProblem`. 
+"""
 struct LinearAliases <: AbstractAliasSpecifier
     alias_A::Union{Bool,Nothing}
     alias_b::Union{Bool,Nothing}
 end
 
+"""
+    LinearAliases(;alias_A = nothing, alias_b = nothing)
+
+Creates a `LinearAliases` where `alias_A` and `alias_b` default to `nothing`.
+When `alias_A` or `alias_b` is nothing, the default value of the solver is used.
+"""
 function LinearAliases(;alias_A = nothing, alias_b = nothing)
     LinearAliases(alias_A, alias_b)
 end

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -83,15 +83,16 @@ struct LinearAliasSpecifier <: AbstractAliasSpecifier
 end
 
 @doc doc"""
-    Holds information on what variables to alias when solving a `LinearProblem`
+   Holds information on what variables to alias
+when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
 
 ### Keywords
 
-* `alias_p::Bool`
-* `alias_f::Bool`
-* `alias_A::Bool`: alias the `A` array.
-* `alias_b::Bool`: alias the `b` array. 
-* `alias::Bool`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_A::Union{Bool, Nothing}`: alias the `A` array.
+* `alias_b::Union{Bool, Nothing}`: alias the `b` array. 
+* `alias::Union{Bool, Nothing}`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
 
 Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothing`.
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -82,17 +82,25 @@ end
 Holds `alias_A` and `alias_b` which determine whether 
 to alias `A` and `b` when solving a `LinearProblem`. 
 """
-struct LinearAliases <: AbstractAliasSpecifier
+struct LinearAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool,Nothing}
     alias_A::Union{Bool,Nothing}
     alias_b::Union{Bool,Nothing}
 end
 
 """
-    LinearAliases(;alias_A = nothing, alias_b = nothing)
+    LinearAliasSpecifier(;alias_A = nothing, alias_b = nothing)
 
-Creates a `LinearAliases` where `alias_A` and `alias_b` default to `nothing`.
+Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothing`.
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.
 """
-function LinearAliases(;alias_A = nothing, alias_b = nothing)
-    LinearAliases(alias_A, alias_b)
+function LinearAliasSpecifier(;alias_A = nothing, alias_b = nothing, alias_p = nothing, alias_f = nothing, alias = nothing)
+    if alias == true 
+        LinearAliasSpecifier(true,true,true,true)
+    elseif alias == false
+        LinearAliasSpecifier(false,false,false,false)
+    elseif isnothing(alias)
+        LinearAliasSpecifier(alias_p, alias_f, alias_A, alias_b)
+    end
 end

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -76,3 +76,12 @@ function LinearProblem(A, b, args...; kwargs...)
         LinearProblem{isinplace(A, 4)}(A, b, args...; kwargs...)
     end
 end
+
+struct LinearAliases <: AbstractAliasSpecifier
+    alias_A::Union{Bool,Nothing}
+    alias_b::Union{Bool,Nothing}
+end
+
+function LinearAliases(;alias_A = nothing, alias_b = nothing)
+    LinearAliases(alias_A, alias_b)
+end

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -83,8 +83,11 @@ struct LinearAliasSpecifier <: AbstractAliasSpecifier
 end
 
 @doc doc"""
-   Holds information on what variables to alias
+Holds information on what variables to alias
 when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
+    `LinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_A = nothing, alias_b = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords
 

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -78,8 +78,6 @@ function LinearProblem(A, b, args...; kwargs...)
 end
 
 struct LinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool,Nothing}
-    alias_f::Union{Bool,Nothing}
     alias_A::Union{Bool,Nothing}
     alias_b::Union{Bool,Nothing}
 end

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -77,11 +77,6 @@ function LinearProblem(A, b, args...; kwargs...)
     end
 end
 
-@doc doc"""
-
-Holds `alias_A` and `alias_b` which determine whether 
-to alias `A` and `b` when solving a `LinearProblem`. 
-"""
 struct LinearAliasSpecifier <: AbstractAliasSpecifier
     alias_p::Union{Bool,Nothing}
     alias_f::Union{Bool,Nothing}
@@ -89,8 +84,16 @@ struct LinearAliasSpecifier <: AbstractAliasSpecifier
     alias_b::Union{Bool,Nothing}
 end
 
-"""
-    LinearAliasSpecifier(;alias_A = nothing, alias_b = nothing)
+@doc doc"""
+    Holds information on what variables to alias when solving a `LinearProblem`
+
+### Keywords
+
+* `alias_p::Bool`
+* `alias_f::Bool`
+* `alias_A::Bool`: alias the `A` array.
+* `alias_b::Bool`: alias the `b` array. 
+* `alias::Bool`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
 
 Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothing`.
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -558,15 +558,16 @@ struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
 end
 
 @doc doc"""
-    Holds information on what variables to alias when solving a `NonlinearProblem`.
+    Holds information on what variables to alias when solving a `NonlinearProblem`. 
+Conforms to the AbstractAliasSpecifier interface. 
 
 ### Keywords
 
-* `alias_p::Bool`
-* `alias_f::Bool`
-* `alias_A::Bool`: alias the `A` array.
-* `alias_b::Bool`: alias the `b` array. 
-* `alias::Bool`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_A::Union{Bool, Nothing}`: alias the `A` array.
+* `alias_b::Union{Bool, Nothing}`: alias the `b` array. 
+* `alias::Union{Bool, Nothing}`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
 """
 function NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
     if isnothing(alias)

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -558,15 +558,17 @@ struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
 end
 
 @doc doc"""
-    Holds information on what variables to alias when solving a `NonlinearProblem`. 
+Holds information on what variables to alias when solving a `NonlinearProblem`. 
 Conforms to the AbstractAliasSpecifier interface. 
+    `NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords
 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_A::Union{Bool, Nothing}`: alias the `A` array.
-* `alias_b::Union{Bool, Nothing}`: alias the `b` array. 
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
 * `alias::Union{Bool, Nothing}`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
 """
 function NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -549,3 +549,9 @@ function SymbolicIndexingInterface.set_parameter!(prob::SCCNonlinearProblem, val
         set_parameter!(scc, val, idx)
     end
 end
+
+
+struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -557,6 +557,17 @@ struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
     alias_u0::Union{Bool,Nothing}
 end
 
+@doc doc"""
+    Holds information on what variables to alias when solving a `NonlinearProblem`.
+
+### Keywords
+
+* `alias_p::Bool`
+* `alias_f::Bool`
+* `alias_A::Bool`: alias the `A` array.
+* `alias_b::Bool`: alias the `b` array. 
+* `alias::Bool`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
+"""
 function NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
     if isnothing(alias)
         NonlinearAliasSpecifier(alias_p, alias_f, alias_u0)

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -550,13 +550,6 @@ function SymbolicIndexingInterface.set_parameter!(prob::SCCNonlinearProblem, val
     end
 end
 
-
-struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool,Nothing}
-    alias_f::Union{Bool,Nothing}
-    alias_u0::Union{Bool,Nothing}
-end
-
 @doc doc"""
 Holds information on what variables to alias when solving a `NonlinearProblem`. 
 Conforms to the AbstractAliasSpecifier interface. 
@@ -571,12 +564,21 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
 * `alias::Union{Bool, Nothing}`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
 """
-function NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
-    if isnothing(alias)
-        NonlinearAliasSpecifier(alias_p, alias_f, alias_u0)
-    elseif alias
-        NonlinearAliasSpecifier(true, true, true)
-    elseif !alias
-        NonlinearAliasSpecifier(false, false, false)
+
+struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool,Nothing}
+    alias_u0::Union{Bool,Nothing}
+
+    function NonlinearAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+        if isnothing(alias)
+            new(alias_p, alias_f, alias_u0)
+        elseif alias
+            new(true, true, true)
+        elseif !alias
+            new(false, false, false)
+        end
     end
 end
+

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -552,6 +552,17 @@ end
 
 
 struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool,Nothing}
+    alias_u0::Union{Bool,Nothing}
+end
+
+function NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    if isnothing(alias)
+        NonlinearAliasSpecifier(alias_p, alias_f, alias_u0)
+    elseif alias
+        NonlinearAliasSpecifier(true, true, true)
+    elseif !alias
+        NonlinearAliasSpecifier(false, false, false)
+    end
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -512,11 +512,22 @@ function IncrementingODEProblem{iip}(f::IncrementingODEFunction, u0, tspan,
     ODEProblem(f, u0, tspan, p, IncrementingODEProblem{iip}(); kwargs...)
 end
 
+@doc doc"""
 
+Holds information on what variables to alias
+when solving an ODE. The field `alias_u0` determines whether the initial condition
+will be aliased when the ODE is solved. 
+"""
 struct ODEAliases <: AbstractAliasSpecifier
     alias_u0::Union{Bool,Nothing}
 end
 
+"""
+    ODEAliases(;alias_u0 = nothing)
+
+Creates an `ODEAliases`, with a default `alias_u0` value of `nothing`.
+When `alias_u0` is `nothing`, the solvers default to not aliasing `u0`.
+"""
 function ODEAliases(;alias_u0 = nothing)
     ODEAliases(alias_u0)
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -525,7 +525,9 @@ end
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
-    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+    `ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -514,9 +514,9 @@ end
 
 
 struct ODEAliases <: AbstractAliasSpecifier
-    u0::Union{Bool,Nothing}
+    alias_u0::Union{Bool,Nothing}
 end
 
-function ODEAliases(;u0 = nothing)
-    ODEAliases(u0)
+function ODEAliases(;alias_u0 = nothing)
+    ODEAliases(alias_u0)
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -518,8 +518,12 @@ Holds information on what variables to alias
 when solving an ODE. The field `alias_u0` determines whether the initial condition
 will be aliased when the ODE is solved. 
 """
-struct ODEAliases <: AbstractAliasSpecifier
+struct ODEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool,Nothing}
     alias_u0::Union{Bool,Nothing}
+    alias_du0::Union{Bool,Nothing}
+    alias_tstops::Union{Bool,Nothing}
 end
 
 """
@@ -528,6 +532,12 @@ end
 Creates an `ODEAliases`, with a default `alias_u0` value of `nothing`.
 When `alias_u0` is `nothing`, the solvers default to not aliasing `u0`.
 """
-function ODEAliases(;alias_u0 = nothing)
-    ODEAliases(alias_u0)
+function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        ODEAliasSpecifier(true,true,true,true,true)
+    elseif alias == false
+        ODEAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        ODEAliasSpecifier(alias_p,alias_f,alias_u0,alias_du0,alias_tstops)
+    end
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -528,12 +528,12 @@ when solving an ODE. Conforms to the AbstractAliasSpecifier interface.
     ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
 
 ### Keywords 
-* `alias_p::Bool`
-* `alias_f::Bool`
-* `alias_u0::Bool`: alias the u0 array. Defaults to false .
-* `alias_du0::Bool`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Bool`: alias the tstops array
-* `alias::Bool`: sets all fields of the `ODEAliasSpecifier` to `alias`
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `ODEAliasSpecifier` to `alias`
 
 """
 function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -512,15 +512,6 @@ function IncrementingODEProblem{iip}(f::IncrementingODEFunction, u0, tspan,
     ODEProblem(f, u0, tspan, p, IncrementingODEProblem{iip}(); kwargs...)
 end
 
-
-struct ODEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool,Nothing}
-    alias_f::Union{Bool,Nothing}
-    alias_u0::Union{Bool,Nothing}
-    alias_du0::Union{Bool,Nothing}
-    alias_tstops::Union{Bool,Nothing}
-end
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -538,12 +529,22 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `ODEAliasSpecifier` to `alias`
 
 """
-function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        ODEAliasSpecifier(true,true,true,true,true)
-    elseif alias == false
-        ODEAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        ODEAliasSpecifier(alias_p,alias_f,alias_u0,alias_du0,alias_tstops)
+struct ODEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool,Nothing}
+    alias_f::Union{Bool,Nothing}
+    alias_u0::Union{Bool,Nothing}
+    alias_du0::Union{Bool,Nothing}
+    alias_tstops::Union{Bool,Nothing}
+
+    function ODEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -530,13 +530,13 @@ when solving an ODE. Conforms to the AbstractAliasSpecifier interface.
 ### Keywords 
 * `alias_p::Bool`
 * `alias_f::Bool`
-* `alias_u0::Bool = false`: alias the u0 array
-* `alias_du0::Bool = false`: alias the du0 array for DAEs
-* `alias_tstops::Bool = false`: alias the tstops array
-* `alias::Bool`: sets all fields to `alias`
+* `alias_u0::Bool`: alias the u0 array. Defaults to false .
+* `alias_du0::Bool`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Bool`: alias the tstops array
+* `alias::Bool`: sets all fields of the `ODEAliasSpecifier` to `alias`
 
 """
-function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
     if alias == true
         ODEAliasSpecifier(true,true,true,true,true)
     elseif alias == false

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -511,3 +511,12 @@ function IncrementingODEProblem{iip}(f::IncrementingODEFunction, u0, tspan,
         p = NullParameters(); kwargs...) where {iip}
     ODEProblem(f, u0, tspan, p, IncrementingODEProblem{iip}(); kwargs...)
 end
+
+
+struct ODEAliases <: AbstractAliasSpecifier
+    u0::Union{Bool,Nothing}
+end
+
+function ODEAliases(;u0 = nothing)
+    ODEAliases(u0)
+end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -527,12 +527,12 @@ struct ODEAliasSpecifier <: AbstractAliasSpecifier
 end
 
 """
-    ODEAliases(;alias_u0 = nothing)
+    ODEAliasSpecifier(;alias_u0 = nothing)
 
 Creates an `ODEAliases`, with a default `alias_u0` value of `nothing`.
 When `alias_u0` is `nothing`, the solvers default to not aliasing `u0`.
 """
-function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = nothing, alias = nothing)
+function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
     if alias == true
         ODEAliasSpecifier(true,true,true,true,true)
     elseif alias == false

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -512,12 +512,7 @@ function IncrementingODEProblem{iip}(f::IncrementingODEFunction, u0, tspan,
     ODEProblem(f, u0, tspan, p, IncrementingODEProblem{iip}(); kwargs...)
 end
 
-@doc doc"""
 
-Holds information on what variables to alias
-when solving an ODE. The field `alias_u0` determines whether the initial condition
-will be aliased when the ODE is solved. 
-"""
 struct ODEAliasSpecifier <: AbstractAliasSpecifier
     alias_p::Union{Bool,Nothing}
     alias_f::Union{Bool,Nothing}
@@ -526,13 +521,22 @@ struct ODEAliasSpecifier <: AbstractAliasSpecifier
     alias_tstops::Union{Bool,Nothing}
 end
 
-"""
-    ODEAliasSpecifier(;alias_u0 = nothing)
+@doc doc"""
 
-Creates an `ODEAliases`, with a default `alias_u0` value of `nothing`.
-When `alias_u0` is `nothing`, the solvers default to not aliasing `u0`.
+Holds information on what variables to alias
+when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
+    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+
+### Keywords 
+* `alias_p::Bool`
+* `alias_f::Bool`
+* `alias_u0::Bool = false`: alias the u0 array
+* `alias_du0::Bool = false`: alias the du0 array for DAEs
+* `alias_tstops::Bool = false`: alias the tstops array
+* `alias::Bool`: sets all fields to `alias`
+
 """
-function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+function ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
     if alias == true
         ODEAliasSpecifier(true,true,true,true,true)
     elseif alias == false

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -154,3 +154,9 @@ end
 
 isinplace(f::OptimizationFunction{iip}) where {iip} = iip
 isinplace(f::OptimizationProblem{iip}) where {iip} = iip
+
+struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+    
+end

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -158,5 +158,15 @@ isinplace(f::OptimizationProblem{iip}) where {iip} = iip
 struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
     alias_p
     alias_f
-    
+    alias_u0
+end
+
+function OptimizationAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    if alias == true
+        OptimizationAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        OptimizationAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        OptimizationAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+    end
 end

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -161,11 +161,25 @@ struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
     alias_u0
 end
 
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier interface. 
+    OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias::Union{Bool, Nothing}`: sets all fields of the `OptimizationAliasSpecifier` to `alias`
+
+"""
 function OptimizationAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
     if alias == true
-        OptimizationAliasSpecifier(true, true, true, true, true)
+        OptimizationAliasSpecifier(true, true, true)
     elseif alias == false
-        OptimizationAliasSpecifier(false, false, false, false, false)
+        OptimizationAliasSpecifier(false, false, false)
     elseif isnothing(alias)
         OptimizationAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
     end

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -166,7 +166,7 @@ end
 
 Holds information on what variables to alias
 when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier interface. 
-    OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)
+    `OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)`
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -155,13 +155,6 @@ end
 isinplace(f::OptimizationFunction{iip}) where {iip} = iip
 isinplace(f::OptimizationProblem{iip}) where {iip} = iip
 
-struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
-    alias_u0
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -175,12 +168,22 @@ when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier inte
 * `alias::Union{Bool, Nothing}`: sets all fields of the `OptimizationAliasSpecifier` to `alias`
 
 """
-function OptimizationAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
-    if alias == true
-        OptimizationAliasSpecifier(true, true, true)
-    elseif alias == false
-        OptimizationAliasSpecifier(false, false, false)
-    elseif isnothing(alias)
-        OptimizationAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+
+    function OptimizationAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true)
+        elseif alias == false
+            new(false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_tstops)
+        end
     end
 end
+
+
+

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -95,4 +95,34 @@ end
 struct RODEAliasSpecifier <: AbstractAliasSpecifier
     alias_p
     alias_f
+    alias_u0
+    alias_du0
+    alias_tstops
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an RODEProblem. Conforms to the AbstractAliasSpecifier interface. 
+    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `RODEAliasSpecifier` to `alias`
+
+"""
+function RODEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        RODEAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        RODEAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        RODEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
 end

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -105,7 +105,9 @@ end
 
 Holds information on what variables to alias
 when solving an RODEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+    `RODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -92,15 +92,6 @@ function RODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
 end
 
 
-struct RODEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
-    alias_u0
-    alias_du0
-    alias_tstops
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -118,13 +109,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `RODEAliasSpecifier` to `alias`
 
 """
-function RODEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        RODEAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        RODEAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        RODEAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+
+struct RODEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function RODEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -90,3 +90,9 @@ end
 function RODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     RODEProblem(RODEFunction(f), u0, tspan, p; kwargs...)
 end
+
+
+struct RODEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -174,14 +174,6 @@ end
 
 SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob.h
 
-struct SDDEAliasSpecifier
-    alias_p
-    alias_f
-    alias_u0
-    alias_tstops
-end
-
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -197,16 +189,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDDEAliasSpecifier` to `alias`
 
-
-
 """
-function SDDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        SDDEAliasSpecifier(true, true, true, true)
-    elseif alias == false
-        SDDEAliasSpecifier(false, false, false, false)
-    elseif isnothing(alias)
-        SDDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+struct SDDEAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function SDDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_tstops)
+        end
     end
 end
+
+
+

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -177,4 +177,34 @@ SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob
 struct SDDEAliasSpecifier
     alias_p
     alias_f
+    alias_u0
+    alias_tstops
+end
+
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an SDDEProblem. Conforms to the AbstractAliasSpecifier interface. 
+    SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `SDDEAliasSpecifier` to `alias`
+
+
+
+"""
+function SDDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        SDDEAliasSpecifier(true, true, true, true)
+    elseif alias == false
+        SDDEAliasSpecifier(false, false, false, false)
+    elseif isnothing(alias)
+        SDDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+    end
 end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -173,3 +173,8 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: SDDEProblem}
 end
 
 SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob.h
+
+struct SDDEAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -186,7 +186,9 @@ end
 
 Holds information on what variables to alias
 when solving an SDDEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -215,3 +215,8 @@ function DynamicalSDEProblem{iip}(f::DynamicalSDEFunction, v0, u0, tspan,
     end
     SDEProblem(_f, ArrayPartition(v0, u0), tspan, p; kwargs...)
 end
+
+struct SDEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -216,11 +216,6 @@ function DynamicalSDEProblem{iip}(f::DynamicalSDEFunction, v0, u0, tspan,
     SDEProblem(_f, ArrayPartition(v0, u0), tspan, p; kwargs...)
 end
 
-struct SDEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
-end
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -237,13 +232,22 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDEAliasSpecifier` to `alias`
 
 """
-function SDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        SDDEAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        SDDEAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        SDDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+struct SDEAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function SDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_tstops)
+        end
     end
 end
+
+

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -225,7 +225,9 @@ end
 
 Holds information on what variables to alias
 when solving an SDEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)
+    `SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -220,3 +220,28 @@ struct SDEAliasSpecifier <: AbstractAliasSpecifier
     alias_p
     alias_f
 end
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving an SDEProblem. Conforms to the AbstractAliasSpecifier interface. 
+    SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `SDEAliasSpecifier` to `alias`
+
+"""
+function SDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        SDDEAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        SDDEAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        SDDEAliasSpecifier(alias_p, alias_f, alias_u0, alias_tstops)
+    end
+end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -123,6 +123,35 @@ function SteadyStateProblem(prob::AbstractODEProblem)
 end
 
 struct SteadyStateAliasSpecifier <: AbstractAliasSpecifier
-    alias_p
-    alias_f
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+end
+
+@doc doc"""
+
+Holds information on what variables to alias
+when solving a SteadyStateProblem. Conforms to the AbstractAliasSpecifier interface. 
+    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+
+### Keywords 
+* `alias_p::Union{Bool, Nothing}`
+* `alias_f::Union{Bool, Nothing}`
+* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
+* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias::Union{Bool, Nothing}`: sets all fields of the `SteadStateAliasSpecifier` to `alias`
+
+"""
+function SteadyStateAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    if alias == true
+        SteadyStateAliasSpecifier(true, true, true, true, true)
+    elseif alias == false
+        SteadyStateAliasSpecifier(false, false, false, false, false)
+    elseif isnothing(alias)
+        SteadyStateAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+    end
 end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -121,3 +121,8 @@ Define a steady state problem from a standard ODE problem.
 function SteadyStateProblem(prob::AbstractODEProblem)
     SteadyStateProblem{isinplace(prob)}(prob.f, prob.u0, prob.p; prob.kwargs...)
 end
+
+struct SteadyStateAliasSpecifier <: AbstractAliasSpecifier
+    alias_p
+    alias_f
+end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -134,7 +134,9 @@ end
 
 Holds information on what variables to alias
 when solving a SteadyStateProblem. Conforms to the AbstractAliasSpecifier interface. 
-    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    `SteadyStateAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
+
+When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -122,14 +122,6 @@ function SteadyStateProblem(prob::AbstractODEProblem)
     SteadyStateProblem{isinplace(prob)}(prob.f, prob.u0, prob.p; prob.kwargs...)
 end
 
-struct SteadyStateAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-end
-
 @doc doc"""
 
 Holds information on what variables to alias
@@ -147,13 +139,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SteadStateAliasSpecifier` to `alias`
 
 """
-function SteadyStateAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-        alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
-    if alias == true
-        SteadyStateAliasSpecifier(true, true, true, true, true)
-    elseif alias == false
-        SteadyStateAliasSpecifier(false, false, false, false, false)
-    elseif isnothing(alias)
-        SteadyStateAliasSpecifier(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+struct SteadyStateAliasSpecifier <: AbstractAliasSpecifier
+    alias_p::Union{Bool, Nothing}
+    alias_f::Union{Bool, Nothing}
+    alias_u0::Union{Bool, Nothing}
+    alias_du0::Union{Bool, Nothing}
+    alias_tstops::Union{Bool, Nothing}
+
+    function SteadyStateAliasSpecifier(;
+            alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+        if alias == true
+            new(true, true, true, true, true)
+        elseif alias == false
+            new(false, false, false, false, false)
+        elseif isnothing(alias)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+        end
     end
 end
+
+


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context
This adds the abstract type `AbstractAliasSpecifier` and the concrete subtypes `ODEAliases` and `LinearAliases` meant to hold information on which variables to alias when solving the problems. When an alias specifier is true, that variable is aliased, and vice versa for false. When the alias specifier is `nothing`, the solvers default behavior is used. 

Also bumps the minor version since this is a new feature.