### PR TITLE
Make `get_initial_values` differentiate

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -258,7 +258,7 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
             initdata.update_initializeprob!(initprob, valp)
         end
     end
-    
+
     if is_trivial_initialization(initdata)
         nlsol = initdata
         success = true

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -248,7 +248,7 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
         return u0, p, true
     end
 
-    initdata::OverrideInitData = ChainRulesCore.@ignore_derivatives f.initialization_data
+    initdata::OverrideInitData = f.initialization_data
     initprob = initdata.initializeprob
 
     if initdata.update_initializeprob! !== nothing
@@ -260,7 +260,7 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
     end
     
     if is_trivial_initialization(initdata)
-        nlsol = initprob
+        nlsol = initdata
         success = true
     else
         nlsolve_alg = something(nlsolve_alg, alg.nlsolve, Some(nothing))
@@ -294,11 +294,11 @@ function get_initial_values(prob, valp, f, alg::OverrideInit,
         end
     end
 
-    u0 = if initdata.initializeprobmap !== nothing
-        initdata.initializeprobmap(nlsol)
+    if initdata.initializeprobmap !== nothing
+        u0 = initdata.initializeprobmap(choose_branch(nlsol))
     end
-    p = if initdata.initializeprobpmap !== nothing
-        initdata.initializeprobpmap(valp, nlsol)
+    if initdata.initializeprobpmap !== nothing
+        p = initdata.initializeprobpmap(valp, choose_branch(nlsol))
     end
 
     return u0, p, success

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -550,3 +550,6 @@ Strips a SciMLSolution object and its interpolation of their functions to better
 function strip_solution(sol::AbstractSciMLSolution)
     sol
 end
+
+choose_branch(x::OverrideInitData) = x.initializeprob
+choose_branch(sol::AbstractSciMLSolution) = sol


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
`nlsol` has 2 incompatible graphs that assign to the same variable. This way we can use a simple indirection to disambiguate between them. For some reason this causes the `Ref` with the extra field access in `initprob`, so using `initdata` instead.


Add any other context about the problem here.
