### PR TITLE
fix(docs): Parameter names of `LinearProblem` in docs

### DIFF
--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -82,8 +82,8 @@ Optionally, an initial guess ``u₀`` can be supplied which is used for iterativ
 methods.
 
 ```julia
-LinearProblem{isinplace}(A,x,p=NullParameters();u0=nothing,kwargs...)
-LinearProblem(f::AbstractSciMLOperator,u0,p=NullParameters();u0=nothing,kwargs...)
+LinearProblem{isinplace}(A,b,p=NullParameters();u0=nothing,kwargs...)
+LinearProblem(f::AbstractSciMLOperator,b,p=NullParameters();u0=nothing,kwargs...)
 ```
 
 `isinplace` optionally sets whether the function is in-place or not, i.e. whether


### PR DESCRIPTION
The parameter names in the signature are confusing in the context of the descriptions of the parameters with the same names but different meanings under the signature in the `# Fields` section.