### PR TITLE
Add validation for constrained optimization problems missing bounds

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -151,6 +151,10 @@ function _check_opt_alg(prob::OptimizationProblem, alg; kwargs...)
         throw(IncompatibleOptimizerError("The algorithm $(typeof(alg)) does not support constraints. Either remove the `cons` function passed to `OptimizationFunction` or use a different algorithm."))
     requiresconstraints(alg) && isnothing(prob.f.cons) &&
         throw(IncompatibleOptimizerError("The algorithm $(typeof(alg)) requires constraints, pass them with the `cons` kwarg in `OptimizationFunction`."))
+    # Check that if constraints are present and the algorithm supports constraints, both lcons and ucons are provided
+    allowsconstraints(alg) && !isnothing(prob.f.cons) && (isnothing(prob.lcons) || isnothing(prob.ucons)) &&
+        throw(ArgumentError("Constrained optimization problem requires both `lcons` and `ucons` to be provided to OptimizationProblem. " *
+                            "Example: OptimizationProblem(optf, u0, p; lcons=[-Inf], ucons=[0.0])"))
     !allowscallback(alg) && haskey(kwargs, :callback) &&
         throw(IncompatibleOptimizerError("The algorithm $(typeof(alg)) does not support callbacks, remove the `callback` keyword argument from the `solve` call."))
     requiresgradient(alg) && !(prob.f isa AbstractOptimizationFunction) &&


### PR DESCRIPTION
## Description
This PR adds validation to ensure that constrained optimization problems have both `lcons` and `ucons` bounds defined when constraints are present. This addresses issue SciML/Optimization.jl#959.

## Problem
When users forget to provide `lcons` and `ucons` for a constrained optimization problem, they get unhelpful errors like:
```
MethodError: no method matching keys(::Nothing)
```

## Solution
Added a check in the `_check_opt_alg` function that validates:
- If the algorithm supports constraints (`allowsconstraints(alg)`)
- AND constraints are present (`\!isnothing(prob.f.cons)`)
- AND either `lcons` or `ucons` is missing
- THEN throw a helpful `ArgumentError` with an example

## Example Error Message
```
Constrained optimization problem requires both `lcons` and `ucons` to be provided to OptimizationProblem. Example: OptimizationProblem(optf, u0, p; lcons=[-Inf], ucons=[0.0])
```

## Benefits
This validation at the SciMLBase level ensures all optimization solvers benefit from the improved error message, providing a uniform experience across the ecosystem.

## Related
- Fixes SciML/Optimization.jl#959
- Related PR in Optimization.jl: SciML/Optimization.jl#960

🤖 Generated with [Claude Code](https://claude.ai/code)