### PR TITLE
Add verbosity specifier types 

### DIFF
--- a/docs/src/interfaces/Verbosity.md
+++ b/docs/src/interfaces/Verbosity.md
@@ -1,9 +1,57 @@
 # SciML Verbosity
-The SciML verbosity system is designed to make it easy for users to specify what messages are logged, and at what level they are logged at, during the solution process. 
+The SciML verbosity system is designed to make it easy for users to specify what messages are logged and at what level they are logged at during the solution process. 
 
-At the highest level are the `AbstractVerbositySpecifier` subtypes, e.g. `ODEVerbosity`, `LinearVerbosity`, and so on. These hold `group` objects that group the error messages into three broad categories. The first is error control, which contains options related to solver error control and adaptivity algorithms, such as convergence issues and correctness guarantees (e.g. `dt < dtmin) 
+At the highest level are the `AbstractVerbositySpecifier` subtypes, e.g. `ODEVerbosity`, `LinearVerbosity`, and so on. These hold "group" objects that group the error messages into three broad categories. The first is error control, which contains options related to solver error control and adaptivity algorithms, such as convergence issues and correctness guarantees (e.g. `dt < dtmin`). The numerical group holds options pertaining to performance issues, such as large condition numbers and detection of potential floating point issues. Finally the performance group has options related to potential performance issues. For example, mismatched input/output types in out of place functions, and other known performance traps. An example of a group object would be `ODEPerformanceVerbosity`. 
 
-At the lowest level are the `option` settings. These correspond to either individual messages or groups of messages in
+At the lowest level are the `option` settings. These correspond to either individual messages or groups of messages relating to a specific issue or piece of information. For example, the `dt_NaN` option in the `ODEErrorControl` group sets the level of a log message that states that the adaptive timestepping algorithm set `dt` to `NaN`. 
 
-## Verbosity Types
+The system is also hierarchical in the sense that for example `ODEVerbosity` also contains a `NonlinearVerbosity` and a `LinearVerbosity`, because an ODE solve might use NonlinearSolve and LinearSolve. Note that `NonlinearVerbosity` also has a `LinearVerbosity`, because NonlinearSolve also can use LinearSolve. The `LinearVerbosity` in the `ODEVerbosity` handles any calls to LinearSolve that are not inside of a call to NonlinearSolve. 
+
+# Base Verbosity Types 
+The base verbosity specifiers are [Moshi.jl](https://rogerluo.dev/Moshi.jl/) algebraic data types. These allow for pattern matching and gives a namespace `Verbosity` to access the types with. 
+There are five of these types that are used for the lowest level option toggles:
+
+- `None`: indicates that this message should not be logged.
+- `Info`: indicates that this message should be logged with a log level of `Info`
+- `Warn`: indicates that this message should be logged with a log level of `Warn`
+- `Error`: indicates that this message should be logged with a log level of `Error`
+- `Level`: indicates that this message should be logged with a custom log level held by the `Level` type, e.g. `Verbosity.Level(4)` corresponds to `Logging.LogLevel(4)`
+
+Three of these types are only meant to be used for higher level constructors of the verbosity types:
+
+- `Edge`: messages in this group or verbosity specifier are only logged when they relate to edge cases
+- `All`: All messages in this group or verbosity specifier are logged
+- `Default`: only the default messages of this group or verbosity specifier are logged.
+
+# Constructors
+
+The constructors for the verbosity specifiers are designed to be flexible. For example, they can takes some of the base verbosity types described above:
+
+```julia
+ODEVerbosity(Verbosity.None()) #logs nothing
+ODEVerbosity(Verbosity.All()) #logs everything
+ODEVerbosity(Verbosity.Default()) #logs somethings 
+```
+
+They also have keyword argument constructors that can take base verbosity types and automatically construct the correct group object, while also taking a group object for a different 
+group:
+
+```julia 
+# Doesn't print out any error_control information, warns if there is an `init_dt` issue, errors if there is a `dt_NaN` issue, uses Verbosity.Default() for ODENumericalVerbosity
+ODEVerbosity(error_control = Verbosity.None(), performance = ODEPerformanceVerbosity(init_dt = Verbosity.Warn(), dt_NaN = Verbosity.Error()))
+```
+
+Similarly, all of the group objects have equally flexible constructors, but take different base verbosity types. 
+
+```julia
+ODENumericalVerbosity(Verbosity.None()) #logs nothing
+ODENumericalVerbosity(Verbosity.Warn()) #everything is logged as a warning
+```
+
+# SciMLMessage Macro
+```@docs
+SciMLBase.SciMLMessage
+```
+
+# Verbosity API
 

--- a/docs/src/interfaces/Verbosity.md
+++ b/docs/src/interfaces/Verbosity.md
@@ -1,0 +1,9 @@
+# SciML Verbosity
+The SciML verbosity system is designed to make it easy for users to specify what messages are logged, and at what level they are logged at, during the solution process. 
+
+At the highest level are the `AbstractVerbositySpecifier` subtypes, e.g. `ODEVerbosity`, `LinearVerbosity`, and so on. These hold `group` objects that group the error messages into three broad categories. The first is error control, which contains options related to solver error control and adaptivity algorithms, such as convergence issues and correctness guarantees (e.g. `dt < dtmin) 
+
+At the lowest level are the `option` settings. These correspond to either individual messages or groups of messages in
+
+## Verbosity Types
+

