### PR TITLE
Upgrade path for check_error interface conformity

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -632,7 +632,7 @@ function check_error(integrator::DEIntegrator)
         end
         return ReturnCode.Unstable
     end
-    if last_step_failed(integrator)
+    if last_step_failed(integrator) && !isadaptive(integrator)
         if verbose
             @warn("Newton steps could not converge and algorithm is not adaptive. Use a lower dt.")
         end


### PR DESCRIPTION
Precedes #896 to provide an upgrade path for `last_step_failed`