### PR TITLE
Fix `remake` for `SCCNonlinearProblem`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -824,6 +824,9 @@ function remake(prob::SCCNonlinearProblem; u0 = missing, p = missing, probs = mi
     if probs === missing
         probs = prob.probs
     end
+    if explicitfuns! === missing
+        explicitfuns! = prob.explictfuns!
+    end
     offset = 0
     if u0 !== missing || p !== missing && parameters_alias
         probs = map(probs) do subprob

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -321,6 +321,7 @@ end
     @test state_values(sccprob2) ≈ 2ones(3)
     @test sccprob2.probs[1].u0 ≈ 2ones(2)
     @test sccprob2.probs[2].u0 ≈ 2ones(1)
+    @test sccprob2.explicitfuns! !== missing
 
     sccprob3 = remake(sccprob; p = [σ => 2.0])
     @test sccprob3.p === sccprob3.probs[1].p


### PR DESCRIPTION
It looks like the `explicitfuns!` argument is directly forwarded to the constructor resulting in broken problems after a remake due to `explicitfuns!` being `missing`.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
