### PR TITLE
fix: fix depwarn in `EnsembleProblem` constructor

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -138,8 +138,8 @@ tighten_container_eltype(u) = u
 function __solve(prob::EnsembleProblem{<:AbstractVector{<:AbstractSciMLProblem}},
         alg::Union{AbstractDEAlgorithm, Nothing},
         ensemblealg::BasicEnsembleAlgorithm; kwargs...)
-    warn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
-    Ensembles Simulations Interface page for more details")
+    Base.depwarn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
+    Ensembles Simulations Interface page for more details", :EnsembleProblemSolve)
     invoke(__solve, Tuple{AbstractEnsembleProblem, typeof(alg), typeof(ensemblealg)},
         prob, alg, ensemblealg; trajectories = length(prob.prob), kwargs...)
 end

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -95,8 +95,8 @@ DEFAULT_OUTPUT_FUNC(sol, i) = (sol, false)
 DEFAULT_REDUCTION(u, data, I) = append!(u, data), false
 DEFAULT_VECTOR_PROB_FUNC(prob, i, repeat) = prob[i]
 function EnsembleProblem(prob::AbstractVector{<:AbstractSciMLProblem}; kwargs...)
-    warn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
-    Ensembles Simulations Interface page for more details")
+    Base.depwarn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
+    Ensembles Simulations Interface page for more details", :EnsembleProblem)
     invoke(EnsembleProblem,
         Tuple{Any},
         prob;

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -128,8 +128,8 @@ end
 #since NonlinearProblem might want to use this dispatch as well
 function SciMLBase.EnsembleProblem(
         prob::AbstractSciMLProblem, u0s::Vector{Vector{T}}; kwargs...) where {T}
-    warn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
-    Ensembles Simulations Interface page for more details")
+    Base.depwarn("This dispatch is deprecated for the standard ensemble syntax. See the Parallel
+    Ensembles Simulations Interface page for more details", :EnsebleProblem)
     prob_func = (prob, i, repeat = nothing) -> remake(prob, u0 = u0s[i])
     return SciMLBase.EnsembleProblem(prob; prob_func, kwargs...)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
