### PR TITLE
Remove outdated Julia version checks

### DIFF
--- a/test/downstream/remake_autodiff.jl
+++ b/test/downstream/remake_autodiff.jl
@@ -30,23 +30,20 @@ end
 du01, dp1 = Zygote.gradient(sum_of_solution, u0, p)
 
 # These tests depend on a ZygoteRule in a package extension
-# package exentsions do not exist before 1.9, so they cannot work.
-if VERSION >= v"1.9"
-    function symbolic_indexing(u0, p)
-        _prob = remake(prob, u0 = u0, p = p)
-        soln = solve(_prob, Tsit5(), reltol = 1e-6, abstol = 1e-6, saveat = 0.1,
-            sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
-        sum(soln[x])
-    end
-
-    du01, dp1 = Zygote.gradient(symbolic_indexing, u0, p)
-
-    function symbolic_indexing_observed(u0, p)
-        _prob = remake(prob, u0 = u0, p = p)
-        soln = solve(_prob, Tsit5(), reltol = 1e-6, abstol = 1e-6, saveat = 0.1,
-            sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
-        sum(soln[o, i] for i in 1:length(soln))
-    end
-
-    du01, dp1 = Zygote.gradient(symbolic_indexing_observed, u0, p)
+function symbolic_indexing(u0, p)
+    _prob = remake(prob, u0 = u0, p = p)
+    soln = solve(_prob, Tsit5(), reltol = 1e-6, abstol = 1e-6, saveat = 0.1,
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+    sum(soln[x])
 end
+
+du01, dp1 = Zygote.gradient(symbolic_indexing, u0, p)
+
+function symbolic_indexing_observed(u0, p)
+    _prob = remake(prob, u0 = u0, p = p)
+    soln = solve(_prob, Tsit5(), reltol = 1e-6, abstol = 1e-6, saveat = 0.1,
+        sensealg = BacksolveAdjoint(autojacvec = ZygoteVJP()))
+    sum(soln[o, i] for i in 1:length(soln))
+end
+
+du01, dp1 = Zygote.gradient(symbolic_indexing_observed, u0, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,10 +89,8 @@ end
         @time @safetestset "Ensemble with DifferentialEquations automatic algorithm selection" begin
             include("downstream/ensemble_diffeq.jl")
         end
-        if VERSION >= v"1.8"
-            @time @safetestset "Solution Indexing" begin
-                include("downstream/solution_interface.jl")
-            end
+        @time @safetestset "Solution Indexing" begin
+            include("downstream/solution_interface.jl")
         end
         @time @safetestset "Unitful interpolations" begin
             include("downstream/unitful_interpolations.jl")


### PR DESCRIPTION
## Summary
- Remove version checks for Julia v1.8 and v1.9 since Julia v1.10 is now the LTS version
- These checks are no longer needed as the minimum supported version is above these thresholds

## Changes
- Removed `VERSION >= v"1.9"` check in `test/downstream/remake_autodiff.jl` (kept the code inside since the condition is always true)
- Removed `VERSION >= v"1.8"` check in `test/runtests.jl` (kept the code inside since the condition is always true)

## Test plan
- [ ] CI tests pass
- [ ] No functionality changes, only removal of version conditionals that are always true

🤖 Generated with [Claude Code](https://claude.ai/code)