### PR TITLE
HOTFIX: handle `getindex` adjoint for scalar `u`

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -176,6 +176,8 @@ end
             ((u = gs[1], prob = (p = gs[2],),), nothing)
         elseif i === nothing
             throw(error("Zygote AD of purely-symbolic slicing for observed quantities is not yet supported. Work around this by using `A[sym,i]` to access each element sequentially in the function being differentiated."))
+        elseif i isa Int && VA.u isa Number
+            (Δ, nothing)
         else
             VA = recursivecopy(VA)
             recursivefill!(VA, zero(eltype(VA)))


### PR DESCRIPTION
There are some cases where `.u` becomes scalar. Could be when `u0` is a float or `save_idxs` is a Integer for example. This shows up in SciMLSensitivity https://github.com/SciML/SciMLSensitivity.jl/actions/runs/14307459224/job/40094466372?pr=1168#step:6:1036

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
