### PR TITLE
Improve Downstream testing

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
+        julia-version: ['1.10']
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: DelayDiffEq.jl, group: Interface}
@@ -57,6 +57,7 @@ jobs:
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core5}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core6}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core7}
+          - {user: SciML, repo: SciMLSensitivity.jl, group: Core8}
           - {user: SciML, repo: Catalyst.jl, group: All}
 
     steps:


### PR DESCRIPTION
https://github.com/SciML/SciMLSensitivity.jl/pull/1189 highlights that the downstream tests that are failing for SciMLSensitivity.jl are actually Enzyme issues with v1.11. These are now being tracked here https://github.com/EnzymeAD/Enzyme.jl/issues/2318 for the Enzyme developers to work on. But there are certain things we've been weary about, like:

* https://github.com/SciML/SciMLBase.jl/pull/997
* https://github.com/SciML/SciMLBase.jl/pull/998

Because of failing downstream tests. But that's counter productive: we're not improving our autodiff interfaces because we see failures, but those aren't failures of our autodiff interfaces, those are Enzyme failures.

So for now the solution seems to be to go to v1.10 in these downstream tests and increase the coverage of SciMLSensitivity, and focus on our parts. We can re-enable "1" when Enzyme is ready for it, but for now it's just noise.
