### PR TITLE
Fix OptimizationFunction{false} isinplace check

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -4279,7 +4279,6 @@ function OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
         lag_hess_colorvec = nothing,
         initialization_data = __has_initialization_data(f) ? f.initialization_data :
                               nothing) where {iip}
-    isinplace(f, 2; has_two_dispatches = false, isoptimization = true)
     sys = sys_or_symbolcache(sys, syms, paramsyms)
     OptimizationFunction{
         iip, typeof(adtype), typeof(f), typeof(grad), typeof(fg), typeof(hess),

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -510,7 +510,7 @@ OptimizationProblem(optf, 1.0)
 # Test OptimizationFunction{iip} respects explicit iip parameter
 # This function would fail isinplace check due to method ambiguity
 struct ProblematicOptFunction end
-(::ProblematicOptFunction)(x, p) = sum(x.^2)
+(::ProblematicOptFunction)(x, p) = sum(x .^ 2)
 # But when iip is explicitly provided, it should work without calling isinplace
 @test_nowarn OptimizationFunction{false}(ProblematicOptFunction())
 @test_nowarn OptimizationFunction{true}(ProblematicOptFunction())

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -507,6 +507,14 @@ optf(u, p) = 1.0
 OptimizationFunction(optf)
 OptimizationProblem(optf, 1.0)
 
+# Test OptimizationFunction{iip} respects explicit iip parameter
+# This function would fail isinplace check due to method ambiguity
+struct ProblematicOptFunction end
+(::ProblematicOptFunction)(x, p) = sum(x.^2)
+# But when iip is explicitly provided, it should work without calling isinplace
+@test_nowarn OptimizationFunction{false}(ProblematicOptFunction())
+@test_nowarn OptimizationFunction{true}(ProblematicOptFunction())
+
 # BVPFunction
 
 bfoop(u, p, t) = u


### PR DESCRIPTION
## Summary
- Remove unnecessary `isinplace` check from `OptimizationFunction{iip}` constructor when `iip` is explicitly provided
- Add tests to verify the fix works correctly
- Align behavior with `ODEFunction{iip}` which already handles this correctly

## Problem
`OptimizationFunction{false}` was still calling `isinplace(f, 2)` even when the user explicitly provided the `iip=false` type parameter. This prevented users from creating `OptimizationFunction` objects with functions that fail the `isinplace` check (such as compiled Reactant functions), even when they know the function signature and want to bypass the automatic detection.

## Solution
- Remove the `isinplace` call from line 4282 in the `OptimizationFunction{iip}` constructor
- Keep the `isinplace` call in the non-parameterized `OptimizationFunction` constructor where it's needed to infer the `iip` value
- Add tests to ensure both `OptimizationFunction{false}` and `OptimizationFunction{true}` work without triggering `isinplace` checks

## Test plan
- [x] All existing tests pass
- [x] New test verifies that `OptimizationFunction{iip}` can be created with functions that would fail `isinplace` checks
- [x] Behavior now matches `ODEFunction{iip}` patterns

Fixes #1103

🤖 Generated with [Claude Code](https://claude.ai/code)