### PR TITLE
Add arguments for alias_noise and alias_jumps for RODEs, SDEs, SDDEs

### DIFF
--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -107,6 +107,7 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
 * `alias_noise::Union{Bool,Nothing}`: alias the noise process
+* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
 * `alias::Union{Bool, Nothing}`: sets all fields of the `RODEAliasSpecifier` to `alias`
 
 """

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -106,6 +106,7 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
 * `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias_noise::Union{Bool,Nothing}`: alias the noise process
 * `alias::Union{Bool, Nothing}`: sets all fields of the `RODEAliasSpecifier` to `alias`
 
 """
@@ -116,15 +117,17 @@ struct RODEAliasSpecifier <: AbstractAliasSpecifier
     alias_u0::Union{Bool, Nothing}
     alias_du0::Union{Bool, Nothing}
     alias_tstops::Union{Bool, Nothing}
+    alias_noise::Union{Bool, Nothing}
+    alias_jumps::Union{Bool, Nothing}
 
     function RODEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+            alias_du0 = nothing, alias_tstops = nothing, alias_noise = nothing, alias_jumps = nothing, alias = nothing)
         if alias == true
-            new(true, true, true, true, true)
+            new(true, true, true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new(false, false, false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops, alias_noise, alias_jumps)
         end
     end
 end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -195,15 +195,16 @@ struct SDDEAliasSpecifier
     alias_f::Union{Bool, Nothing}
     alias_u0::Union{Bool, Nothing}
     alias_tstops::Union{Bool, Nothing}
+    alias_jumps::Union{Bool, Nothing}
 
     function SDDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+            alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
         if alias == true
-            new(true, true, true, true)
+            new(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false)
+            new(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_tstops)
+            new(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end
 end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -187,6 +187,7 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_f::Union{Bool, Nothing}`
 * `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDDEAliasSpecifier` to `alias`
 
 """

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -229,6 +229,7 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias_f::Union{Bool, Nothing}`
 * `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
 * `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDEAliasSpecifier` to `alias`
 
 """

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -237,15 +237,16 @@ struct SDEAliasSpecifier <: AbstractAliasSpecifier
     alias_f::Union{Bool, Nothing}
     alias_u0::Union{Bool, Nothing}
     alias_tstops::Union{Bool, Nothing}
+    alias_jumps::Union{Bool,Nothing}
 
     function SDEAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
-            alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+            alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
         if alias == true
-            new(true, true, true, true)
+            new(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false)
+            new(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_tstops)
+            new(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

SDE, SDDE, RODE problems can choose to alias the jump process when they're wrapped in a JumpProblem, so a kwarg is needed. 

Additionally, RODE problems can choose to alias the noise problem, so that needed to be added as well.
