### PR TITLE
Make CheckInit more informative

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -835,6 +835,8 @@ export ODEFunction, DiscreteFunction, ImplicitDiscreteFunction, SplitFunction, D
 
 export OptimizationFunction, MultiObjectiveOptimizationFunction
 
+export CheckInit
+
 export EnsembleThreads, EnsembleDistributed, EnsembleSplitThreads, EnsembleSerial
 
 export EnsembleAnalysis, EnsembleSummary

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -59,7 +59,17 @@ end
 
 function Base.showerror(io::IO, e::CheckInitFailureError)
     print(io,
-        "CheckInit specified but initialization not satisfied. normresid = $(e.normresid) > abstol = $(e.abstol)")
+        "DAE initialization failed: your u0 did not satisfy the initialization requirements, 
+        normresid = $(e.normresid) > abstol = $(e.abstol). If you wish for the system to 
+        automatically change the algebraic variables to satisfy the algebraic constraints, 
+        please pass `initializealg = BrownBasicInit()` to solve (this option will require 
+        `using OrdinaryDiffEqNonlinearSolve`). If you wish to perform an initialization on the
+        complete u0, please pass initializealg = ShampineCollocationInit() to solve. Note that 
+        initialization can be a very difficult process for DAEs and in many cases can be 
+        numerically intractable without symbolic manipulation of the system. For an automated 
+        system that will generate numerically stable initializations, see ModelingToolkit.jl 
+        structural simplification for more details."
+    )
 end
 
 struct OverrideInitMissingAlgorithm <: Exception end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Follows on from https://github.com/SciML/OrdinaryDiffEq.jl/issues/2513 and https://github.com/SciML/OrdinaryDiffEq.jl/pull/2514 .
This pull request exports `CheckInit` and adds an informative error message for `CheckInit` if supplied initialization isn't incorrect, as discussed in the above pull request.

As far as SciMLBase is concerned, I don't believe this should be breaking in any way. This is required before merging https://github.com/SciML/OrdinaryDiffEq.jl/pull/2514 .
