### PR TITLE
fix: check if `prob.f.sys` exists before accessing it in `remake`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -804,7 +804,7 @@ function updated_u0_p(
     if u0 === missing && p === missing
         return state_values(prob), parameter_values(prob)
     end
-    if prob.f.sys === nothing
+    if has_sys(prob.f) && prob.f.sys === nothing
         if interpret_symbolicmap && eltype(p) !== Union{} && eltype(p) <: Pair
             throw(ArgumentError("This problem does not support symbolic maps with " *
                                 "`remake`, i.e. it does not have a symbolic origin. Please use `remake`" *

--- a/test/downstream/problem_interface.jl
+++ b/test/downstream/problem_interface.jl
@@ -261,12 +261,12 @@ eprob = EnsembleProblem(oprob)
 @test eprob.ps[osys.p] == 0.1
 
 @test state_values(remake(eprob; u0 = [X => 0.1])) == [0.1]
-@test_broken state_values(remake(eprob; u0 = [:X => 0.2])) == [0.2]
+@test state_values(remake(eprob; u0 = [:X => 0.2])) == [0.2]
 @test state_values(remake(eprob; u0 = [osys.X => 0.3])) == [0.3]
 
-@test_broken remake(eprob; p = [d => 0.4]).ps[d] == 0.4
-@test_broken remake(eprob; p = [:d => 0.5]).ps[d] == 0.5
-@test_broken remake(eprob; p = [osys.d => 0.6]).ps[d] == 0.6
+@test remake(eprob; p = [d => 0.4]).ps[d] == 0.4
+@test remake(eprob; p = [:d => 0.5]).ps[d] == 0.5
+@test remake(eprob; p = [osys.d => 0.6]).ps[d] == 0.6
 
 # SteadyStateProblem Indexing
 # Issue#660


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
