### PR TITLE
fix: retain specialization of explicit `f` in `remake`

### DIFF
--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -26,12 +26,14 @@ function Base.summary(io::IO, prob::AbstractDEProblem)
         prob.tspan isa Function ?
         "Unknown" : (prob.tspan === nothing ?
          "Nothing" : typeof(prob.tspan[1])),
-        no_color, 
-        ". In-place: ", type_color, isinplace(prob), no_color) 
+        no_color,
+        ". In-place: ", type_color, isinplace(prob), no_color)
     init = initialization_status(prob)
-    !isnothing(init) && print(io, "Initialization status: ", type_color, initialization_status(prob), no_color)
+    !isnothing(init) && print(io, "Initialization status: ", type_color,
+        initialization_status(prob), no_color)
     println(io)
-    print(io, "Non-trivial mass matrix: ", type_color, !(prob.f.mass_matrix isa LinearAlgebra.UniformScaling{Bool}), no_color)
+    print(io, "Non-trivial mass matrix: ", type_color,
+        !(prob.f.mass_matrix isa LinearAlgebra.UniformScaling{Bool}), no_color)
 end
 
 function Base.summary(io::IO, prob::AbstractLinearProblem)
@@ -114,7 +116,6 @@ function Base.show(io::IO, mime::MIME"text/plain", A::AbstractDEProblem)
     println(io)
     print(io, "u0: ")
     show(io, mime, A.u0)
-     
 end
 function Base.show(io::IO, mime::MIME"text/plain", A::AbstractNoiseProblem)
     summary(io, A)

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -143,6 +143,8 @@ function remake(
         T = parameterless_type(func)
         f = isdefined(func, :f) ? func.f : func.f1
     elseif f isa AbstractSciMLFunction
+        iip = isinplace(f)
+        spec = specialization(f)
         # if `f` is a SciMLFunction, create that type
         T = parameterless_type(f)
         # properties of `f` take priority over those in the existing `func`

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -417,3 +417,11 @@ end
     prob2 = remake(prob; u0 = zeros(2))
     @test prob2.f.f.jac == fjac!
 end
+
+@testset "Issue#925: `remake` retains specialization of explicit `f`" begin
+    f = ODEFunction{false, SciMLBase.FullSpecialize}((u, p, t) -> u)
+    prob = ODEProblem(f, nothing, nothing)
+    @test SciMLBase.specialization(prob.f) == SciMLBase.FullSpecialize
+    prob2 = remake(ODEProblem((u, p, t) -> 2 .* u, nothing, nothing); f = f)
+    @test SciMLBase.specialization(prob2.f) == SciMLBase.FullSpecialize
+end


### PR DESCRIPTION
Close #925 