### PR TITLE
Support Moshi wildcards via dispatch

### DIFF
--- a/src/clock.jl
+++ b/src/clock.jl
@@ -40,22 +40,28 @@ discrete-time systems that assume a fixed sample time, such as PID controllers a
 filters.
 """ SolverStepClock
 
-isclock(c) = isa(c, TimeDomain) && @match c begin
+isclock(c::TimeDomain) = @match c begin
     PeriodicClock() => true
     _ => false
 end
 
-issolverstepclock(c) = isa(c, TimeDomain) && @match c begin
+issolverstepclock(c::TimeDomain) = @match c begin
     SolverStepClock() => true
     _ => false
 end
 
-iscontinuous(c) = isa(c, TimeDomain) && @match c begin
+iscontinuous(c::TimeDomain) = @match c begin
     ContinuousClock() => true
     _ => false
 end
 
-is_discrete_time_domain(c) = !iscontinuous(c)
+is_discrete_time_domain(c::TimeDomain) = !iscontinuous(c)
+
+# workaround for https://github.com/Roger-luo/Moshi.jl/issues/43
+isclock(::Any) = false
+issolverstepclock(::Any) = false
+iscontinuous(::Any) = false
+is_discrete_time_domain(::Any) = false
 
 function first_clock_tick_time(c, t0)
     @match c begin

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -34,6 +34,7 @@ using MLStyle: @match
     @test is_discrete_time_domain(PeriodicClock(; dt = 1.0))
     @test !is_discrete_time_domain(Continuous())
     @test is_discrete_time_domain(SolverStepClock())
+    @test !is_discrete_time_domain(nothing)
 
     @test first_clock_tick_time(PeriodicClock(; dt = 2.0), 5.0) === 6.0
     @test_throws ErrorException first_clock_tick_time(Continuous(), 5.0)


### PR DESCRIPTION
Fixes #945
Reported upstream as https://github.com/Roger-luo/Moshi.jl/issues/43.

This should restore the old behavior. One possible exception is `is_discrete_time_domain`, which was defined as not being continuous. So that previously returned true for non-clocks, which seems undesirable to me. Though I'd be happy to preserve that behavior if it is expected anywhere.