### PR TITLE
feat: retain information in `SplitFunction` when adding `_func_cache`

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -475,8 +475,7 @@ function SplitODEProblem{iip}(f::SplitFunction, u0, tspan, p = NullParameters();
         kwargs...) where {iip}
     if f._func_cache === nothing && iip
         _func_cache = similar(u0)
-        f = SplitFunction{iip}(f.f1, f.f2; mass_matrix = f.mass_matrix,
-            _func_cache = _func_cache, analytic = f.analytic)
+        f = remake(f; _func_cache)
     end
     ODEProblem(f, u0, tspan, p, SplitODEProblem{iip}(); kwargs...)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
