### PR TITLE
fix: make sure remake(::SCCNonlinearProblem) doesn't drop prob.f.sys

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -833,6 +833,9 @@ function remake(prob::SCCNonlinearProblem; u0 = missing, p = missing, probs = mi
     if explicitfuns! === missing
         explicitfuns! = prob.explictfuns!
     end
+    if sys === missing
+        sys = prob.f.sys
+    end
     offset = 0
     if u0 !== missing || p !== missing && parameters_alias
         probs = map(probs) do subprob

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -324,6 +324,7 @@ end
     @test sccprob2.probs[1].u0 ≈ 2ones(2)
     @test sccprob2.probs[2].u0 ≈ 2ones(1)
     @test sccprob2.explicitfuns! !== missing
+    @test sccprob2.f.sys !== missing
 
     sccprob3 = remake(sccprob; p = [σ => 2.0])
     @test sccprob3.p === sccprob3.probs[1].p


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Looks like `prob.f.sys` was dropped too.
