### PR TITLE
chore: rm `literal_getproperty(::EnsembleSolution)`

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -70,6 +70,9 @@ end
     function EnsembleSolution_adjoint(p̄::EnsembleSolution)
         (p̄, nothing, nothing, nothing)
     end
+    function EnsembleSolution_adjoint(p̄::NamedTuple)
+        (p̄.u, nothing, nothing, nothing)
+    end
     out, EnsembleSolution_adjoint
 end
 
@@ -80,11 +83,6 @@ end
         (Δ′, nothing)
     end
     VA[:, i], ODESolution_getindex_pullback
-end
-
-@adjoint function Zygote.literal_getproperty(sim::EnsembleSolution,
-        ::Val{:u})
-    sim.u, p̄ -> (EnsembleSolution(p̄, 0.0, true, sim.stats),)
 end
 
 @adjoint function Base.getindex(VA::ODESolution, sym)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

fixes https://github.com/SciML/SciMLSensitivity.jl/issues/1160

This should unblock sensitivity with `EnsembleProblem` for now, but we also need to remove `EnsembleSolution_adjoint` rather than returning `ODESolution`. 

Add any other context about the problem here.