--- a/docs/src/interfaces/Verbosity.md
+++ b/docs/src/interfaces/Verbosity.md
@@ -46,6 +46,8 @@ Similarly, all of the group objects have equally flexible constructors, but take
 ```julia
 ODENumericalVerbosity(Verbosity.None()) #logs nothing
 ODENumericalVerbosity(Verbosity.Warn()) #everything is logged as a warning
+
+ODEErrorControlVerbosity(init_dt = Verbosity.Warn(), dt_NaN = Verbosity.Error())
 ```
 
 # SciMLMessage Macro

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -629,10 +629,17 @@ abstract type ADOriginator end
 """
 $(TYPEDEF)
 
-Used to specify which variables can be aliased in a solve. 
+Base for types that specify which variables can be aliased in a solve. 
 Every concrete AbstractAliasSpecifier should have at least the fields `alias_p` and `alias_f`. 
 """
 abstract type AbstractAliasSpecifier end
+
+"""
+$(TYPEDEF)
+
+Base for types which specify what will be printed during a solve. 
+"""
+abstract type AbstractVerbositySpecifier end
 
 """
 $(TYPEDEF)

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -637,9 +637,9 @@ abstract type AbstractAliasSpecifier end
 """
 $(TYPEDEF)
 
-Base for types which specify what will be printed during a solve. 
+Base for types which specify which log messages are emitted at what level.
 """
-abstract type AbstractVerbositySpecifier end
+abstract type AbstractVerbositySpecifier{T} end
 
 """
 $(TYPEDEF)
@@ -758,6 +758,8 @@ include("interpolation.jl")
 include("integrator_interface.jl")
 include("remake.jl")
 include("callbacks.jl")
+
+include("verbosity.jl")
 
 include("deprecated.jl")
 

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -18,11 +18,13 @@ end
 
 function LinearErrorControlVerbosity(verbose::Verbosity.Type)
     @match verbose begin
