### PR TITLE
Allow future Moshi style syntax to ease transition

### DIFF
--- a/src/clock.jl
+++ b/src/clock.jl
@@ -13,6 +13,8 @@ using Expronicon.ADT: variant_type, @adt, @match
     SolverStepClock
 end
 
+(clock::TimeDomain)() = clock
+
 Base.Broadcast.broadcastable(d::TimeDomain) = Ref(d)
 
 const DiscriminatorType = typeof(variant_type(Continuous))


### PR DESCRIPTION
The Expronicon singleton variant is `Continuous`, for Moshi it is `Continuous()`. This makes `Continuous()` return `Continuous` so we can update ModelingToolkit to the new syntax already.

The actual migration PR is #922, but this should go first unless you the direct route as mentioned in that PR.