### PR TITLE
feat: allow `initializeprobmap` to be `nothing`

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -19,7 +19,8 @@ struct OverrideInitData{IProb, UIProb, IProbMap, IProbPmap}
     update_initializeprob!::UIProb
     """
     A function which takes the solution of `initializeprob` and returns
-    the state vector of the original problem.
+    the state vector of the original problem. If absent, the existing state vector
+    will be used.
     """
     initializeprobmap::IProbMap
     """
@@ -260,7 +261,9 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
         success = SciMLBase.successful_retcode(nlsol)
     end
 
-    u0 = initdata.initializeprobmap(nlsol)
+    if initdata.initializeprobmap !== nothing
+        u0 = initdata.initializeprobmap(nlsol)
+    end
     if initdata.initializeprobpmap !== nothing
         p = initdata.initializeprobpmap(valp, nlsol)
     end

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -230,6 +230,21 @@ end
         @test success
     end
 
+    @testset "Solves without `initializeprobmap`" begin
+        initdata = SciMLBase.@set initialization_data.initializeprobmap = nothing
+        fn = ODEFunction(rhs2; initialization_data = initdata)
+        prob = ODEProblem(fn, [2.0, 0.0], (0.0, 1.0), 0.0)
+        integ = init(prob; initializealg = NoInit())
+
+        u0, p, success = SciMLBase.get_initial_values(
+            prob, integ, fn, SciMLBase.OverrideInit(),
+            Val(false); nlsolve_alg = NewtonRaphson(), abstol, reltol)
+
+        @test u0 ≈ [2.0, 0.0]
+        @test p ≈ 1.0
+        @test success
+    end
+
     @testset "Solves without `initializeprobpmap`" begin
         initdata = SciMLBase.@set initialization_data.initializeprobpmap = nothing
         fn = ODEFunction(rhs2; initialization_data = initdata)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
