### PR TITLE
Fix: make isclock robust to non TimeDomain argument

### DIFF
--- a/src/clock.jl
+++ b/src/clock.jl
@@ -40,7 +40,7 @@ discrete-time systems that assume a fixed sample time, such as PID controllers a
 filters.
 """ SolverStepClock
 
-isclock(c) = @match c begin
+isclock(c) = isa(c, TimeDomain) && @match c begin
     PeriodicClock() => true
     _ => false
 end

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -45,12 +45,12 @@ isclock(c) = isa(c, TimeDomain) && @match c begin
     _ => false
 end
 
-issolverstepclock(c) = @match c begin
+issolverstepclock(c) = isa(c, TimeDomain) && @match c begin
     SolverStepClock() => true
     _ => false
 end
 
-iscontinuous(c) = @match c begin
+iscontinuous(c) = isa(c, TimeDomain) && @match c begin
     ContinuousClock() => true
     _ => false
 end

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -24,10 +24,12 @@ using MLStyle: @match
     @test !issolverstepclock(PeriodicClock(; dt = 1.0))
     @test !issolverstepclock(Continuous())
     @test issolverstepclock(SolverStepClock())
+    @test !issolverstepclock(nothing)
 
     @test !iscontinuous(PeriodicClock(; dt = 1.0))
     @test iscontinuous(Continuous())
     @test !iscontinuous(SolverStepClock())
+    @test !iscontinuous(nothing)
 
     @test is_discrete_time_domain(PeriodicClock(; dt = 1.0))
     @test !is_discrete_time_domain(Continuous())

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -19,6 +19,7 @@ using MLStyle: @match
     @test isclock(PeriodicClock(; dt = 1.0))
     @test !isclock(Continuous())
     @test !isclock(SolverStepClock())
+    @test !isclock(nothing)
 
     @test !issolverstepclock(PeriodicClock(; dt = 1.0))
     @test !issolverstepclock(Continuous())


### PR DESCRIPTION
Tentative to fix: https://github.com/SciML/SciMLBase.jl/issues/945

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
