### PR TITLE
fix: handle `I` as mass matrix for `CheckInit`

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -123,6 +123,7 @@ function get_initial_values(
     t = current_time(integrator)
     M = f.mass_matrix
 
+    M == I && return u0, p, true
     algebraic_vars = [all(iszero, x) for x in eachcol(M)]
     algebraic_eqs = [all(iszero, x) for x in eachrow(M)]
     (iszero(algebraic_vars) || iszero(algebraic_eqs)) && return u0, p, true

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -385,7 +385,7 @@ and below.
 !!! warn
     While `explictfuns![i]` could in theory use `sols[i+1]` in its computation,
     these values will not be updated. It is thus the contract of the interface
-    to not use those values except for as caches to be overriden.
+    to not use those values except for as caches to be overridden.
 
 !!! note
     prob.probs[i].p can be aliased with each other as a performance / memory

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -1,4 +1,5 @@
-using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterface, Test
+using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterface,
+      LinearAlgebra, Test
 
 @testset "CheckInit" begin
     @testset "ODEProblem" begin
@@ -26,6 +27,20 @@ using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterfac
             @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
                 prob, integ, f, SciMLBase.CheckInit(),
                 Val(SciMLBase.isinplace(f)); abstol = 1e-10)
+        end
+
+        @testset "With I mass matrix" begin
+            function rhs(u, p, t)
+                return u
+            end
+            prob = ODEProblem(ODEFunction(rhs; mass_matrix = I), ones(2), (0.0, 1.0))
+            integ = init(prob)
+            u0, _, success = SciMLBase.get_initial_values(
+                prob, integ, prob.f, SciMLBase.CheckInit(),
+                Val(false); abstol = 1e-10
+            )
+            @test success
+            @test u0 == prob.u0
         end
     end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
