### PR TITLE
fix: handle `:var => nothing` provided to `remake`

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -986,6 +986,7 @@ function fill_vars(
     end
     for (k, v) in varmap
         haskey(sym_to_idx, k) && continue
+        v === nothing && continue
         newvals[k] = v
     end
     return newvals

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -397,3 +397,12 @@ end
     # old value retained
     @test prob2.ps[Gamma] ≈ 3.0
 end
+
+@testset "`nothing` value for variable specified as `Symbol`" begin
+    @variables x(t) [guess = 1.0] y(t) [guess = 1.0]
+    @parameters p [guess = 1.0] q [guess = 1.0]
+    @mtkbuild sys = ODESystem(
+        [D(x) ~ p * x + q * y, y ~ 2x], t; parameter_dependencies = [q ~ 2p])
+    prob = ODEProblem(sys, [:x => 1.0], (0.0, 1.0), [p => 1.0])
+    @test_nowarn remake(prob; u0 = [:y => 1.0, :x => nothing])
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
