### PR TITLE
Remove DiffEqBase reference from Mooncake Extension 

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -152,14 +152,14 @@ const FORWARDDIFF_AUTODETECTION_FAILURE_MESSAGE = """
                                 end
                                 ```
 
-                                Or you can define a dispatch on `DiffEqBase.anyeltypedual`
+                                Or you can define a dispatch on `SciMLBase.anyeltypedual`
                                 which tells the system what fields to interpret as the
                                 differentiable parts. For example, to support ODESolutions
                                 as parameters we tell it the data is `sol.u` and `sol.t` via:
 
                                 ```julia
-                                function DiffEqBase.anyeltypedual(sol::ODESolution, counter = 0)
-                                    DiffEqBase.anyeltypedual((sol.u, sol.t))
+                                function SciMLBase.anyeltypedual(sol::ODESolution, counter = 0)
+                                    SciMLBase.anyeltypedual((sol.u, sol.t))
                                 end
                                 ```
 
@@ -167,7 +167,7 @@ const FORWARDDIFF_AUTODETECTION_FAILURE_MESSAGE = """
                                 that returns Any. For example:
 
                                 ```julia
-                                function DiffEqBase.anyeltypedual(::YourType, ::Type{Val{counter}}) where {counter}
+                                function SciMLBase.anyeltypedual(::YourType, ::Type{Val{counter}}) where {counter}
                                     Any
                                 end
                                 ```

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -6,12 +6,12 @@ import Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
                  @from_rrule, @zero_adjoint, @mooncake_overlay, MinimalCtx,
                  NoPullback
 
-@zero_adjoint MinimalCtx Tuple{typeof(DiffEqBase.numargs), Any}
+@zero_adjoint MinimalCtx Tuple{typeof(SciMLBase.numargs), Any}
 @is_primitive MinimalCtx Tuple{
-    typeof(DiffEqBase.set_mooncakeoriginator_if_mooncake), SciMLBase.ChainRulesOriginator
+    typeof(SciMLBase.set_mooncakeoriginator_if_mooncake), SciMLBase.ChainRulesOriginator
 }
 
-@mooncake_overlay DiffEqBase.set_mooncakeoriginator_if_mooncake(x::SciMLBase.ADOriginator) = SciMLBase.MooncakeOriginator()
+@mooncake_overlay SciMLBase.set_mooncakeoriginator_if_mooncake(x::SciMLBase.ADOriginator) = SciMLBase.MooncakeOriginator()
 
 function rrule!!(
         f::CoDual{typeof(SciMLBase.set_mooncakeoriginator_if_mooncake)},


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Fixes https://github.com/SciML/SciMLBase.jl/issues/1119