-        Verbosity.None() => LinearErrorControlVerbosity(fill(Verbosity.None(), nfields(LinearErrorControlVerbosity))...)
+        Verbosity.None() => LinearErrorControlVerbosity(fill(Verbosity.None(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Warn() => LinearErrorControlVerbosity(fill(Verbosity.Warn(), nfields(LinearErrorControlVerbosity))...)
+        Verbosity.Info() => LinearErrorControlVerbosity(fill(Verbosity.Info(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Error() => LinearErrorControlVerbosity(fill(Verbosity.Error(), nfields(LinearErrorControlVerbosity))...)
+        Verbosity.Warn() => LinearErrorControlVerbosity(fill(Verbosity.Warn(), length(fieldnames(LinearErrorControlVerbosity)))...)
+
+        Verbosity.Error() => LinearErrorControlVerbosity(fill(Verbosity.Error(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
         Verbosity.Default() => LinearErrorControlVerbosity()
 
@@ -44,13 +46,16 @@ end
 function LinearPerformanceVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => LinearPerformanceVerbosity(fill(
-            Verbosity.None(), nfields(LinearPerformanceVerbosity))...)
+            Verbosity.None(), length(fieldnames(LinearPerformanceVerbosity)))...)
+
+        Verbosity.Info() => LinearPerformanceVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
         Verbosity.Warn() => LinearPerformanceVerbosity(fill(
-            Verbosity.Warn(), nfields(LinearPerformanceVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
         Verbosity.Error() => LinearPerformanceVerbosity(fill(
-            Verbosity.Error(), nfields(LinearPerformanceVerbosity))...)
+            Verbosity.Error(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
         Verbosity.Default() => LinearPerformanceVerbosity()
 
@@ -62,7 +67,7 @@ end
 
 mutable struct LinearNumericalVerbosity
     @add_kwonly function LinearNumericalVerbosity()
-        LinearNumericalVerbosity()
+        new()
     end
 
 end
@@ -71,13 +76,16 @@ end
 function LinearNumericalVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => LinearNumericalVerbosity(fill(
-            Verbosity.None(), nfields(LinearNumericalVerbosity))...)
+            Verbosity.None(), length(fieldnames(LinearNumericalVerbosity)))...)
+
+        Verbosity.Info() => LinearNumericalVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(LinearNumericalVerbosity)))...)
 
         Verbosity.Warn() => LinearNumericalVerbosity(fill(
-            Verbosity.Warn(), nfields(LinearNumericalVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(LinearNumericalVerbosity)))...)
 
         Verbosity.Error() => LinearNumericalVerbosity(fill(
-            Verbosity.Error(), nfields(LinearNumericalVerbosity))...)
+            Verbosity.Error(), length(fieldnames(LinearNumericalVerbosity)))...)
 
         Verbosity.Default() => LinearNumericalVerbosity()
 
@@ -87,7 +95,7 @@ function LinearNumericalVerbosity(verbose::Verbosity.Type)
     end
 end
 
-struct LinearVerbosity{T} 
+struct LinearVerbosity{T} <: AbstractVerbositySpecifier{T}
     error_control::LinearErrorControlVerbosity
     performance::LinearPerformanceVerbosity
     numerical::LinearNumericalVerbosity
@@ -106,10 +114,10 @@ function LinearVerbosity(verbose::Verbosity.Type)
             LinearPerformanceVerbosity(Verbosity.None()),
             LinearNumericalVerbosity(Verbosity.None()))
 
-        Verbosity.All() => ODEVerbosity{true}(
-            LinearErrorControlVerbosity(Verbosity.All()),
-            LinearPerformanceVerbosity(Verbosity.All()),
-            LinearNumericalVerbosity(Verbosity.All())
+        Verbosity.All() => LinearVerbosity{true}(
+            LinearErrorControlVerbosity(Verbosity.Info()),
+            LinearPerformanceVerbosity(Verbosity.Info()),
+            LinearNumericalVerbosity(Verbosity.Info())
         )
 
         _ => @error "Not a valid choice for verbosity."
@@ -120,7 +128,7 @@ end
 
 mutable struct NonlinearErrorControlVerbosity
     @add_kwonly function NonlinearErrorControlVerbosity()
-        NonlinearErrorControlVerbosity()
+        new()
     end
 end
 
@@ -129,13 +137,16 @@ end
 function NonlinearErrorControlVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => NonlinearErrorControlVerbosity(fill(
-            Verbosity.None(), nfields(NonlinearErrorControlVerbosity))...)
+            Verbosity.None(), length(fieldnames(NonlinearErrorControlVerbosity)))...)
+
+        Verbosity.Info() => NonlinearErrorControlVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(NonlinearErrorControlVerbosity)))...)
 
         Verbosity.Warn() => NonlinearErrorControlVerbosity(fill(
-            Verbosity.Warn(), nfields(NonlinearErrorControlVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(NonlinearErrorControlVerbosity)))...)
 
         Verbosity.Error() => NonlinearNumericalVerbosity(fill(
-            Verbosity.Error(), nfields(NonlinearErrorControlVerbosity))...)
+            Verbosity.Error(), length(fieldnames(NonlinearErrorControlVerbosity)))...)
 
         Verbosity.Default() => NonlinearErrorControlVerbosity()
 
