### PR TITLE
Remove SplitFunction remake drop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "2.74.0"
+version = "2.74.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -166,12 +166,6 @@ function remake(
 
     args = (f,)
     if is_split_function(T)
-        # for DynamicalSDEFunction and SplitFunction
-        if isdefined(props, :_func_cache)
-            props = @insert props._func_cache = props._func_cache
-            props = @delete props._func_cache
-        end
-
         # `f1` and `f2` are wrapped in another SciMLFunction, unless they're
         # already wrapped in the appropriate type or are an `AbstractSciMLOperator`
         if !(f isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})


### PR DESCRIPTION
This is the piece of code that's assuming _func_cache doesn't match cache which now that the names are complete we don't need to sidestep the common path.
