### PR TITLE
feat: add fields to `OverrideInit`, better `nlsolve_alg` handling 

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -85,4 +85,4 @@ jobs:
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/src/ODE_nlsolve.jl
+++ b/src/ODE_nlsolve.jl
@@ -43,4 +43,3 @@ struct ODE_NLProbData{NLProb, UNLProb, NLProbMap, NLProbPmap}
     """
     nlprobpmap::NLProbPmap
 end
-

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -351,13 +351,14 @@ struct CheckInit <: DAEInitializationAlgorithm end
 """
 $(TYPEDEF)
 """
-struct OverrideInit{T, F} <: DAEInitializationAlgorithm
-    abstol::T
+struct OverrideInit{T1, T2, F} <: DAEInitializationAlgorithm
+    abstol::T1
+    reltol::T2
     nlsolve::F
 end
 
-function OverrideInit(; abstol = 1e-10, nlsolve = nothing)
-    OverrideInit(abstol, nlsolve)
+function OverrideInit(; abstol = nothing, reltol = nothing, nlsolve = nothing)
+    OverrideInit(abstol, reltol, nlsolve)
 end
 OverrideInit(abstol) = OverrideInit(; abstol = abstol, nlsolve = nothing)
 

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -21,7 +21,7 @@ import CommonSolve: solve, init, step!, solve!
 import FunctionWrappersWrappers
 import RuntimeGeneratedFunctions
 import EnumX
-import ADTypes: AbstractADType
+import ADTypes: ADTypes, AbstractADType
 import Accessors: @set, @reset
 using Expronicon.ADT: @match
 
@@ -351,7 +351,15 @@ struct CheckInit <: DAEInitializationAlgorithm end
 """
 $(TYPEDEF)
 """
-struct OverrideInit <: DAEInitializationAlgorithm end
+struct OverrideInit{T, F} <: DAEInitializationAlgorithm
+    abstol::T
+    nlsolve::F
+end
+
+function OverrideInit(; abstol = 1e-10, nlsolve = nothing)
+    OverrideInit(abstol, nlsolve)
+end
+OverrideInit(abstol) = OverrideInit(; abstol = abstol, nlsolve = nothing)
 
 # PDE Discretizations
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -182,7 +182,11 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
         initdata.update_initializeprob!(initprob, valp)
     end
 
-    nlsol = solve(initprob, nlsolve_alg; abstol = alg.abstol)
+    if alg.abstol !== nothing
+        nlsol = solve(initprob, nlsolve_alg; abstol = alg.abstol)
+    else
+        nlsol = solve(initprob, nlsolve_alg)
+    end
 
     u0 = initdata.initializeprobmap(nlsol)
     if initdata.initializeprobpmap !== nothing

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -115,7 +115,8 @@ function get_initial_values(
     tmp = _evaluate_f_ode(integrator, f, isinplace, u0, p, t)
     tmp .= ArrayInterface.restructure(tmp, algebraic_eqs .* _vec(tmp))
 
-    normresid = integrator.opts.internalnorm(tmp, t)
+    normresid = isdefined(integrator.opts, :internalnorm) ?
+                integrator.opts.internalnorm(tmp, t) : norm(tmp)
     if normresid > integrator.opts.abstol
         throw(CheckInitFailureError(normresid, integrator.opts.abstol))
     end
@@ -144,7 +145,8 @@ function get_initial_values(
     t = current_time(integrator)
 
     resid = _evaluate_f_dae(integrator, f, isinplace, integrator.du, u0, p, t)
-    normresid = integrator.opts.internalnorm(resid, t)
+    normresid = isdefined(integrator.opts, :internalnorm) ?
+                integrator.opts.internalnorm(resid, t) : norm(resid)
     if normresid > integrator.opts.abstol
         throw(CheckInitFailureError(normresid, integrator.opts.abstol))
     end

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -160,7 +160,7 @@ argument, failing which this function will throw an error. The success value ret
 depends on the success of the nonlinear solve.
 """
 function get_initial_values(prob, valp, f, alg::OverrideInit,
-        isinplace::Union{Val{true}, Val{false}}; nlsolve_alg = nothing, kwargs...)
+        iip::Union{Val{true}, Val{false}}; nlsolve_alg = nothing, kwargs...)
     u0 = state_values(valp)
     p = parameter_values(valp)
 
@@ -171,7 +171,8 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
     initdata::OverrideInitData = f.initialization_data
     initprob = initdata.initializeprob
 
-    if nlsolve_alg === nothing
+    nlsolve_alg = something(nlsolve_alg, alg.nlsolve, Some(nothing))
+    if nlsolve_alg === nothing && state_values(initprob) !== nothing
         throw(OverrideInitMissingAlgorithm())
     end
 