@@ -156,13 +167,16 @@ end
 function NonlinearPerformanceVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => NonlinearPerformanceVerbosity(fill(
-            Verbosity.None(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.None(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
+
+        Verbosity.Info() => NonlinearPerformanceVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Warn() => NonlinPerformanceVerbosity(fill(
-            Verbosity.Warn(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Error() => NonlinearPerformanceVerbosity(fill(
-            Verbosity.Error(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.Error(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Default() => NonlinearPerformanceVerbosity()
 
@@ -182,13 +196,16 @@ end
 function NonlinearNumericalVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => NonlinearNumericalVerbosity(fill(
-            Verbosity.None(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.None(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
+
+        Verbosity.Info() => NonlinearNumericalVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Warn() => NonlinearNumericalVerbosity(fill(
-            Verbosity.Warn(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Error() => NonlinearNumericalVerbosity(fill(
-            Verbosity.Error(), nfields(NonlinearPerformanceVerbosity))...)
+            Verbosity.Error(), length(fieldnames(NonlinearPerformanceVerbosity)))...)
 
         Verbosity.Default() => NonlinearNumericalVerbosity()
 
@@ -198,7 +215,7 @@ function NonlinearNumericalVerbosity(verbose::Verbosity.Type)
     end
 end
 
-struct NonlinearVerbosity{T}
+struct NonlinearVerbosity{T} <: AbstractVerbositySpecifier{T}
     linear_verbosity::LinearVerbosity 
 
     error_control::NonlinearErrorControlVerbosity
@@ -221,11 +238,11 @@ function NonlinearVerbosity(verbose::Verbosity.Type)
             NonlinearPerformanceVerbosity(Verbosity.None()), 
             NonlinearNumericalVerbosity(Verbosity.None()))
 
-        Verbosity.All() => ODEVerbosity{true}(
+        Verbosity.All() => NonlinearVerbosity{true}(
             LinearVerbosity(Verbosity.All()),
-            NonlinearErrorControlVerbosity(Verbosity.All()),
-            NonlinearPerformanceVerbosity(Verbosity.All()),
-            NonlinearNumericalVerbosity(Verbosity.All())
+            NonlinearErrorControlVerbosity(Verbosity.Info()),
+            NonlinearPerformanceVerbosity(Verbosity.Info()),
+            NonlinearNumericalVerbosity(Verbosity.Info())
         )
 
         _ => @error "Not a valid choice for verbosity."
@@ -248,13 +265,16 @@ end
 function ODEErrorControlVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => ODEErrorControlVerbosity(fill(
-            Verbosity.None(), nfields(ODEErrorControlVerbosity))...)
+            Verbosity.None(), length(fieldnames(ODEErrorControlVerbosity)))...)
+
+        Verbosity.Info() => ODEErrorControlVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(ODEErrorControlVerbosity)))...)
 
         Verbosity.Warn() => ODEErrorControlVerbosity(fill(
-            Verbosity.Warn(), nfields(ODEErrorControlVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(ODEErrorControlVerbosity)))...)
 
         Verbosity.Error() => ODEErrorControlVerbosity(fill(
-            Verbosity.Error(), nfields(ODEErrorControlVerbosity))...)
+            Verbosity.Error(), length(fieldnames(ODEErrorControlVerbosity)))...)
 
         Verbosity.Default() => ODEErrorControlVerbosity(Verbosity.Info(), Verbosity.Error())
 
@@ -265,8 +285,8 @@ function ODEErrorControlVerbosity(verbose::Verbosity.Type)
 end
 
 mutable struct ODEPerformanceVerbosity
-    @add_kwonly function ODEPerformanceVerbosity(dt_NaN, init_NaN)
-        new(dt_NaN, init_NaN)
+    @add_kwonly function ODEPerformanceVerbosity()
+        new()
     end
 end
 
@@ -275,13 +295,16 @@ end
 function ODEPerformanceVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => ODEPerformanceVerbosity(fill(
-            Verbosity.None(), nfields(ODEPerformanceVerbosity))...)
+            Verbosity.None(), length(fieldnames(ODEPerformanceVerbosity)))...)
+
+        Verbosity.Info() => ODEPerformanceVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(ODEPerformanceVerbosity)))...)
 
         Verbosity.Warn() => ODEPerformanceVerbosity(fill(
-            Verbosity.Warn(), nfields(ODEPerformanceVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(ODEPerformanceVerbosity)))...)
 
         Verbosity.Error() => ODEPerformanceVerbosity(fill(
-            Verbosity.Error(), nfields(ODEPerformanceVerbosity))...)
+            Verbosity.Error(), length(fieldnames(ODEPerformanceVerbosity)))...)
 
         Verbosity.Default() => ODEPerformanceVerbosity()
 
@@ -290,8 +313,8 @@ function ODEPerformanceVerbosity(verbose::Verbosity.Type)
 end
 
 mutable struct ODENumericalVerbosity
-    @add_kwonly function ODENumericalVerbosity(dt_NaN, init_NaN)
-        new(dt_NaN, init_NaN)
+    @add_kwonly function ODENumericalVerbosity()
+        new()
     end
 end
 
@@ -300,13 +323,16 @@ end
 function ODENumericalVerbosity(verbose::Verbosity.Type)
     @match verbose begin
         Verbosity.None() => ODENumericalVerbosity(fill(
-            Verbosity.None(), nfields(ODENumericalVerbosity))...)
+            Verbosity.None(), length(fieldnames(ODENumericalVerbosity)))...)
+
+        Verbosity.Info() => ODENumericalVerbosity(fill(
+            Verbosity.None(), length(fieldnames(ODENumericalVerbosity)))...)
 
         Verbosity.Warn() => ODENumericalVerbosity(fill(
-            Verbosity.Warn(), nfields(ODENumericalVerbosity))...)
+            Verbosity.Warn(), length(fieldnames(ODENumericalVerbosity)))...)
 
         Verbosity.Error() => ODENumericalVerbosity(fill(
-            Verbosity.Error(), nfields(ODENumericalVerbosity))...)
+            Verbosity.Error(), length(fieldnames(ODENumericalVerbosity)))...)
 
         Verbosity.Default() => ODENumericalVerbosity()
 
