### PR TITLE
trial better ode wrapper

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -198,7 +198,12 @@ function ODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     iip = isinplace(f, 4)
     _u0 = prepare_initial_state(u0)
     _tspan = promote_tspan(tspan)
-    _f = ODEFunction{iip, DEFAULT_SPECIALIZATION}(f)
+    _f = if iip
+        out = copy(u0) # TODO: do this properly
+        ODEFunction{iip, FullSpecialize}(DUMB_WRAPPER(out, u0, p, first(_tspan), ODE_F_WRAPPER(f)))
+    else
+        _f = ODEFunction{iip, DEFAULT_SPECIALIZATION}(f)
+    end
     ODEProblem(_f, _u0, _tspan, p; kwargs...)
 end
 

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -199,7 +199,6 @@ function ODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     _u0 = prepare_initial_state(u0)
     _tspan = promote_tspan(tspan)
     _f = if iip
-        out = copy(u0) # TODO: do this properly
         ODEFunction{iip, FullSpecialize}(DUMB_WRAPPER(p, first(_tspan), ODE_F_WRAPPER(f)))
     else
         _f = ODEFunction{iip, DEFAULT_SPECIALIZATION}(f)

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -200,7 +200,7 @@ function ODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     _tspan = promote_tspan(tspan)
     _f = if iip
         out = copy(u0) # TODO: do this properly
-        ODEFunction{iip, FullSpecialize}(DUMB_WRAPPER(out, u0, p, first(_tspan), ODE_F_WRAPPER(f)))
+        ODEFunction{iip, FullSpecialize}(DUMB_WRAPPER(p, first(_tspan), ODE_F_WRAPPER(f)))
     else
         _f = ODEFunction{iip, DEFAULT_SPECIALIZATION}(f)
     end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2415,8 +2415,31 @@ end
 (f::BVPFunction)(args...) = f.f(args...)
 (f::DynamicalBVPFunction)(args...) = f.f(args...)
 
-######### Basic Constructor
+#### fun hack to make NOSPECIALIZE fast
+mutable struct ODE_F_WRAPPER{F}
+    const f::F
+end
+mutable struct DUMB_WRAPPER{OUT, U, P, T}
+    out::OUT
+    u::U
+    p::P
+    t::T
+    f::ODE_F_WRAPPER
+end
+function (w::ODE_F_WRAPPER)(d::DUMB_WRAPPER)
+    w.f(d.out, d.u, d.p, d.t)
+    return nothing
+end
+function (w::DUMB_WRAPPER)(out, u, p, t)
+    w.out = out
+    w.u = u
+    w.p = p
+    w.t = t
+    w.f(w)
+    return nothing
+end
 
+######### Basic Constructor
 function ODEFunction{iip, specialize}(f;
         mass_matrix = __has_mass_matrix(f) ? f.mass_matrix :
                       I,

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2419,23 +2419,19 @@ end
 mutable struct ODE_F_WRAPPER{F}
     const f::F
 end
-mutable struct DUMB_WRAPPER{OUT, U, P, T}
-    out::OUT
-    u::U
+mutable struct DUMB_WRAPPER{P, T}
     p::P
     t::T
     f::ODE_F_WRAPPER
 end
-function (w::ODE_F_WRAPPER)(d::DUMB_WRAPPER)
-    w.f(d.out, d.u, d.p, d.t)
+function (w::ODE_F_WRAPPER)(out, u, d::DUMB_WRAPPER)
+    w.f(out, u, d.p, d.t)
     return nothing
 end
 function (w::DUMB_WRAPPER)(out, u, p, t)
-    w.out = out
-    w.u = u
     w.p = p
     w.t = t
-    w.f(w)
+    w.f(out, u, w)
     return nothing
 end
 


### PR DESCRIPTION
This is a prototype of a replacement for FunctionWrappersWrappers specialization of ODEs. It works by not specializing the function, and wrapping the `p` and `t` fields to prevent them from needing to be boxed. This still has some overhead, and doesn't work for derivatives with respect to t or p, but it will work with arbitrary chunksizes for the jacobians.
```
julia> prob = ODEProblem{true}(lorenz!, [1.0; 0.0; 0.0], (0,100.0)) # FunctionWrapperWrapper
julia> @btime  solve(prob, Tsit5(), save_everystep=false);
  221.112 μs (74 allocations: 3.98 KiB)
julia> prob2 = ODEProblem(lorenz!, [1.0; 0.0; 0.0], (0,100.0)) # new wrapper
julia> @btime  solve(prob2, Tsit5(), save_everystep=false);
  254.728 μs (61 allocations: 3.48 KiB)
```