### PR TITLE
Fix Makie recipe to support 3D plots with automatic LScene detection

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -23,6 +23,19 @@ function ensure_plottrait(PT::Type, arg, desired_plottrait_type::Type)
     end
 end
 
+# Define preferred axis type based on the idxs parameter
+function Makie.preferred_axis_type(plot::Plot{<:Tuple{<:SciMLBase.AbstractTimeseriesSolution}})
+    if haskey(plot, :idxs) || haskey(plot, :vars)
+        idxs = haskey(plot, :idxs) ? plot[:idxs][] : (haskey(plot, :vars) ? plot[:vars][] : nothing)
+        if idxs isa Tuple && length(idxs) == 3
+            return Makie.LScene
+        elseif idxs isa AbstractArray && length(idxs) == 3
+            return Makie.LScene  
+        end
+    end
+    return Makie.Axis
+end
+
 # ## `AbstractTimeseriesSolution` recipe
 
 # First, we define the standard plot type for timeseries solutions.
@@ -137,6 +150,19 @@ end
 # This will be very similar to the timeseries solution recipe, but without some of the conveniences.
 
 Makie.plottype(integrator::SciMLBase.DEIntegrator) = Makie.Lines
+
+# Define preferred axis type for integrator plots
+function Makie.preferred_axis_type(plot::Plot{<:Tuple{<:SciMLBase.DEIntegrator}})
+    if haskey(plot, :idxs) || haskey(plot, :vars)
+        idxs = haskey(plot, :idxs) ? plot[:idxs][] : (haskey(plot, :vars) ? plot[:vars][] : nothing)
+        if idxs isa Tuple && length(idxs) == 3
+            return Makie.LScene
+        elseif idxs isa AbstractArray && length(idxs) == 3
+            return Makie.LScene  
+        end
+    end
+    return Makie.Axis
+end
 
 function Makie.used_attributes(::Type{<:Plot}, integrator::SciMLBase.DEIntegrator)
     (:plot_analytic, :denseplot, :plotdensity, :vars, :idxs)
@@ -272,6 +298,19 @@ end
 
 # Again, we first define the "ideal" plot type for ensemble solutions.
 Makie.plottype(sol::SciMLBase.AbstractEnsembleSolution) = Makie.Lines
+
+# Define preferred axis type for ensemble plots
+function Makie.preferred_axis_type(plot::Plot{<:Tuple{<:SciMLBase.AbstractEnsembleSolution}})
+    if haskey(plot, :idxs) || haskey(plot, :vars)
+        idxs = haskey(plot, :idxs) ? plot[:idxs][] : (haskey(plot, :vars) ? plot[:vars][] : nothing)
+        if idxs isa Tuple && length(idxs) == 3
+            return Makie.LScene
+        elseif idxs isa AbstractArray && length(idxs) == 3
+            return Makie.LScene  
+        end
+    end
+    return Makie.Axis
+end
 
 # We also define the attributes that are used by the ensemble solution recipe:
 function Makie.used_attributes(::Type{<:Plot}, sol::SciMLBase.AbstractEnsembleSolution)


### PR DESCRIPTION
## Summary
- Fixes #947 by adding `preferred_axis_type` methods for SciML solution types
- Automatically detects when 3D plotting is requested (idxs=(1,2,3)) and returns LScene as the preferred axis type
- Maintains backward compatibility by defaulting to regular Axis for 2D plots

## The Problem
When plotting a 3D system using the Makie recipe with `idxs = (1, 2, 3)`, the plot fails because Makie defaults to a 2D `Axis` instead of using `LScene` for 3D visualizations. Users had to manually specify `axis = (; type = LScene)` as a workaround.

## The Solution
Added `preferred_axis_type` methods for:
- `AbstractTimeseriesSolution`
- `DEIntegrator`
- `AbstractEnsembleSolution`

These methods check if `idxs` (or the deprecated `vars`) parameter contains exactly 3 indices, and if so, return `Makie.LScene` as the preferred axis type. Otherwise, they default to `Makie.Axis`.

## Test plan
- [x] Tested the fix with the MRE from issue #947
- [x] Verified that 2D plots still work correctly with regular Axis
- [x] Verified that manual axis specification still works
- [x] Checked that both tuple and array forms of idxs are handled

🤖 Generated with [Claude Code](https://claude.ai/code)