### PR TITLE
Remove fallbacks from SciMLOperators

### DIFF
--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -3,10 +3,6 @@
 isconstant(::AbstractDiffEqLinearOperator) = true
 islinear(o::AbstractDiffEqLinearOperator) = isconstant(o)
 
-# fallbacks
-islinear(L) = false
-isconstant(L) = false
-
 # Other ones from LinearMaps.jl
 # Generic fallbacks
 LinearAlgebra.exp(L::AbstractDiffEqLinearOperator, t) = exp(t * L)


### PR DESCRIPTION
Fix: #967 

Since the fallbacks are moved to SciMLOperators in https://github.com/SciML/SciMLOperators.jl/pull/260, we can safely remove these lines in SciMLBase