@@ -314,9 +340,9 @@ function ODENumericalVerbosity(verbose::Verbosity.Type)
     end
 end
 
-struct ODEVerbosity{T}
-    nonlinear_verbosity::NonlinearVerbosity
+struct ODEVerbosity{T} <: AbstractVerbositySpecifier{T}
     linear_verbosity::LinearVerbosity
+    nonlinear_verbosity::NonlinearVerbosity
 
     error_control::ODEErrorControlVerbosity
     performance::ODEPerformanceVerbosity
@@ -344,9 +370,9 @@ function ODEVerbosity(verbose::Verbosity.Type)
         Verbosity.All() => ODEVerbosity{true}(
             LinearVerbosity(Verbosity.All()),
             NonlinearVerbosity(Verbosity.All()),
-            ODEErrorControlVerbosity(Verbosity.All()),
-            ODEPerformanceVerbosity(Verbosity.All()),
-            ODENumericalVerbosity(Verbosity.All())
+            ODEErrorControlVerbosity(Verbosity.Info()),
+            ODEPerformanceVerbosity(Verbosity.Info()),
+            ODENumericalVerbosity(Verbosity.Info())
         )
 
         _ => @error "Not a valid choice for verbosity."
@@ -385,7 +411,7 @@ function ODEVerbosity(; error_control = Verbosity.Default(), performance = Verbo
         nonlinear = nonlinear_verbosity
     end
 
-    ODEVerbosity(nonlinear, linear, error_control_verbosity, performance_verbosity, numerical_verbosity)
+    ODEVerbosity{true}(linear, nonlinear, error_control_verbosity, performance_verbosity, numerical_verbosity)
 end
 
 
@@ -405,17 +431,18 @@ function message_level(verbose::AbstractVerbositySpecifier{true}, option, group)
 end
 
 function emit_message(
-        f::Function, verbose::AbstractVerbositySpecifier{true}, option, group, file, line, _module)
-    level = message_level(verbose, option, group)
+    f::Function, verbose::V, option, group, file, line, _module) where {V<:AbstractVerbositySpecifier{true}}
 
+    level = message_level(
+        verbose, option, group) 
     if !isnothing(level)
         message = f()
         Base.@logmsg level message _file=file _line=line _module=_module
     end
 end
 
-function emit_message(message::String, verbose::AbstractVerbositySpecifier{true},
-        option, group, file, line, _module)
+function emit_message(message::String, verbose::V,
+        option, group, file, line, _module) where {V<:AbstractVerbositySpecifier{true}}
     level = message_level(verbose, option, group)
 
     if !isnothing(level)
