### PR TITLE
Remove `OptimizationFunction`'s `@ref` link from `BVPFunction` docstring

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2261,7 +2261,7 @@ All of the remaining functions are optional for improving or accelerating
 the usage of `f` and `bc`. These include:
 
 - `cost(u, p)`: the target to be minimized, similar with the `cost` function
-  in [`OptimizationFunction`](@ref). This is used to define the objective function
+  in `OptimizationFunction`. This is used to define the objective function
   of the BVP, which can be minimized by optimization solvers.
 - `equality(res, u, t)`: equality constraints functions for the BVP.
 - `inequality(res, u, t)`: inequality constraints functions for the BVP.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

When this docstring is used in DiffEqDocs.jl, the `[...](@ref)` causes the build to fail because `OptimizationFunction`'s docstring is hosted under Optimization.jl and not DiffEqDocs.jl. This can probably be solved by using DocumenterInterlinks.jl or something and using an `[...](@extref)`, but as a quick fix, a simple un-linked name of the type, leaving the user to search online seems sufficient.