### PR TITLE
fix: fix `remake` for parameters dependent on observed variables

### DIFF
--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -219,3 +219,13 @@ end
     @test newoprob.ps[k] == [2.0, 3.0, 4.0, 5.0]
     @test newoprob[V] == [1.5, 2.5]
 end
+
+@testset "remake with parameter dependent on observed" begin
+    @variables x(t) y(t)
+    @parameters p = x + y
+    @mtkbuild sys = ODESystem([D(x) ~ x, p ~ x + y], t)
+    prob = ODEProblem(sys, [x => 1.0, y => 2.0], (0.0, 1.0))
+    @test prob.ps[p] ≈ 3.0
+    prob2 = remake(prob; u0 = [y => 3.0], p = Dict())
+    @test prob2.ps[p] ≈ 4.0
+end


### PR DESCRIPTION
@isaacsas @TorkelE this should fix the `remake` issue you were having with conservation laws.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
