### PR TITLE
fix printing of DEStats

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -51,8 +51,8 @@ function Base.show(io::IO, ::MIME"text/plain", s::DEStats)
     @printf io "%-50s %-d\n" "Number of Jacobians created:" s.njacs
     @printf io "%-50s %-d\n" "Number of nonlinear solver iterations:" s.nnonliniter
     @printf io "%-50s %-d\n" "Number of nonlinear solver convergence failures:" s.nnonlinconvfail
-    @printf io "%-60s %-d\n" "Number of fixed-point solver iterations:" s.nfpiter
-    @printf io "%-60s %-d\n" "Number of fixed-point solver convergence failures:" s.nfpconvfail
+    @printf io "%-50s %-d\n" "Number of fixed-point solver iterations:" s.nfpiter
+    @printf io "%-50s %-d\n" "Number of fixed-point solver convergence failures:" s.nfpconvfail
     @printf io "%-50s %-d\n" "Number of rootfind condition calls:" s.ncondition
     @printf io "%-50s %-d\n" "Number of accepted steps:" s.naccept
     @printf io "%-50s %-d" "Number of rejected steps:" s.nreject


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Before this PR:

```julia
julia> SciMLBase.DEStats()
SciMLBase.DEStats
Number of function 1 evaluations:                  -1
Number of function 2 evaluations:                  -1
Number of W matrix evaluations:                    -1
Number of linear solves:                           -1
Number of Jacobians created:                       -1
Number of nonlinear solver iterations:             -1
Number of nonlinear solver convergence failures:   -1
Number of fixed-point solver iterations:                     -1
Number of fixed-point solver convergence failures:           -1
Number of rootfind condition calls:                -1
Number of accepted steps:                          -1
Number of rejected steps:                          -1
```



With this PR:

```julia
julia> SciMLBase.DEStats()
SciMLBase.DEStats
Number of function 1 evaluations:                  -1
Number of function 2 evaluations:                  -1
Number of W matrix evaluations:                    -1
Number of linear solves:                           -1
Number of Jacobians created:                       -1
Number of nonlinear solver iterations:             -1
Number of nonlinear solver convergence failures:   -1
Number of fixed-point solver iterations:           -1
Number of fixed-point solver convergence failures: -1
Number of rootfind condition calls:                -1
Number of accepted steps:                          -1
Number of rejected steps:                          -1
```

