### PR TITLE
Linear Verbosity Specifiers

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -763,6 +763,8 @@ include("integrator_interface.jl")
 include("remake.jl")
 include("callbacks.jl")
 
+include("verbosity.jl")
+
 include("adapt.jl")
 
 include("deprecated.jl")

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -641,6 +641,13 @@ abstract type AbstractAliasSpecifier end
 """
 $(TYPEDEF)
 
+Base for types which specify which log messages are emitted at what level.
+"""
+abstract type AbstractVerbositySpecifier{T} end
+
+"""
+$(TYPEDEF)
+
 Internal. Used for signifying the AD context comes from a ChainRules.jl definition.
 """
 struct ChainRulesOriginator <: ADOriginator end

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -11,14 +11,14 @@ end
 
 # Linear Verbosity
 
-# linear_defaults = Dict(
-#     :default_lu_fallback => Verbosity.Warn()
-#     :no_right_preconditioning => Verbosity.Warn()
-#     :using_iterative_solvers => Verbosity.Warn()
-#     :using_IterativeSolvers => Verbosity.Warn()
-#     :IterativeSolvers_iterations => Verbosity.Warn()
-#     :KrylovKit_verbosity => Verbosity.Warn()
-# )
+linear_defaults = Dict(
+    :default_lu_fallback => Verbosity.Warn(),
+    :no_right_preconditioning => Verbosity.Warn(),
+    :using_iterative_solvers => Verbosity.Warn(),
+    :using_IterativeSolvers => Verbosity.Warn(),
+    :IterativeSolvers_iterations => Verbosity.Warn(),
+    :KrylovKit_verbosity => Verbosity.Warn()
+)
 mutable struct LinearErrorControlVerbosity
     default_lu_fallback::Verbosity.Type
 
@@ -26,58 +26,61 @@ mutable struct LinearErrorControlVerbosity
             default_lu_fallback = linear_defaults[:default_lu_fallback])
         new(default_lu_fallback)
     end
-end
 
