### PR TITLE
Fix function call line split following Catalyst.jl PR #1306

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -58,10 +58,7 @@ expression. Two common reasons for this issue are:
 
 function __init__()
     Base.Experimental.register_error_hint(DomainError) do io, e
-        if e isa DomainError &&
-           occursin(
-            "will only return a complex result if called with a complex argument. Try ",
-            e.msg)
+        if e isa DomainError && occursin("will only return a complex result if called with a complex argument. Try ", e.msg)
             println(io, DOMAINERROR_COMPLEX_MSG)
         end
     end


### PR DESCRIPTION
## Summary

Fix unnecessary line split in Julia code following the guidelines established in [Catalyst.jl PR #1306](https://github.com/SciML/Catalyst.jl/pull/1306). This PR improves code readability by consolidating a short expression that was unnecessarily split across multiple lines.

## Background

These formatting issues are being addressed upstream in [JuliaFormatter.jl PR #934](https://github.com/domluna/JuliaFormatter.jl/pull/934), which implements algorithmic fixes to prevent these unnecessary line splits. However, since that PR is not yet merged, manual fixes are needed in the meantime to improve code readability.

## Changes Made

Fixed **1 instance** of problematic line split:

- **src/debug.jl**: Function call split across 4 lines consolidated to 1 line

## Example Fix

### Before:
```julia
if e isa DomainError &&
   occursin(
    "will only return a complex result if called with a complex argument. Try ",
    e.msg)
```

### After:
```julia
if e isa DomainError && occursin("will only return a complex result if called with a complex argument. Try ", e.msg)
```

## Rationale

Following Catalyst.jl PR #1306's approach:
- **Prioritize readability** over strict formatter rules for short expressions
- **Keep semantically related code units together**
- **Line reduced to 123 characters** (well under reasonable limits)

## Note

This is part of a systematic effort to apply the same formatting improvements across 10+ SciML repositories.

🤖 Generated with [Claude Code](https://claude.ai/code)