### PR TITLE
fix: remove usages of TruncatedStacktraces

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -120,8 +120,6 @@ function Base.showerror(io::IO, e::CommonKwargError)
     unrecognized = collect(keys(e.kwargs))[notin]
     print(io, "Unrecognized keyword arguments: ")
     printstyled(io, unrecognized; bold = true, color = :red)
-    print(io, "\n\n")
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 @enum KeywordArgError KeywordArgWarn KeywordArgSilent
@@ -147,7 +145,6 @@ struct IncompatibleInitialConditionError <: Exception end
 
 function Base.showerror(io::IO, e::IncompatibleInitialConditionError)
     print(io, INCOMPATIBLE_U0_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NO_DEFAULT_ALGORITHM_MESSAGE = """
@@ -164,7 +161,6 @@ struct NoDefaultAlgorithmError <: Exception end
 
 function Base.showerror(io::IO, e::NoDefaultAlgorithmError)
     print(io, NO_DEFAULT_ALGORITHM_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NO_TSPAN_MESSAGE = """
@@ -175,7 +171,6 @@ struct NoTspanError <: Exception end
 
 function Base.showerror(io::IO, e::NoTspanError)
     print(io, NO_TSPAN_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NAN_TSPAN_MESSAGE = """
@@ -189,7 +184,6 @@ struct NaNTspanError <: Exception end
 
 function Base.showerror(io::IO, e::NaNTspanError)
     print(io, NAN_TSPAN_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NON_SOLVER_MESSAGE = """
@@ -207,7 +201,6 @@ struct NonSolverError <: Exception end
 
 function Base.showerror(io::IO, e::NonSolverError)
     print(io, NON_SOLVER_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NOISE_SIZE_MESSAGE = """
@@ -235,7 +228,6 @@ function Base.showerror(io::IO, e::NoiseSizeIncompatabilityError)
     println(io, NOISE_SIZE_MESSAGE)
     println(io, "size(prob.noise_rate_prototype,2) = $(e.prototypesize)")
     println(io, "length(prob.noise.W[1]) = $(e.noisesize)")
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const PROBSOLVER_PAIRING_MESSAGE = """
@@ -256,7 +248,6 @@ function Base.showerror(io::IO, e::ProblemSolverPairingError)
     println(io, "Solver type: $(SciMLBase.__parameterless_type(typeof(e.alg)))")
     println(io,
         "Problem types compatible with the chosen solver: $(compatible_problem_types(e.prob,e.alg))")
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 function compatible_problem_types(prob, alg)
@@ -297,7 +288,6 @@ struct DirectAutodiffError <: Exception end
 
 function Base.showerror(io::IO, e::DirectAutodiffError)
     println(io, DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const NONNUMBER_ELTYPE_MESSAGE = """
@@ -336,7 +326,6 @@ end
 function Base.showerror(io::IO, e::NonNumberEltypeError)
     print(io, NONNUMBER_ELTYPE_MESSAGE)
     print(io, e.eltype)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const GENERIC_NUMBER_TYPE_ERROR_MESSAGE = """
@@ -362,7 +351,6 @@ function Base.showerror(io::IO, e::GenericNumberTypeError)
     println(io, "Solver: $(e.alg)")
     println(io, "u0 type: $(e.uType)")
     print(io, "Timespan type: $(e.tType)")
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const COMPLEX_SUPPORT_ERROR_MESSAGE = """
@@ -381,7 +369,6 @@ end
 function Base.showerror(io::IO, e::ComplexSupportError)
     println(io, COMPLEX_SUPPORT_ERROR_MESSAGE)
     println(io, "Solver: $(e.alg)")
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const COMPLEX_TSPAN_ERROR_MESSAGE = """
@@ -396,7 +383,6 @@ struct ComplexTspanError <: Exception end
 
 function Base.showerror(io::IO, e::ComplexTspanError)
     println(io, COMPLEX_TSPAN_ERROR_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const TUPLE_STATE_ERROR_MESSAGE = """
@@ -434,7 +420,6 @@ struct TupleStateError <: Exception end
 
 function Base.showerror(io::IO, e::TupleStateError)
     println(io, TUPLE_STATE_ERROR_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const MASS_MATRIX_ERROR_MESSAGE = """
@@ -455,7 +440,6 @@ function Base.showerror(io::IO, e::IncompatibleMassMatrixError)
     println(io, e.sz)
     print(io, "length(u0): ")
     println(e.len)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 const LATE_BINDING_TSTOPS_ERROR_MESSAGE = """
@@ -468,5 +452,4 @@ struct LateBindingTstopsNotSupportedError <: Exception end
 
 function Base.showerror(io::IO, e::LateBindingTstopsNotSupportedError)
     println(io, LATE_BINDING_TSTOPS_ERROR_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -29,7 +29,6 @@ end
 function Base.showerror(io::IO, e::NonConcreteEltypeError)
     print(io, NONCONCRETE_ELTYPE_MESSAGE)
     print(io, e.eltype)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 # Skip the DiffEqBase handling
@@ -531,7 +530,6 @@ struct AdjointNotFoundError <: Exception end
 
 function Base.showerror(io::IO, e::AdjointNotFoundError)
     print(io, ADJOINT_NOT_FOUND_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 function _concrete_solve_adjoint(args...; kwargs...)
@@ -548,7 +546,6 @@ struct ForwardSensitivityNotFoundError <: Exception end
 
 function Base.showerror(io::IO, e::ForwardSensitivityNotFoundError)
     print(io, FORWARD_SENSITIVITY_NOT_FOUND_MESSAGE)
-    println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
 
 function _concrete_solve_forward(args...; kwargs...)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