-function LinearErrorControlVerbosity(verbose::Verbosity.Type)
-    @match verbose begin
-        Verbosity.None() => LinearErrorControlVerbosity(fill(
-            Verbosity.None(), length(fieldnames(LinearErrorControlVerbosity)))...)
+    function LinearErrorControlVerbosity(verbose::Verbosity.Type)
+        @match verbose begin
+            Verbosity.None() => new(fill(
+                Verbosity.None(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Info() => LinearErrorControlVerbosity(fill(
-            Verbosity.Info(), length(fieldnames(LinearErrorControlVerbosity)))...)
+            Verbosity.Info() => new(fill(
+                Verbosity.Info(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Warn() => LinearErrorControlVerbosity(fill(
-            Verbosity.Warn(), length(fieldnames(LinearErrorControlVerbosity)))...)
+            Verbosity.Warn() => new(fill(
+                Verbosity.Warn(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Error() => LinearErrorControlVerbosity(fill(
-            Verbosity.Error(), length(fieldnames(LinearErrorControlVerbosity)))...)
+            Verbosity.Error() => new(fill(
+                Verbosity.Error(), length(fieldnames(LinearErrorControlVerbosity)))...)
 
-        Verbosity.Default() => LinearErrorControlVerbosity()
+            Verbosity.Default() => LinearErrorControlVerbosity()
 
-        Verbosity.Edge() => LinearErrorControlVerbosity()
+            Verbosity.Edge() => LinearErrorControlVerbosity()
 
-        _ => @error "Not a valid choice for verbosity."
+            _ => @error "Not a valid choice for verbosity."
+        end
     end
 end
 
+
 mutable struct LinearPerformanceVerbosity
     no_right_preconditioning::Verbosity.Type
+
     function LinearPerformanceVerbosity(;
             no_right_preconditioning = linear_defaults[:no_right_preconditioning])
         new(no_right_preconditioning)
     end
-end
 
-function LinearPerformanceVerbosity(verbose::Verbosity.Type)
-    @match verbose begin
-        Verbosity.None() => LinearPerformanceVerbosity(fill(
-            Verbosity.None(), length(fieldnames(LinearPerformanceVerbosity)))...)
+    function LinearPerformanceVerbosity(verbose::Verbosity.Type)
+        @match verbose begin
+            Verbosity.None() => new(fill(
+                Verbosity.None(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
-        Verbosity.Info() => LinearPerformanceVerbosity(fill(
-            Verbosity.Info(), length(fieldnames(LinearPerformanceVerbosity)))...)
+            Verbosity.Info() => new(fill(
+                Verbosity.Info(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
-        Verbosity.Warn() => LinearPerformanceVerbosity(fill(
-            Verbosity.Warn(), length(fieldnames(LinearPerformanceVerbosity)))...)
+            Verbosity.Warn() => new(fill(
+                Verbosity.Warn(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
-        Verbosity.Error() => LinearPerformanceVerbosity(fill(
-            Verbosity.Error(), length(fieldnames(LinearPerformanceVerbosity)))...)
+            Verbosity.Error() => new(fill(
+                Verbosity.Error(), length(fieldnames(LinearPerformanceVerbosity)))...)
 
-        Verbosity.Default() => LinearPerformanceVerbosity()
+            Verbosity.Default() => LinearPerformanceVerbosity()
 
-        Verbosity.Edge() => LinearPerformanceVerbosity()
+            Verbosity.Edge() => LinearPerformanceVerbosity()
 
-        _ => @error "Not a valid choice for verbosity."
+            _ => @error "Not a valid choice for verbosity."
+        end
     end
+
 end
 
 mutable struct LinearNumericalVerbosity
@@ -91,29 +94,31 @@ mutable struct LinearNumericalVerbosity
             KrylovKit_verbosity = linear_defaults[:KrylovKit_verbosity])
         new(using_IterativeSolvers, IterativeSolvers_iterations, KrylovKit_verbosity)
     end
-end
 
-function LinearNumericalVerbosity(verbose::Verbosity.Type)
-    @match verbose begin
-        Verbosity.None() => LinearNumericalVerbosity(fill(
-            Verbosity.None(), length(fieldnames(LinearNumericalVerbosity)))...)
+    function LinearNumericalVerbosity(verbose::Verbosity.Type)
+        @match verbose begin
+            Verbosity.None() => new(fill(
+                Verbosity.None(), length(fieldnames(LinearNumericalVerbosity)))...)
 
-        Verbosity.Info() => LinearNumericalVerbosity(fill(
-            Verbosity.Info(), length(fieldnames(LinearNumericalVerbosity)))...)
+            Verbosity.Info() => new(fill(
+                Verbosity.Info(), length(fieldnames(LinearNumericalVerbosity)))...)
 
-        Verbosity.Warn() => LinearNumericalVerbosity(fill(
-            Verbosity.Warn(), length(fieldnames(LinearNumericalVerbosity)))...)
+            Verbosity.Warn() => new(fill(
+                Verbosity.Warn(), length(fieldnames(LinearNumericalVerbosity)))...)
 
-        Verbosity.Error() => LinearNumericalVerbosity(fill(
-            Verbosity.Error(), length(fieldnames(LinearNumericalVerbosity)))...)
+            Verbosity.Error() => new(fill(
+                Verbosity.Error(), length(fieldnames(LinearNumericalVerbosity)))...)
 
-        Verbosity.Default() => LinearNumericalVerbosity()
+            Verbosity.Default() => LinearNumericalVerbosity()
 
-        Verbosity.Edge() => LinearNumericalVerbosity()
+            Verbosity.Edge() => LinearNumericalVerbosity()
 
-        _ => @error "Not a valid choice for verbosity."
+            _ => @error "Not a valid choice for verbosity."
+        end
     end
 end
+
+
 
 struct LinearVerbosity{T} <: AbstractVerbositySpecifier{T}
     error_control::LinearErrorControlVerbosity

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -17,7 +17,8 @@ linear_defaults = Dict(
     :using_iterative_solvers => Verbosity.Warn(),
     :using_IterativeSolvers => Verbosity.Warn(),
     :IterativeSolvers_iterations => Verbosity.Warn(),
-    :KrylovKit_verbosity => Verbosity.Warn()
+    :KrylovKit_verbosity => Verbosity.Warn(),
+    :KrylovJL_verbosity => Verbosity.None()
 )
 mutable struct LinearErrorControlVerbosity
     default_lu_fallback::Verbosity.Type
@@ -87,12 +88,14 @@ mutable struct LinearNumericalVerbosity
     using_IterativeSolvers::Verbosity.Type
     IterativeSolvers_iterations::Verbosity.Type
     KrylovKit_verbosity::Verbosity.Type
+    KrylovJL_verbosity::Verbosity.Type
 
     function LinearNumericalVerbosity(;
             using_IterativeSolvers = linear_defaults[:using_IterativeSolvers],
             IterativeSolvers_iterations = linear_defaults[:IterativeSolvers_iterations],
-            KrylovKit_verbosity = linear_defaults[:KrylovKit_verbosity])
-        new(using_IterativeSolvers, IterativeSolvers_iterations, KrylovKit_verbosity)
+            KrylovKit_verbosity = linear_defaults[:KrylovKit_verbosity],
+            KrylovJL_verbosity = linear_defaults[:KrylovJL_verbosity])
+        new(using_IterativeSolvers, IterativeSolvers_iterations, KrylovKit_verbosity, KrylovJL_verbosity)
     end
 
     function LinearNumericalVerbosity(verbose::Verbosity.Type)

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,0 +1,250 @@
+@data Verbosity begin
+    None
+    Info
+    Warn
+    Error
+    Level(Int)
+    Edge
+    All
+    Default
+end
+
+# Linear Verbosity
+
+linear_defaults = Dict(
+    :default_lu_fallback => Verbosity.Warn()
+:using_iterative_solvers => Verbosity.Warn()
+)
+mutable struct LinearErrorControlVerbosity
+    default_lu_fallback::Verbosity.Type
+
+    function LinearErrorControlVerbosity(;
+            default_lu_fallback = linear_defaults[:default_lu_fallback])
+        new(default_lu_fallback)
+    end
+end
+
+function LinearErrorControlVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearErrorControlVerbosity(fill(
+            Verbosity.None(), length(fieldnames(LinearErrorControlVerbosity)))...)
+
+        Verbosity.Info() => LinearErrorControlVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(LinearErrorControlVerbosity)))...)
+
+        Verbosity.Warn() => LinearErrorControlVerbosity(fill(
+            Verbosity.Warn(), length(fieldnames(LinearErrorControlVerbosity)))...)
+
+        Verbosity.Error() => LinearErrorControlVerbosity(fill(
+            Verbosity.Error(), length(fieldnames(LinearErrorControlVerbosity)))...)
+
+        Verbosity.Default() => LinearErrorControlVerbosity()
+
+        Verbosity.Edge() => LinearErrorControlVerbosity()
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct LinearPerformanceVerbosity
+    no_right_preconditioning::Verbosity.Type
+    function LinearPerformanceVerbosity(;
+            no_right_preconditioning = linear_defaults[:no_right_preconditioning])
+        new(no_right_preconditioning)
+    end
+end
+
+function LinearPerformanceVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearPerformanceVerbosity(fill(
+            Verbosity.None(), length(fieldnames(LinearPerformanceVerbosity)))...)
+
+        Verbosity.Info() => LinearPerformanceVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(LinearPerformanceVerbosity)))...)
+
+        Verbosity.Warn() => LinearPerformanceVerbosity(fill(
+            Verbosity.Warn(), length(fieldnames(LinearPerformanceVerbosity)))...)
+
+        Verbosity.Error() => LinearPerformanceVerbosity(fill(
+            Verbosity.Error(), length(fieldnames(LinearPerformanceVerbosity)))...)
+
+        Verbosity.Default() => LinearPerformanceVerbosity()
+
+        Verbosity.Edge() => LinearPerformanceVerbosity()
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+mutable struct LinearNumericalVerbosity
+    using_IterativeSolvers::Verbosity.Type
+    IterativeSolvers_iterations::Verbosity.Type
+    KrylovKit_verbosity::Verbosity.Type
+
+    function LinearNumericalVerbosity(;
+            using_IterativeSolvers = linear_defaults[:using_IterativeSolvers],
+            IterativeSolvers_iterations = linear_defaults[:IterativeSolvers_iterations],
+            KrylovKit_verbosity = linear_defaults[:KrylovKit_verbosity])
+        new(using_IterativeSolvers, IterativeSolvers_iterations, KrylovKit_verbosity)
+    end
+end
+
+function LinearNumericalVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.None() => LinearNumericalVerbosity(fill(
+            Verbosity.None(), length(fieldnames(LinearNumericalVerbosity)))...)
+
+        Verbosity.Info() => LinearNumericalVerbosity(fill(
+            Verbosity.Info(), length(fieldnames(LinearNumericalVerbosity)))...)
+
+        Verbosity.Warn() => LinearNumericalVerbosity(fill(
+            Verbosity.Warn(), length(fieldnames(LinearNumericalVerbosity)))...)
+
+        Verbosity.Error() => LinearNumericalVerbosity(fill(
+            Verbosity.Error(), length(fieldnames(LinearNumericalVerbosity)))...)
+
+        Verbosity.Default() => LinearNumericalVerbosity()
+
+        Verbosity.Edge() => LinearNumericalVerbosity()
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+struct LinearVerbosity{T} <: AbstractVerbositySpecifier{T}
+    error_control::LinearErrorControlVerbosity
+    performance::LinearPerformanceVerbosity
+    numerical::LinearNumericalVerbosity
+end
+
+function LinearVerbosity(verbose::Verbosity.Type)
+    @match verbose begin
+        Verbosity.Default() => LinearVerbosity{true}(
+            LinearErrorControlVerbosity(Verbosity.Default()),
+            LinearPerformanceVerbosity(Verbosity.Default()),
+            LinearNumericalVerbosity(Verbosity.Default())
+        )
+
+        Verbosity.None() => LinearVerbosity{false}(
+            LinearErrorControlVerbosity(Verbosity.None()),
+            LinearPerformanceVerbosity(Verbosity.None()),
+            LinearNumericalVerbosity(Verbosity.None()))
+
+        Verbosity.All() => LinearVerbosity{true}(
+            LinearErrorControlVerbosity(Verbosity.Info()),
+            LinearPerformanceVerbosity(Verbosity.Info()),
+            LinearNumericalVerbosity(Verbosity.Info())
+        )
+
+        _ => @error "Not a valid choice for verbosity."
+    end
+end
+
+function LinearVerbosity(;
+        error_control = Verbosity.Default(), performance = Verbosity.Default(),
+        numerical = Verbosity.Default(), kwargs...)
+    if error_control isa Verbosity.Type
+        error_control_verbosity = LinearErrorControlVerbosity(error_control)
+    else
+        error_control_verbosity = error_control
+    end
+
+    if performance isa Verbosity.Type
+        performance_verbosity = LinearPerformanceVerbosity(performance)
+    else
+        performance_verbosity = performance
+    end
+
+    if numerical isa Verbosity.Type
+        numerical_verbosity = LinearNumericalVerbosity(numerical)
+    else
+        numerical_verbosity = numerical
+    end
+
+    if !isempty(kwargs)
+        for (key, value) in pairs(kwargs)
+            if hasfield(LinearErrorControlVerbosity, key)
+                setproperty!(error_control_verbosity, key, value)
+            elseif hasfield(LinearPerformanceVerbosity, key)
+                setproperty!(performance_verbosity, key, value)
+            elseif hasfield(LinearNumericalVerbosity, key)
+                setproperty!(numerical_verbosity, key, value)
+            else
+                error("$key is not a recognized verbosity toggle.")
+            end
+        end
+    end
+
+    LinearVerbosity{true}(error_control_verbosity,
+        performance_verbosity, numerical_verbosity)
+end
+
+# Utilities 
+
+function message_level(verbose::AbstractVerbositySpecifier{true}, option, group)
+    group = getproperty(verbose, group)
+    opt_level = getproperty(group, option)
+
+    @match opt_level begin
+        Verbosity.None() => nothing
+        Verbosity.Info() => Logging.Info
+        Verbosity.Warn() => Logging.Warn
+        Verbosity.Error() => Logging.Error
+        Verbosity.Level(i) => Logging.LogLevel(i)
+    end
+end
+
+function emit_message(
+        f::Function, verbose::V, option, group, file, line,
+        _module) where {V <: AbstractVerbositySpecifier{true}}
+    level = message_level(
+        verbose, option, group)
+    if !isnothing(level)
+        message = f()
+        Base.@logmsg level message _file=file _line=line _module=_module
+    end
+end
+
+function emit_message(message::String, verbose::V,
+        option, group, file, line, _module) where {V <: AbstractVerbositySpecifier{true}}
+    level = message_level(verbose, option, group)
+
+    if !isnothing(level)
+        Base.@logmsg level message _file=file _line=line _module=_module
+    end
+end
+
+function emit_message(
+        f, verbose::AbstractVerbositySpecifier{false}, option, group, file, line, _module)
+end
+
+@doc doc"""
+A macro that emits a log message based on the log level specified in the `option` and `group` of the `AbstractVerbositySpecifier` supplied. 
+    
+`f_or_message` may be a message String, or a 0-argument function that returns a String. 
+
+## Usage
+To emit a simple string, `@SciMLMessage("message", verbosity, :option, :group)` will emit a log message with the LogLevel specified in `verbosity`, at the appropriate `option` and `group`. 
+
+`@SciMLMessage` can also be used to emit a log message coming from the evaluation of a 0-argument function. This function is resolved in the environment of the macro call.
+Therefore it can use variables from the surrounding environment. This may be useful if the log message writer wishes to carry out some calculations using existing variables
+and use them in the log message.
+
+```julia
+x = 10
+y = 20
+
+@SciMLMessage(verbosity, :option, :group) do 
+    z = x + y
+    "Message is: x + y = \$z"
+end
+```
+"""
+macro SciMLMessage(f_or_message, verb, option, group)
+    line = __source__.line
+    file = string(__source__.file)
+    _module = __module__
+    return :(emit_message(
+        $(esc(f_or_message)), $(esc(verb)), $option, $group, $file, $line, $_module))
+end
+

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -145,7 +145,7 @@ function LinearVerbosity(verbose::Verbosity.Type)
             LinearNumericalVerbosity(Verbosity.Info())
         )
 
-        _ => @error "Not a valid choice for verbosity."
+        _ => @error "Not a valid choice for LinearVerbosity. Available choices are `Default`, `None`, and `All`."
     end
 end
 

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -11,10 +11,14 @@ end
 
 # Linear Verbosity
 
-linear_defaults = Dict(
-    :default_lu_fallback => Verbosity.Warn()
-:using_iterative_solvers => Verbosity.Warn()
-)
+# linear_defaults = Dict(
+#     :default_lu_fallback => Verbosity.Warn()
+#     :no_right_preconditioning => Verbosity.Warn()
+#     :using_iterative_solvers => Verbosity.Warn()
+#     :using_IterativeSolvers => Verbosity.Warn()
+#     :IterativeSolvers_iterations => Verbosity.Warn()
+#     :KrylovKit_verbosity => Verbosity.Warn()
+# )
 mutable struct LinearErrorControlVerbosity
     default_lu_fallback::Verbosity.Type
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

https://github.com/SciML/SciMLBase.jl/issues/962

This contains just the things necessary to use the verbosity system with LinearSolve, so we can test things out and make sure that this meets the requirements for the verbosity system. 

A Moshi.jl ADT is used for the base verbosity specifiers. `LinearVerbosity` holds a `LinearErrorControlVerbosity`, a `LinearPerformanceVerbosity`, and a `LinearNumericalVerbosity`. The `@SciMLMessage` macro takes a String or a function that returns a String, a verbosity object, a symbol representing the base toggle, and a symbol representing what group the message belongs to. 

```julia
using SciMLBase
using SciMLBase: Verbosity


verbose = SciMLBase.LinearVerbosity(default_lu_fallback=Verbosity.Warn())

SciMLBase.@SciMLMessage("LU factorization failed, switching to QR factorization", verbose, :default_lu_fallback, :error_control)


verbose = SciMLBase.LinearVerbosity(numerical = Verbosity.Info())

SciMLBase.@SciMLMessage("Using IterativeSolvers", verbose, :using_IterativeSolvers, :numerical)


error_verb = SciMLBase.LinearErrorControlVerbosity(Verbosity.Info())

verbose = SciMLBase.LinearVerbosity(error_control = error_verb)

SciMLBase.@SciMLMessage("LU factorization failed, switching to QR factorization", verbose, :default_lu_fallback, :error_control)


x = 10
y = 20

SciMLBase.@SciMLMessage(verbose, :default_lu_fallback, :error_control) do 
    z = x + y
    "z is $z."
end
```