@@ -179,7 +180,7 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
         initdata.update_initializeprob!(initprob, valp)
     end
 
-    nlsol = solve(initprob, nlsolve_alg)
+    nlsol = solve(initprob, nlsolve_alg; abstol = alg.abstol)
 
     u0 = initdata.initializeprobmap(nlsol)
     if initdata.initializeprobpmap !== nothing

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -100,7 +100,8 @@ Check if the algebraic constraints are satisfied, and error if they aren't. Retu
 the `u0` and `p` as-is, and is always successful if it returns. Valid only for
 `ODEProblem` and `DAEProblem`. Requires a `DEIntegrator` as its second argument.
 """
-function get_initial_values(prob::AbstractODEProblem, integrator, f, alg::CheckInit,
+function get_initial_values(
+        prob::AbstractDEProblem, integrator::DEIntegrator, f, alg::CheckInit,
         isinplace::Union{Val{true}, Val{false}}; kwargs...)
     u0 = state_values(integrator)
     p = parameter_values(integrator)
@@ -109,7 +110,7 @@ function get_initial_values(prob::AbstractODEProblem, integrator, f, alg::CheckI
 
     algebraic_vars = [all(iszero, x) for x in eachcol(M)]
     algebraic_eqs = [all(iszero, x) for x in eachrow(M)]
-    (iszero(algebraic_vars) || iszero(algebraic_eqs)) && return
+    (iszero(algebraic_vars) || iszero(algebraic_eqs)) && return u0, p, true
     update_coefficients!(M, u0, p, t)
     tmp = _evaluate_f_ode(integrator, f, isinplace, u0, p, t)
     tmp .= ArrayInterface.restructure(tmp, algebraic_eqs .* _vec(tmp))
@@ -135,7 +136,8 @@ function _evaluate_f_dae(integrator, f, isinplace::Val{false}, args...)
     return f(args...)
 end
 
-function get_initial_values(prob::AbstractDAEProblem, integrator, f, alg::CheckInit,
+function get_initial_values(
+        prob::AbstractDAEProblem, integrator::DEIntegrator, f, alg::CheckInit,
         isinplace::Union{Val{true}, Val{false}}; kwargs...)
     u0 = state_values(integrator)
     p = parameter_values(integrator)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -401,7 +401,8 @@ numerically-defined functions.
 """
 struct ODEFunction{iip, specialize, F, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, WP, TPJ,
     O, TCV,
-    SYS, ID<:Union{Nothing, OverrideInitData}, NLP<:Union{Nothing, ODE_NLProbData}} <: AbstractODEFunction{iip}
+    SYS, ID <: Union{Nothing, OverrideInitData}, NLP <: Union{Nothing, ODE_NLProbData}} <:
+       AbstractODEFunction{iip}
     f::F
     mass_matrix::TMM
     analytic::Ta