@@ -454,5 +481,5 @@ macro SciMLMessage(f_or_message, verb, option, group)
     file = string(__source__.file)
     _module = __module__
     return :(emit_message(
-        $(esc(f_or_message)), $(esc(verb)), $toggle, $group, $file, $line, $_module))
+        $(esc(f_or_message)), $(esc(verb)), $option, $group, $file, $line, $_module))
 end

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,0 +1,460 @@
+@data Verbosity begin
+    None
+    Edge
+    Info
+    Warn
+    Error
+    All
+    Default
+    Level(Int)
+end
+
+
+function message_level(verbose::AbstractVerbositySpecifier{true}, option, group)
+    group = getproperty(verbose, group)
+    opt_level = getproperty(group, option)
+
+    @match opt_level begin
+        Verbosity.None() => nothing
+        Verbosity.Info() => Logging.Info
+        Verbosity.Warn() => Logging.Warn
+        Verbosity.Error() => Logging.Error
+        Verbosity.Level(i) => Logging.LogLevel(i)
+    end
+end
+
+function emit_message(
+        f::Function, verbose::AbstractVerbositySpecifier{true}, option, group, file, line, _module)
+    level = message_level(verbose, option, group)
+
+    if !isnothing(level)
+        message = f()
+        Base.@logmsg level message _file=file _line=line _module=_module
+    end
+end
+
+function emit_message(message::String, verbose::AbstractVerbositySpecifier{true}, option, group, file, line, _module)
+    level = message_level(verbose, option, group)
+
+    if !isnothing(level)
+        Base.@logmsg level message _file=file _line=line _module=_module
+    end
+end
+
+function emit_message(f, verbose::AbstractVerbositySpecifier{false}, option, group, file, line, _module)
+end
+
+@doc doc"""
+A macro that emits a log message based on the log level specified in the `option` and `group` of the `AbstractVerbositySpecifier` supplied. 
+    
+`f_or_message` may be a message String, or a 0-argument function that returns a String. 
+
+## Usage
+To emit a simple string, `@SciMLMessage("message", verbosity, :option, :group)` will emit a log message with the LogLevel specified in `verbosity`, at the appropriate `option` and `group`. 
+
+`@SciMLMessage` can also be used to emit a log message coming from the evaluation of a 0-argument function. This function is resolved in the environment of the macro call.
+Therefore it can use variables from the surrounding evironment. This may be useful if the log message writer wishes to carry out some calculations using existing variables
+and use them.
+
+```julia
+x = 10
+y = 20
+
+@SciMLMessage(verbosity, :option, :group) do 
+    z = x + y
+    "Message is: x + y = \$z"
+end
+```
+"""
+macro SciMLMessage(f_or_message, verb, option, group)
+    line = __source__.line
+    file = string(__source__.file)
+    _module = __module__
+    return :(emit_message($(esc(f_or_message)), $(esc(verb)), $toggle, $group, $file, $line, $_module))
+end
+
+
+# Linear Verbosity
+
+mutable struct LinearErrorControlVerbosity
+
+end
+
+function LinearErrorControlVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearErrorControlVerbosity(fill(Verbosity.None(), nfields(LinearErrorControlVerbosity))...)
+
+        Verbosity.Warn() => LinearErrorControlVerbosity(fill(Verbosity.Warn(), nfields(LinearErrorControlVerbosity))...)
+
+        Verbosity.Error() => LinearErrorControlVerbosity(fill(Verbosity.Error(), nfields(LinearErrorControlVerbosity))...)
+
+        Verbosity.Default() => LinearErrorControlVerbosity(Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => LinearErrorControlVerbosity(Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct LinearPerformanceVerbosity
+
+    @add_kwonly function LinearPerformanceVerbosity()
+        new()
+    end
+end
+
+
+
+function LinearPerformanceVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearPerformanceVerbosity(fill(
+            Verbosity.None(), nfields(LinearPerformanceVerbosity))...)
+
+        Verbosity.Warn() => LinearPerformanceVerbosity(fill(
+            Verbosity.Warn(), nfields(LinearPerformanceVerbosity))...)
+
+        Verbosity.Error() => LinearPerformanceVerbosity(fill(
+            Verbosity.Error(), nfields(LinearPerformanceVerbosity))...)
+
+        Verbosity.Default() => LinearPerformanceVerbosity(
+            Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => LinearPerformanceVerbosity(Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct LinearNumericalVerbosity
+    @add_kwonly function LinearNumericalVerbosity()
+        LinearNumericalVerbosity()
+    end
+
+end
+
+
+function LinearNumericalVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearNumericalVerbosity(fill(
+            Verbosity.None(), nfields(LinearNumericalVerbosity))...)
+
+        Verbosity.Warn() => LinearNumericalVerbosity(fill(
+            Verbosity.Warn(), nfields(LinearNumericalVerbosity))...)
+
+        Verbosity.Error() => LinearNumericalVerbosity(fill(
+            Verbosity.Error(), nfields(LinearNumericalVerbosity))...)
+
+        Verbosity.Default() => LinearNumericalVerbosity(
+            Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => LinearNumericalVerbosity(Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+struct LinearVerbosity{T} 
+    error_control::LinearErrorControlVerbosity
+    performance::LinearPerformanceVerbosity
+    numerical::LinearNumericalVerbosity
+end
+
+function LinearVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.Default() => LinearVerbosity{true}(
+            LinearErrorControlVerbosity(Verbosity.Default()),
+            LinearPerformanceVerbosity(Verbosity.Default()),
+            LinearNumericalVerbosity(Verbosity.Default())
+        )
+
+        Verbosity.None() => LinearVerbosity{false}(
+            LinearErrorControlVerbosity(Verbosity.None()),
+            LinearPerformanceVerbosity(Verbosity.None()),
+            LinearNumericalVerbosity(Verbosity.None()))
+
+        Verbosity.All() => ODEVerbosity{true}(
+            LinearErrorControlVerbosity(Verbosity.All()),
+            LinearPerformanceVerbosity(Verbosity.All()),
+            LinearNumericalVerbosity(Verbosity.All())
+        )
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+# Nonlinear Verbosity
+
+mutable struct NonlinearErrorControlVerbosity
+    @add_kwonly function NonlinearErrorControlVerbosity()
+        NonlinearErrorControlVerbosity()
+    end
+end
+
+
+
+function NonlinearErrorControlVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => NonlinearErrorControlVerbosity(fill(
+            Verbosity.None(), nfields(NonlinearErrorControlVerbosity))...)
+
+        Verbosity.Warn() => NonlinearErrorControlVerbosity(fill(
+            Verbosity.Warn(), nfields(NonlinearErrorControlVerbosity))...)
+
+        Verbosity.Error() => NonlinearNumericalVerbosity(fill(
+            Verbosity.Error(), nfields(NonlinearErrorControlVerbosity))...)
+
+        Verbosity.Default() => NonlinearErrorControlVerbosity(
+            Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => NonlinearErrorControlVerbosity(Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct NonlinearPerformanceVerbosity
+    @add_kwonly function NonlinearPerformanceVerbosity()
+        NonlinearPerformanceVerbosity()
+    end
+
+end
+
+
+function NonlinearPerformanceVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => NonlinearPerformanceVerbosity(fill(
+            Verbosity.None(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Warn() => NonlinPerformanceVerbosity(fill(
+            Verbosity.Warn(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Error() => NonlinearPerformanceVerbosity(fill(
+            Verbosity.Error(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Default() => NonlinearPerformanceVerbosity(
+            Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => NonlinearPerformanceVerbosity(
+            Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+
+mutable struct NonlinearNumericalVerbosity
+    @add_kwonly function NonlinearNumericalVerbosity()
+        NonlinearNumericalVerbosity()
+    end
+end
+
+function NonlinearNumericalVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => NonlinearNumericalVerbosity(fill(
+            Verbosity.None(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Warn() => NonlinearNumericalVerbosity(fill(
+            Verbosity.Warn(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Error() => NonlinearNumericalVerbosity(fill(
+            Verbosity.Error(), nfields(NonlinearPerformanceVerbosity))...)
+
+        Verbosity.Default() => NonlinearNumericalVerbosity(
+            Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => NonlinearNumericalVerbosity(
+            Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+struct NonlinearVerbosity{T}
+    linear_verbosity::LinearVerbosity 
+
+    error_control::NonlinearErrorControlVerbosity
+    performance::NonlinearPerformanceVerbosity
+    numerical::NonlinearNumericalVerbosity
+end
+
+function NonlinearVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.Default() => NonlinearVerbosity{true}(
+            LinearVerbosity(Verbosity.Default()),
+            NonlinearErrorControlVerbosity(Verbosity.Default()),
+            NonlinearPerformanceVerbosity(Verbosity.Default()),
+            NonlinearNumericalVerbosity(Verbosity.Default())
+        )
+
+        Verbosity.None() => NonlinearVerbosity{false}(
+            LinearVerbosity(Verbosity.None()),
+            NonlinearErrorControlVerbosity(Verbosity.None()), 
+            NonlinearPerformanceVerbosity(Verbosity.None()), 
+            NonlinearNumericalVerbosity(Verbosity.None()))
+
+        Verbosity.All() => ODEVerbosity{true}(
+            LinearVerbosity(Verbosity.All()),
+            NonlinearErrorControlVerbosity(Verbosity.All()),
+            NonlinearPerformanceVerbosity(Verbosity.All()),
+            NonlinearNumericalVerbosity(Verbosity.All())
+        )
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+# ODE Verbosity
+
+mutable struct ODEErrorControlVerbosity
+    dt_NaN::Verbosity.Type
+    init_NaN::Verbosity.Type
+
+    @add_kwonly function ODEErrorControlVerbosity(dt_NaN, init_NaN)
+        ODEErrorControlVerbosity(dt_NaN, init_NaN)
+    end
+end
+
+
+
+function ODEErrorControlVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => ODEErrorControlVerbosity(fill(
+            Verbosity.None(), nfields(ODEErrorControlVerbosity))...)
+
+        Verbosity.Warn() => ODEErrorControlVerbosity(fill(
+            Verbosity.Warn(), nfields(ODEErrorControlVerbosity))...)
+
+        Verbosity.Error() => ODEErrorControlVerbosity(fill(
+            Verbosity.Error(), nfields(ODEErrorControlVerbosity))...)
+
+        Verbosity.Default() => ODEErrorControlVerbosity(Verbosity.Info(), Verbosity.Error())
+
+        Verbosity.Edge() => ODEErrorControlVerbosity(Verbosity.Info(), Verbosity.Warn())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct ODEPerformanceVerbosity
+    @add_kwonly function ODEPerformanceVerbosity(dt_NaN, init_NaN)
+        ODEPerformanceVerbosity(dt_NaN, init_NaN)
+    end
+end
+
+
+
+function ODEPerformanceVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => ODEPerformanceVerbosity(fill(
+            Verbosity.None(), nfields(ODEPerformanceVerbosity))...)
+
+        Verbosity.Warn() => ODEPerformanceVerbosity(fill(
+            Verbosity.Warn(), nfields(ODEPerformanceVerbosity))...)
+
+        Verbosity.Error() => ODEPerformanceVerbosity(fill(
+            Verbosity.Error(), nfields(ODEPerformanceVerbosity))...)
+
+        Verbosity.Default() => ODEPerformanceVerbosity(Verbosity.Warn(), Verbosity.Error())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct ODENumericalVerbosity
+    @add_kwonly function ODENumericalVerbosity(dt_NaN, init_NaN)
+        ODEErrorControlVerbosity(dt_NaN, init_NaN)
+    end
+end
+
+
+
+function ODENumericalVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => ODENumericalVerbosity(fill(
+            Verbosity.None(), nfields(ODENumericalVerbosity))...)
+
+        Verbosity.Warn() => ODENumericalVerbosity(fill(
+            Verbosity.Warn(), nfields(ODENumericalVerbosity))...)
+
+        Verbosity.Error() => ODENumericalVerbosity(fill(
+            Verbosity.Error(), nfields(ODENumericalVerbosity))...)
+
+        Verbosity.Default() => ODENumericalVerbosity(Verbosity.Warn(), Verbosity.Error())
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+struct ODEVerbosity{T}
+    nonlinear_verbosity::NonlinearVerbosity
+    linear_verbosity::LinearVerbosity
+
+    error_control::ODEErrorControlVerbosity
+    performance::ODEPerformanceVerbosity
+    numerical::ODENumericalVerbosity
+end
+
+function ODEVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.Default() => ODEVerbosity{true}(
+            LinearVerbosity(Verbosity.Default()),
+            NonlinearVerbosity(Verbosity.Default()),
+            ODEErrorControlVerbosity(Verbosity.Default()),
+            ODEPerformanceVerbosity(Verbosity.Default()),
+            ODENumericalVerbosity(Verbosity.Default())
+        )
+
+        Verbosity.None() => ODEVerbosity{false}(
+            LinearVerbosity(Verbosity.None()),
+            NonlinearVerbosity(Verbosity.None()),
+            ODEErrorControlVerbosity(Verbosity.None()),
+            ODEPerformanceVerbosity(Verbosity.None()),
+            ODENumericalVerbosity(Verbosity.None())
+        )
+
+        Verbosity.All() => ODEVerbosity{true}(
+            LinearVerbosity(Verbosity.All()),
+            NonlinearVerbosity(Verbosity.All()),
+            ODEErrorControlVerbosity(Verbosity.All()),
+            ODEPerformanceVerbosity(Verbosity.All()),
+            ODENumericalVerbosity(Verbosity.All())
+        )
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+function ODEVerbosity(; error_control = Verbosity.Default(), performance = Verbosity.Default(), numerical = Verbosity.Default(), linear_verbosity = Verbosity.Default(), nonlinear_verbosity = Verbosity.Default())
+
+    if error_control isa Verbosity.Type 
+        error_control_verbosity = ODEErrorControlVerbosity(error_control)
+    else 
+        error_control_verbosity = error_control
+    end
+
+    if performance isa Verbosity.Type
+        performance_verbosity = ODEPerformanceVerbosity(performance)
+    else
+        performance_verbosity = performance
+    end
+
+    if numerical isa Verbosity.Type
+        numerical_verbosity = ODENumericalVerbosity(numerical)
+    else
+        numerical_verbosity = numerical
+    end
+
+    if linear_verbosity isa Verbosity.Type 
+        linear = LinearVerbosity(linear_verbosity)
+    else
+        linear = linear_verbosity
+    end
+
+    if nonlinear_verbosity isa Verbosity.Type
+        nonlinear = NonlinearVerbosity(nonlinear_verbosity)
+    else
+        nonlinear = nonlinear_verbosity
+    end
+
+    ODEVerbosity(nonlinear, linear, error_control_verbosity, performance_verbosity, numerical_verbosity)
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

Provides the types and constructors needed for https://github.com/SciML/SciMLBase.jl/issues/962. 

Each type has a kwarg constructor, one that takes a single Bool and sets every field to that Bool, one that takes `nothing` and sets default values for every field, and the default constructor is available, so that `@set` etc. works. 

These will be useful when the types have more fields and more toggles for what can be printed during the solves. 
