### PR TITLE
fix: fix `constructorof` for `NonlinearLeastSquaresProblem`

### DIFF
--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -340,7 +340,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: NonlinearLeastSqu
         else
             iip = isinplace(f, 4)
         end
-        return NonlinearProblem{iip}(f, u0, p; kw...)
+        return NonlinearLeastSquaresProblem{iip}(f, u0, p; kw...)
     end
 end
 

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -1,4 +1,4 @@
-using Test, SciMLBase
+using Test, SciMLBase, SymbolicIndexingInterface, Accessors
 
 function simplependulum!(du, u, p, t)
     θ = u[1]
@@ -12,3 +12,63 @@ function bc!(residual, u, p, t)
 end
 prob_bvp = BVProblem(simplependulum!, bc!, [pi / 2, pi / 2], (0, 1.0))
 @test prob_bvp.tspan === (0.0, 1.0)
+
+@testset "`constructorof` tests" begin
+    probs = []
+
+    function lorenz!(du, u, p, t)
+        du[1] = p[1] * (u[2] - u[1])
+        du[2] = u[1] * (p[2] - u[3]) - u[2]
+        du[3] = u[1] * u[2] - p[3] * u[3]
+    end
+    u0 = [1.0; 2.0; 3.0]
+    du0 = similar(u0)
+    p = [10.0, 20.0, 30.0]
+    tspan = (0.0, 100.0)
+    lorenz!(du0, u0, p, tspan[1])
+    sys = SymbolCache([:x, :y, :z], [:a, :b, :c], :t)
+    fn = ODEFunction(lorenz!; sys)
+    push!(probs, ODEProblem(fn, u0, tspan, p))
+
+    function daelorenz!(resid, du, u, p, t)
+        lorenz!(resid, u, p, t)
+        resid .-= du
+    end
+    fn = DAEFunction(daelorenz!; sys)
+    push!(probs, DAEProblem(fn, du0, u0, tspan, p))
+
+    function ddelorenz!(du, u, h, p, t)
+        du[1] = p[1] * (u[2] - u[1])
+        du[2] = u[1] * (p[2] - u[3]) - u[2]
+        du[3] = u[1] * u[2] - p[3] * u[3]
+    end
+
+    function history(p, t)
+        return u0 .- t
+    end
+
+    fn = DDEFunction(ddelorenz!; sys)
+    push!(probs, DDEProblem(fn, u0, history, tspan, p))
+
+    function noise!(du, u, p, t)
+        du .= 0.1u
+    end
+    fn = SDEFunction(lorenz!, noise!; sys)
+    push!(probs, SDEProblem(fn, u0, tspan, p))
+
+    fn = SDDEFunction(ddelorenz!, noise!; sys)
+    push!(probs, SDDEProblem(fn, noise!, u0, history, tspan, p))
+
+    function nllorenz!(du, u, p)
+        lorenz!(du, u, p, 0.0)
+    end
+
+    fn = NonlinearFunction(nllorenz!; sys)
+    push!(probs, NonlinearProblem(fn, u0, p))
+    push!(probs, NonlinearLeastSquaresProblem(fn, u0, p))
+
+    @testset "$(SciMLBase.parameterless_type(typeof(prob)))" for prob in probs
+        newprob = @reset prob.u0 = u0 .+ 1
+        @test typeof(newprob) == typeof(prob)
+    end
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
