### PR TITLE
chore: add remake adjoint for `ODEFunction`

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -5,13 +5,21 @@ using Zygote: @adjoint, pullback
 import Zygote: literal_getproperty
 import ChainRulesCore
 using SciMLBase
-using SciMLBase: ODESolution, remake,
+using SciMLBase: ODESolution, remake, ODEFunction,
                  getobserved, build_solution, EnsembleSolution,
                  NonlinearSolution, AbstractTimeseriesSolution
 using SymbolicIndexingInterface: symbolic_type, NotSymbolic, variable_index, is_observed,
                                  observed, parameter_values, state_values, current_time
 using RecursiveArrayTools
 import SciMLStructures
+
+@adjoint function SciMLBase.remake(prob::ODEFunction; kw...)
+    y = remake(prob; kw...)
+    function odefunction_remake_back(Δ)
+        (Δ,)
+    end
+    y, odefunction_remake_back
+end
 
 # This method resolves the ambiguity with the pullback defined in
 # RecursiveArrayToolsZygoteExt


### PR DESCRIPTION
Adds a pass-through adjoint for `remake(::ODEFunction)` to resolve some of the failures in https://github.com/SciML/SciMLSensitivity.jl/actions/runs/14308490679/job/40121723763?pr=1168

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
