### PR TITLE
Fix the LinearAliasSpecifier constructor

### DIFF
--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -80,14 +80,12 @@ end
 @doc doc"""
 Holds information on what variables to alias
 when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `LinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_A = nothing, alias_b = nothing, alias = nothing)`
+    `LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords
 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
 * `alias_A::Union{Bool, Nothing}`: alias the `A` array.
 * `alias_b::Union{Bool, Nothing}`: alias the `b` array. 
 * `alias::Union{Bool, Nothing}`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
@@ -99,14 +97,13 @@ struct LinearAliasSpecifier <: AbstractAliasSpecifier
     alias_A::Union{Bool,Nothing}
     alias_b::Union{Bool,Nothing}
 
-    function LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing,
-            alias_p = nothing, alias_f = nothing, alias = nothing)
+    function LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
         if alias == true
-            new(true, true, true, true)
+            new(true, true)
         elseif alias == false
-            new(false, false, false, false)
+            new(false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_A, alias_b)
+            new(alias_A, alias_b)
         end
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
