### PR TITLE
Reference SavedSubsystem in docs

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -104,7 +104,7 @@ https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/
   successfully, whether it terminated early due to a user-defined callback, or whether it
   exited due to an error. For more details, see
   [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
-- `saved_subsystem`: a [`SavedSubsystem`](@ref) representing the subset of variables saved
+- `saved_subsystem`: a [`SciMLBase.SavedSubsystem`](@ref) representing the subset of variables saved
   in this solution, or `nothing` if all variables are saved. Here "variables" refers to
   both continuous-time state variables and timeseries parameters.
 """


### PR DESCRIPTION
Fixes 

```

┌ Error: Cannot resolve @ref for md"[`SavedSubsystem`](@ref)" in src/types/ode_types.md.
│ - No docstring found in doc for binding `SciMLBase.SavedSubsystem`.
│ - No docstring found in doc for binding `Main.SavedSubsystem`.
└ @ Documenter ~/.cache/julia-buildkite-plugin/depots/0185fce3-4489-413a-a934-123dd653ef61/packages/Documenter/Bs999/src/utilities/utilities.jl:44
```
