### PR TITLE
Add methods for SDEFunction in case of SciMLOperators v1+

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2644,6 +2644,26 @@ function Base.getproperty(f::DynamicalDDEFunction, name::Symbol)
 end
 
 (f::SDEFunction)(args...) = f.f(args...)
+
+@static if isdefined(SciMLOperators, :isv1)
+    function (f::SDEFunction)(du, u, p, t)
+        if f.f isa AbstractSciMLOperator
+            f.f(du, u, u, p, t)
+        else
+            f.f(du, u, p, t)
+        end
+    end
+
+    function (f::SDEFunction)(u, p, t)
+        if f.f isa AbstractSciMLOperator
+            f.f(u, u, p, t)
+        else
+            f.f(u, p, t)
+        end
+    end
+end
+
+
 (f::SDDEFunction)(args...) = f.f(args...)
 (f::SplitSDEFunction)(u, p, t) = f.f1(u, p, t) + f.f2(u, p, t)
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR fixes the following issue in running an SDE with a SciMLOperator

```julia
using LinearAlgebra
using StochasticDiffEq
using SciMLOperators
using SciMLOperators: AbstractSciMLOperator
using SciMLBase
using OrdinaryDiffEqTsit5

struct MyMatrixOperator{T, AT <: AbstractMatrix{T}} <: AbstractSciMLOperator{T}
    A::AT
end

(L::MyMatrixOperator)(w, v, u, p, t) = mul!(w, L.A, v)

f = MyMatrixOperator(rand(2, 2))
g(du, u, p, t) = lmul!(0.1, du)

x0 = rand(2)
tspan = (0.0, 1.0)

prob = SDEProblem{true}(f, g, x0, tspan)
sol = solve(prob, SRIW1())
```

```julia
ERROR: MethodError: no method matching *(::MyMatrixOperator{Float64, Matrix{Float64}}, ::Vector{Float64})
The function `*` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  *(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:596
  *(::ChainRulesCore.ZeroTangent, ::Any)
   @ ChainRulesCore ~/.julia/packages/ChainRulesCore/XAgYn/src/tangent_arithmetic.jl:104
  *(::Any, ::ChainRulesCore.NotImplemented)
   @ ChainRulesCore ~/.julia/packages/ChainRulesCore/XAgYn/src/tangent_arithmetic.jl:38
  ...
```

The problem is that it is calling the four-arguments method

```julia
function (L::AbstractSciMLOperator)(v, u, p, t; kwargs...)
    update_coefficients(L, u, p, t; kwargs...) * v
end
```

which is wrong.

This PR fixes https://github.com/SciML/StochasticDiffEq.jl/issues/615. At least the part related to the `f` function.