### PR TITLE
Update some solution adjoint reverse mode rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
-version = "2.86.0"
+version = "2.86.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -75,29 +75,31 @@ end
 function ChainRulesCore.rrule(
         ::Type{
             <:ODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
-            T11, T12, T13, T14
+            T11, T12, T13, T14, T15, T16
         }}, u,
         args...) where {T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,
-        T12, T13, T14}
+        T12, T13, T14, T15, T16}
     function ODESolutionAdjoint(ȳ)
         (NoTangent(), ȳ, ntuple(_ -> NoTangent(), length(args))...)
     end
 
-    ODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14}(u, args...),
+    ODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16}(u, args...),
     ODESolutionAdjoint
 end
 
 function ChainRulesCore.rrule(
         ::Type{
-            <:RODESolution{uType, tType, isinplace, P, NP, F, G, K,
-            ND
+            <:RODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+            T11, T12, T13, T14
         }}, u,
-        args...) where {uType, tType, isinplace, P, NP, F, G, K, ND}
+        args...) where {T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+        T11, T12, T13, T14}
     function RODESolutionAdjoint(ȳ)
         (NoTangent(), ȳ, ntuple(_ -> NoTangent(), length(args))...)
     end
 
-    RODESolution{uType, tType, isinplace, P, NP, F, G, K, ND}(u, args...),
+    RODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+    T11, T12, T13, T14}(u, args...),
     RODESolutionAdjoint
 end
 


### PR DESCRIPTION
These ones are only hit in the DiffEqGPU interfaces right now. Although we will shortly switch to Tangent projections soon, this will at least get tests working there again for now.