@@ -522,7 +523,8 @@ information on generating the SplitFunction from this symbolic engine.
 """
 struct SplitFunction{
     iip, specialize, F1, F2, TMM, C, Ta, Tt, TJ, JVP, VJP, JP, WP, SP, TW, TWt,
-    TPJ, O, TCV, SYS, ID<:Union{Nothing, OverrideInitData}, NLP<:Union{Nothing, ODE_NLProbData}} <: AbstractODEFunction{iip}
+    TPJ, O, TCV, SYS, ID <: Union{Nothing, OverrideInitData},
+    NLP <: Union{Nothing, ODE_NLProbData}} <: AbstractODEFunction{iip}
     f1::F1
     f2::F2
     mass_matrix::TMM
@@ -2442,7 +2444,7 @@ function ODEFunction{iip, specialize}(f;
         initializeprobpmap = __has_initializeprobpmap(f) ? f.initializeprobpmap : nothing,
         initialization_data = __has_initialization_data(f) ? f.initialization_data :
                               nothing,
-        nlprob_data = __has_nlprob_data(f) ? f.nlprob_data : nothing,
+        nlprob_data = __has_nlprob_data(f) ? f.nlprob_data : nothing
 ) where {iip,
         specialize
 }
@@ -2500,7 +2502,8 @@ function ODEFunction{iip, specialize}(f;
             typeof(sparsity), Any, Any, typeof(W_prototype), Any,
             Any,
             typeof(_colorvec),
-            typeof(sys), Union{Nothing, OverrideInitData}, Union{Nothing, ODE_NLProbData}}(_f, mass_matrix, analytic, tgrad, jac,
+            typeof(sys), Union{Nothing, OverrideInitData}, Union{Nothing, ODE_NLProbData}}(
+            _f, mass_matrix, analytic, tgrad, jac,
             jvp, vjp, jac_prototype, sparsity, Wfact,
             Wfact_t, W_prototype, paramjac,
             observed, _colorvec, sys, initdata, nlprob_data)
@@ -2770,7 +2773,8 @@ function SplitFunction{iip, specialize}(f1, f2;
     if specialize === NoSpecialize
         SplitFunction{iip, specialize, Any, Any, Any, Any, Any, Any, Any, Any, Any,
             Any, Any, Any, Any, Any, Any, Any,
-            Any, Any, Union{Nothing, OverrideInitData}, Union{Nothing, ODE_NLProbData}}(f1, f2, mass_matrix, _func_cache,
+            Any, Any, Union{Nothing, OverrideInitData}, Union{Nothing, ODE_NLProbData}}(
+            f1, f2, mass_matrix, _func_cache,
             analytic,
             tgrad, jac, jvp, vjp, jac_prototype, W_prototype,
             sparsity, Wfact, Wfact_t, paramjac,

--- a/test/downstream/initialization.jl
+++ b/test/downstream/initialization.jl
@@ -1,0 +1,60 @@
+using OrdinaryDiffEq, Sundials, SciMLBase, Test
+
+@testset "CheckInit" begin
+    @testset "Sundials + ODEProblem" begin
+        function rhs(u, p, t)
+            return [u[1] * t, u[1]^2 - u[2]^2]
+        end
+        function rhs!(du, u, p, t)
+            du[1] = u[1] * t
+            du[2] = u[1]^2 - u[2]^2
+        end
+
+        oopfn = ODEFunction{false}(rhs, mass_matrix = [1 0; 0 0])
+        iipfn = ODEFunction{true}(rhs!, mass_matrix = [1 0; 0 0])
+
+        @testset "Inplace = $(SciMLBase.isinplace(f))" for f in [oopfn, iipfn]
+            prob = ODEProblem(f, [1.0, 1.0], (0.0, 1.0))
+            integ = init(prob, Sundials.ARKODE())
+            u0, _, success = SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+            @test success
+            @test u0 == prob.u0
+
+            integ.u[2] = 2.0
+            @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+        end
+    end
+
+    @testset "Sundials + DAEProblem" begin
+        function daerhs(du, u, p, t)
+            return [du[1] - u[1] * t - p, u[1]^2 - u[2]^2]
+        end
+        function daerhs!(resid, du, u, p, t)
+            resid[1] = du[1] - u[1] * t - p
+            resid[2] = u[1]^2 - u[2]^2
+        end
+
+        oopfn = DAEFunction{false}(daerhs)
+        iipfn = DAEFunction{true}(daerhs!)
+
+        @testset "Inplace = $(SciMLBase.isinplace(f))" for f in [oopfn, iipfn]
+            prob = DAEProblem(f, [1.0, 0.0], [1.0, 1.0], (0.0, 1.0), 1.0)
+            integ = init(prob, Sundials.IDA())
+            u0, _, success = SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+            @test success
+            @test u0 == prob.u0
+
+            integ.u[2] = 2.0
+            @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+
+            integ.u[2] = 1.0
+            integ.du[1] = 2.0
+            @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+        end
+    end
+end

--- a/test/downstream/initialization.jl
+++ b/test/downstream/initialization.jl
@@ -1,6 +1,7 @@
 using OrdinaryDiffEq, Sundials, SciMLBase, Test
 
 @testset "CheckInit" begin
+    abstol = 1e-10
     @testset "Sundials + ODEProblem" begin
         function rhs(u, p, t)
             return [u[1] * t, u[1]^2 - u[2]^2]
@@ -17,13 +18,13 @@ using OrdinaryDiffEq, Sundials, SciMLBase, Test
             prob = ODEProblem(f, [1.0, 1.0], (0.0, 1.0))
             integ = init(prob, Sundials.ARKODE())
             u0, _, success = SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)); abstol)
             @test success
             @test u0 == prob.u0
 
             integ.u[2] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)); abstol)
         end
     end
 
@@ -43,18 +44,18 @@ using OrdinaryDiffEq, Sundials, SciMLBase, Test
             prob = DAEProblem(f, [1.0, 0.0], [1.0, 1.0], (0.0, 1.0), 1.0)
             integ = init(prob, Sundials.IDA())
             u0, _, success = SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)); abstol)
             @test success
             @test u0 == prob.u0
 
             integ.u[2] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)); abstol)
 
             integ.u[2] = 1.0
             integ.du[1] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)); abstol)
         end
     end
 end

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -17,13 +17,15 @@ using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterfac
             prob = ODEProblem(f, [1.0, 1.0], (0.0, 1.0))
             integ = init(prob)
             u0, _, success = SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
             @test success
             @test u0 == prob.u0
 
             integ.u[2] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
         end
     end
 
@@ -43,18 +45,21 @@ using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterfac
             prob = DAEProblem(f, [1.0, 0.0], [1.0, 1.0], (0.0, 1.0), 1.0)
             integ = init(prob, DImplicitEuler())
             u0, _, success = SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
             @test success
             @test u0 == prob.u0
 
             integ.u[2] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
 
             integ.u[2] = 1.0
             integ.du[1] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
         end
     end
 
@@ -86,13 +91,15 @@ using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterfac
             prob = SDEProblem(f, [1.0, 1.0, -1.0], (0.0, 1.0))
             integ = init(prob, ImplicitEM())
             u0, _, success = SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
             @test success
             @test u0 == prob.u0
 
             integ.u[2] = 2.0
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
-                prob, integ, f, SciMLBase.CheckInit(), Val(SciMLBase.isinplace(f)))
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(SciMLBase.isinplace(f)); abstol = 1e-10)
         end
     end
 end
@@ -138,11 +145,13 @@ end
             prob, integ, fn, SciMLBase.OverrideInit(), Val(false))
     end
 
+    abstol = 1e-10
+    reltol = 1e-10
     @testset "Solves" begin
         @testset "with explicit alg" begin
             u0, p, success = SciMLBase.get_initial_values(
                 prob, integ, fn, SciMLBase.OverrideInit(),
-                Val(false); nlsolve_alg = NewtonRaphson())
+                Val(false); nlsolve_alg = NewtonRaphson(), abstol, reltol)
 
             @test u0 ≈ [2.0, 2.0]
             @test p ≈ 1.0
@@ -152,7 +161,8 @@ end
         end
         @testset "with alg in `OverrideInit`" begin
             u0, p, success = SciMLBase.get_initial_values(
-                prob, integ, fn, SciMLBase.OverrideInit(nlsolve = NewtonRaphson()),
+                prob, integ, fn,
+                SciMLBase.OverrideInit(; nlsolve = NewtonRaphson(), abstol, reltol),
                 Val(false))
 
             @test u0 ≈ [2.0, 2.0]
@@ -170,7 +180,7 @@ end
             _integ = init(_prob; initializealg = NoInit())
 
             u0, p, success = SciMLBase.get_initial_values(
-                _prob, _integ, _fn, SciMLBase.OverrideInit(), Val(false))
+                _prob, _integ, _fn, SciMLBase.OverrideInit(), Val(false); abstol, reltol)
 
             @test u0 ≈ [1.0, 1.0]
             @test p ≈ 1.0
@@ -182,7 +192,7 @@ end
         _integ = ProblemState(; u = integ.u, p = parameter_values(integ), t = integ.t)
         u0, p, success = SciMLBase.get_initial_values(
             prob, _integ, fn, SciMLBase.OverrideInit(),
-            Val(false); nlsolve_alg = NewtonRaphson())
+            Val(false); nlsolve_alg = NewtonRaphson(), abstol, reltol)
 
         @test u0 ≈ [2.0, 2.0]
         @test p ≈ 1.0
@@ -199,7 +209,7 @@ end
 
         u0, p, success = SciMLBase.get_initial_values(
             prob, integ, fn, SciMLBase.OverrideInit(),
-            Val(false); nlsolve_alg = NewtonRaphson())
+            Val(false); nlsolve_alg = NewtonRaphson(), abstol, reltol)
         @test u0 ≈ [1.0, 1.0]
         @test p ≈ 1.0
         @test success
@@ -213,7 +223,7 @@ end
 
         u0, p, success = SciMLBase.get_initial_values(
             prob, integ, fn, SciMLBase.OverrideInit(),
-            Val(false); nlsolve_alg = NewtonRaphson())
+            Val(false); nlsolve_alg = NewtonRaphson(), abstol, reltol)
 
         @test u0 ≈ [2.0, 2.0]
         @test p ≈ 0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,6 +121,9 @@ end
         @time @safetestset "Tables interface with MTK" begin
             include("downstream/tables.jl")
         end
+        @time @safetestset "Initialization" begin
+            include("downstream/initialization.jl")
+        end
     end
 
     if !is_APPVEYOR && (GROUP == "Downstream" || GROUP == "SymbolicIndexingInterface")


### PR DESCRIPTION
This replaces `default_nlsolve` in OrdinaryDiffEq, and will have methods in NonlinearSolve which can then be leveraged by all libraries for initialization.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
