### PR TITLE
feat: support `NoInit` in `get_initial_values`

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -271,6 +271,16 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
     return u0, p, success
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Do not run any initialization routine, and simply return the state and parameter values
+stored in `integrator` successfully.
+"""
+function get_initial_values(prob, integrator, f, ::NoInit, iip; kwargs...)
+    return state_values(integrator), parameter_values(integrator), true
+end
+
 is_trivial_initialization(::Nothing) = true
 
 function is_trivial_initialization(initdata::OverrideInitData)

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -286,3 +286,13 @@ end
         @test success
     end
 end
+
+@testset "NoInit" begin
+    prob = ODEProblem(ones(2), (0.0, 1.0), ones(2)) do u, p, t
+        return u
+    end
+    u, p, success = SciMLBase.get_initial_values(prob, prob, prob.f, SciMLBase.NoInit(), Val(true))
+    @test u == ones(2)
+    @test p == ones(2)
+    @test success
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
