### PR TITLE
Move type/constructor signatures for alias types to top of docstrings

### DIFF
--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -30,10 +30,10 @@ end
 export AnalyticalProblem, AbstractAnalyticalProblem
 
 @doc doc"""
+    AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an AnalyticalProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
     

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -444,10 +444,10 @@ function TwoPointSecondOrderBVProblem(
 end
 
 @doc doc"""
+    BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an BVP. Conforms to the AbstractAliasSpecifier interface. 
-    `BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -121,10 +121,10 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
 end
 
 @doc doc"""
+    DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DAE. Conforms to the AbstractAliasSpecifier interface. 
-    `DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -398,10 +398,10 @@ function SecondOrderDDEProblem(f::DynamicalDDEFunction, args...; kwargs...)
 end
 
 @doc doc"""
+    DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DDE. Conforms to the AbstractAliasSpecifier interface. 
-    `DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -166,10 +166,10 @@ function DiscreteProblem(u0::Union{AbstractArray, Number}, tspan,
 end
 
 @doc doc"""
+    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DiscreteProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -132,7 +132,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: ImplicitDiscreteP
 end
 
 @doc doc"""
-    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    ImplicitDiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -132,10 +132,10 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: ImplicitDiscreteP
 end
 
 @doc doc"""
+    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
-    `DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -169,10 +169,10 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
 end
 
 @doc doc"""
+    IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an IntegralProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)``
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -144,9 +144,10 @@ function SymbolicIndexingInterface.set_parameter!(
 end
 
 @doc doc"""
+    LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
+
 Holds information on what variables to alias
 when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -566,9 +566,10 @@ function SymbolicIndexingInterface.set_parameter!(prob::SCCNonlinearProblem, val
 end
 
 @doc doc"""
+    NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+
 Holds information on what variables to alias when solving a `NonlinearProblem`. 
 Conforms to the AbstractAliasSpecifier interface. 
-    `NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -512,10 +512,10 @@ function IncrementingODEProblem{iip}(f::IncrementingODEFunction, u0, tspan,
 end
 
 @doc doc"""
+    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
-    `ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -155,10 +155,10 @@ isinplace(f::OptimizationFunction{iip}) where {iip} = iip
 isinplace(f::OptimizationProblem{iip}) where {iip} = iip
 
 @doc doc"""
+    OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)
 
 Holds information on what variables to alias
 when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)`
 
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -92,10 +92,10 @@ function RODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
 end
 
 @doc doc"""
+    RODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
 
 Holds information on what variables to alias
 when solving an RODEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `RODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -175,10 +175,10 @@ end
 SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob.h
 
 @doc doc"""
+    SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an SDDEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -223,10 +223,10 @@ function DynamicalSDEProblem{iip}(f::DynamicalSDEFunction, v0, u0, tspan,
 end
 
 @doc doc"""
+    SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an SDEProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -136,10 +136,10 @@ end
 SymbolicIndexingInterface.is_time_dependent(::SteadyStateProblem) = true
 
 @doc doc"""
+    SteadyStateAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a SteadyStateProblem. Conforms to the AbstractAliasSpecifier interface. 
-    `SteadyStateAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)`
 
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
  None applicable
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Moves the type/constructor signature of Alias Specifier subtypes to the top of their respective docstrings. This allows Documenter.jl and terminal/REPL help viewer to pick it up as a signature, and follows convention of docstring order for better readability.
