### PR TITLE
Use markdown link syntax and update hyperlinks

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -98,7 +98,7 @@ to be specified at compiled time and thus cannot have a Bool-based opt out, so i
 may be extended to use a preference system to opt-out with a `UPCONVERT_DUALS`. In the case where
 upconversion is not done automatically, the user is required to upconvert all initial conditions
 themselves, for an example of how this can be confusing to a user see
-https://discourse.julialang.org/t/typeerror-in-julia-turing-when-sampling-for-a-forced-differential-equation/82937
+<https://discourse.julialang.org/t/typeerror-in-julia-turing-when-sampling-for-a-forced-differential-equation/82937>
 """
 @generated function anyeltypedual(x, ::Type{Val{counter}}) where {counter}
     x = x.name === Core.Compiler.typename(Type) ? x.parameters[1] : x

--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -16,7 +16,7 @@ function ensure_plottrait(PT::Type, arg, desired_plottrait_type::Type)
               ::$(string(typeof(arg)))
 
               Makie needs to convert all plot input arguments to types that can be consumed by the backends (typically Arrays with Float32 elements).
-              You can define a method for `Makie.convert_arguments` (a type recipe) for these types or their supertypes to make this set of arguments convertible (See http://docs.makie.org/stable/documentation/recipes/index.html).
+              You can define a method for `Makie.convert_arguments` (a type recipe) for these types or their supertypes to make this set of arguments convertible (See <http://docs.makie.org/stable/documentation/recipes/index.html>).
 
               Alternatively, you can define `Makie.convert_single_argument` for single arguments which have types that are unknown to Makie but which can be converted to known types and fed back to the conversion pipeline.
               """)

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -275,7 +275,7 @@ not converge to the same answer. In the context of a stochastic differential equ
 on the integral rule that is chosen. This trait describes which interpretation the solver algorithm subscribes to, and thus whether the solution should
 be interpreted as the solution to the SDE under the Ito or Stratonovich interpretation.
 
-For more information, see https://oatml.cs.ox.ac.uk/blog/2022/03/22/ito-strat.html as a good high-level explanation.
+For more information, see <https://oatml.cs.ox.ac.uk/blog/2022/03/22/ito-strat.html> as a good high-level explanation.
 
 !!! note
 

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -20,7 +20,7 @@ one could perform a domain transformation on the variables so that such an issue
 definition of `f`.
 
 For more information, check out the following FAQ page:
-https://docs.sciml.ai/Optimization/stable/API/FAQ/#The-Solver-Seems-to-Violate-Constraints-During-the-Optimization,-Causing-DomainErrors,-What-Can-I-Do-About-That?"""
+<https://docs.sciml.ai/Optimization/stable/API/FAQ/#The-Solver-Seems-to-Violate-Constraints-During-the-Optimization,-Causing-DomainErrors,-What-Can-I-Do-About-That?>"""
 
 FUNCTIONWRAPPERSWRAPPERS_MSG = """
 No appropriate function wrapper found. This means that the auto-despecialization code used for the reduction
@@ -36,11 +36,11 @@ if `f` has 3 arguments `(u,p,t)` then it's false, otherwise `f(du,u,p,t)` is tru
 
 For more information on the control of specialization options, please see the documentation at:
 
-https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Choices
+<https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Choices>
 
 If one wants way more detail than necessary on why the function wrappers exist and what they are doing, see:
 
-https://sciml.ai/news/2022/09/21/compile_time/"""
+<https://sciml.ai/news/2022/09/21/compile_time>"""
 
 const NO_PARAMETERS_ARITHMETIC_ERROR_MESSAGE = """
 

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -96,7 +96,7 @@ const KWARGWARN_MESSAGE = """
                           The only allowed keyword arguments to `solve` are:
                           $allowedkeywords
 
-                          See <https://diffeq.sciml.ai/stable/basics/common_solver_opts/> for more details.
+                          See <https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts> for more details.
 
                           Set kwargshandle=KeywordArgError for an error message.
                           Set kwargshandle=KeywordArgSilent to ignore this message.
@@ -107,7 +107,7 @@ const KWARGERROR_MESSAGE = """
                            The only allowed keyword arguments to `solve` are:
                            $allowedkeywords
 
-                           See <https://diffeq.sciml.ai/stable/basics/common_solver_opts/> for more details.
+                           See <https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts> for more details.
                            """
 
 struct CommonKwargError <: Exception
@@ -140,7 +140,7 @@ const INCOMPATIBLE_U0_MESSAGE = """
                                 choice in the problem constructor, i.e. `ODEProblem{false}(f,u0,tspan,p,kwargs...)`.
 
                                 For a longer discussion on mutability vs immutability and in-place vs out-of-place, see:
-                                <https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Example-Accelerating-a-Non-Stiff-Equation:-The-Lorenz-Equation>
+                                <https://docs.sciml.ai/DiffEqDocs/stable/tutorials/faster_ode_example#Example-Accelerating-a-Non-Stiff-Equation:-The-Lorenz-Equation>
                                 """
 
 struct IncompatibleInitialConditionError <: Exception end
@@ -156,7 +156,7 @@ const NO_DEFAULT_ALGORITHM_MESSAGE = """
                                      `init(prob, Tsit5())` for an ODE) or import DifferentialEquations
                                      directly.
 
-                                     You can find the list of available solvers at <https://diffeq.sciml.ai/stable/solvers/ode_solve/>
+                                     You can find the list of available solvers at <https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve>
                                      and its associated pages.
                                      """
 
@@ -199,7 +199,7 @@ const NON_SOLVER_MESSAGE = """
 
                            Please double check the arguments being sent to the solver.
 
-                           You can find the list of available solvers at <https://diffeq.sciml.ai/stable/solvers/ode_solve/>
+                           You can find the list of available solvers at <https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve>
                            and its associated pages.
                            """
 
@@ -290,7 +290,7 @@ const DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE = """
                                                 For more details on automatic differentiation, adjoint, and sensitivity analysis
                                                 of differential equations, see the documentation page:
 
-                                                <https://diffeq.sciml.ai/stable/analysis/sensitivity/>
+                                                <https://docs.sciml.ai/SciMLSensitivity/>
                                                 """
 
 struct DirectAutodiffError <: Exception end
@@ -427,7 +427,7 @@ const TUPLE_STATE_ERROR_MESSAGE = """
                                   ```
 
                                   This will be safer and fast for small ODEs. For more information, see:
-                                  <https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Further-Optimizations-of-Small-Non-Stiff-ODEs-with-StaticArrays>
+                                  <https://docs.sciml.ai/DiffEqDocs/stable/tutorials/faster_ode_example/#Further-Optimizations-of-Small-Non-Stiff-ODEs-with-StaticArrays>
                                   """
 
 struct TupleStateError <: Exception end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -96,7 +96,7 @@ const KWARGWARN_MESSAGE = """
                           The only allowed keyword arguments to `solve` are:
                           $allowedkeywords
 
-                          See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
+                          See <https://diffeq.sciml.ai/stable/basics/common_solver_opts/> for more details.
 
                           Set kwargshandle=KeywordArgError for an error message.
                           Set kwargshandle=KeywordArgSilent to ignore this message.
@@ -107,7 +107,7 @@ const KWARGERROR_MESSAGE = """
                            The only allowed keyword arguments to `solve` are:
                            $allowedkeywords
 
-                           See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
+                           See <https://diffeq.sciml.ai/stable/basics/common_solver_opts/> for more details.
                            """
 
 struct CommonKwargError <: Exception
@@ -140,7 +140,7 @@ const INCOMPATIBLE_U0_MESSAGE = """
                                 choice in the problem constructor, i.e. `ODEProblem{false}(f,u0,tspan,p,kwargs...)`.
 
                                 For a longer discussion on mutability vs immutability and in-place vs out-of-place, see:
-                                https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Example-Accelerating-a-Non-Stiff-Equation:-The-Lorenz-Equation
+                                <https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Example-Accelerating-a-Non-Stiff-Equation:-The-Lorenz-Equation>
                                 """
 
 struct IncompatibleInitialConditionError <: Exception end
@@ -156,7 +156,7 @@ const NO_DEFAULT_ALGORITHM_MESSAGE = """
                                      `init(prob, Tsit5())` for an ODE) or import DifferentialEquations
                                      directly.
 
-                                     You can find the list of available solvers at https://diffeq.sciml.ai/stable/solvers/ode_solve/
+                                     You can find the list of available solvers at <https://diffeq.sciml.ai/stable/solvers/ode_solve/>
                                      and its associated pages.
                                      """
 
@@ -199,7 +199,7 @@ const NON_SOLVER_MESSAGE = """
 
                            Please double check the arguments being sent to the solver.
 
-                           You can find the list of available solvers at https://diffeq.sciml.ai/stable/solvers/ode_solve/
+                           You can find the list of available solvers at <https://diffeq.sciml.ai/stable/solvers/ode_solve/>
                            and its associated pages.
                            """
 
@@ -290,7 +290,7 @@ const DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE = """
                                                 For more details on automatic differentiation, adjoint, and sensitivity analysis
                                                 of differential equations, see the documentation page:
 
-                                                https://diffeq.sciml.ai/stable/analysis/sensitivity/
+                                                <https://diffeq.sciml.ai/stable/analysis/sensitivity/>
                                                 """
 
 struct DirectAutodiffError <: Exception end
@@ -427,7 +427,7 @@ const TUPLE_STATE_ERROR_MESSAGE = """
                                   ```
 
                                   This will be safer and fast for small ODEs. For more information, see:
-                                  https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Further-Optimizations-of-Small-Non-Stiff-ODEs-with-StaticArrays
+                                  <https://diffeq.sciml.ai/stable/tutorials/faster_ode_example/#Further-Optimizations-of-Small-Non-Stiff-ODEs-with-StaticArrays>
                                   """
 
 struct TupleStateError <: Exception end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -11,7 +11,7 @@ struct TwoPointBVProblem{iip} end # The iip is needed to make type stable constr
 @doc doc"""
 
 Defines an BVP problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/>
 
 ## Mathematical Specification of a BVP Problem
 
@@ -253,7 +253,7 @@ struct TwoPointSecondOrderBVProblem{iip} end # The iip is needed to make type st
 @doc doc"""
 
 Defines a second order BVP problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/>
 
 ## Mathematical Specification of a second order BVP Problem
 

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -2,7 +2,7 @@
 
 Defines an implicit ordinary differential equation (ODE) or
 differential-algebraic equation (DAE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/dae_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/dae_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dae_types/>
 
 ## Mathematical Specification of an DAE Problem
 

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -6,7 +6,7 @@ struct StandardDDEProblem end
 @doc doc"""
 
 Defines a delay differential equation (DDE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/dde_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/dde_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dde_types/>
 
 ## Mathematical Specification of a DDE Problem
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -4,7 +4,7 @@ const DISCRETE_OUTOFPLACE_DEFAULT = DiscreteFunction{false}((u, p, t) -> u)
 @doc doc"""
 
 Defines a discrete dynamical system problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/>
 
 ## Mathematical Specification of a Discrete Problem
 

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -1,7 +1,7 @@
 @doc doc"""
 
 Defines a discrete dynamical system problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/>
 
 ## Mathematical Specification of a ImplicitDiscrete Problem
 

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -1,7 +1,7 @@
 @doc doc"""
 
 Defines an integral problem.
-Documentation Page: [https://docs.sciml.ai/Integrals/stable/](https://docs.sciml.ai/Integrals/stable/)
+Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
 
 ## Mathematical Specification of an Integral Problem
 
@@ -123,7 +123,7 @@ struct QuadratureProblem end
 @doc doc"""
 
 Defines a integral problem over pre-sampled data.
-Documentation Page: https://docs.sciml.ai/Integrals/stable/
+Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
 
 ## Mathematical Specification of a data Integral Problem
 

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -50,7 +50,7 @@ end
 @doc doc"""
 
 Defines a linear system problem.
-Documentation Page: [https://docs.sciml.ai/LinearSolve/stable/basics/LinearProblem/](https://docs.sciml.ai/LinearSolve/stable/basics/LinearProblem/)
+Documentation Page: <https://docs.sciml.ai/LinearSolve/stable/basics/LinearProblem/>
 
 ## Mathematical Specification of a Linear Problem
 

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -6,7 +6,7 @@ struct StandardNonlinearProblem end
 @doc doc"""
 
 Defines an interval nonlinear system problem.
-Documentation Page: [https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/](https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/)
+Documentation Page: <https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/>
 
 ## Mathematical Specification of an Interval Nonlinear Problem
 
@@ -107,7 +107,7 @@ end
 @doc doc"""
 
 Defines a nonlinear system problem.
-Documentation Page: [https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/](https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/)
+Documentation Page: <https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/>
 
 ## Mathematical Specification of a Nonlinear Problem
 

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -6,7 +6,7 @@ struct StandardODEProblem end
 @doc doc"""
 
 Defines an ordinary differential equation (ODE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/>
 
 ## Mathematical Specification of an ODE Problem
 
@@ -210,7 +210,7 @@ abstract type AbstractDynamicalODEProblem end
 @doc doc"""
 
 Defines a dynamical ordinary differential equation (ODE) problem.
-Documentation Page: https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/>
 
 Dynamical ordinary differential equations, such as those arising from the definition
 of a Hamiltonian system or a second order ODE, have a special structure that can be
@@ -288,7 +288,7 @@ end
 @doc doc"""
 
 Defines a second order ordinary differential equation (ODE) problem.
-Documentation Page: https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/>
 
 ## Mathematical Specification of a 2nd Order ODE Problem
 
@@ -392,7 +392,7 @@ abstract type AbstractSplitODEProblem end
 @doc doc"""
 
 Defines a split ordinary differential equation (ODE) problem.
-Documentation Page: https://docs.sciml.ai/DiffEqDocs/stable/types/split_ode_types/
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/split_ode_types/>
 
 ## Mathematical Specification of a Split ODE Problem
 

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -3,7 +3,7 @@
 @doc doc"""
 
 Defines an optimization problem.
-Documentation Page: [https://docs.sciml.ai/Optimization/stable/API/optimization_problem/](https://docs.sciml.ai/Optimization/stable/API/optimization_problem/)
+Documentation Page: <https://docs.sciml.ai/Optimization/stable/API/optimization_problem/>
 
 ## Mathematical Specification of an Optimization Problem
 

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,7 +1,7 @@
 @doc doc"""
 
 Defines a random ordinary differential equation (RODE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/rode_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/rode_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/rode_types/>
 
 ## Mathematical Specification of a RODE Problem
 

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -1,7 +1,7 @@
 @doc doc"""
 
 Defines a stochastic delay differential equation (SDDE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/sdde_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/sdde_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/sdde_types/>
 
 ## Mathematical Specification of a Stochastic Delay Differential Equation (SDDE) Problem
 

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -6,7 +6,7 @@ struct StandardSDEProblem end
 @doc doc"""
 
 Defines an stochastic differential equation (SDE) problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/sde_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/sde_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/sde_types/>
 
 ## Mathematical Specification of a SDE Problem
 

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,7 +1,7 @@
 @doc doc"""
 
 Defines a steady state ODE problem.
-Documentation Page: [https://docs.sciml.ai/DiffEqDocs/stable/types/steady_state_types/](https://docs.sciml.ai/DiffEqDocs/stable/types/steady_state_types/)
+Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/steady_state_types/>
 
 ## Mathematical Specification of a Steady State Problem
 

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -17,7 +17,7 @@ Representation of the solution to an linear system Ax=b defined by a LinearProbl
   - `cache`: the `LinearCache` object containing the solver's internal cached variables. This
     is given to allow continuation of solver usage, for example, solving `Ax=b` with the same
     `A` and a new `b` without refactorizing `A`. See the caching interface tutorial for details
-    on how to use the `cache` effectively: http://docs.sciml.ai/LinearSolve/stable/tutorials/caching_interface/
+    on how to use the `cache` effectively: <http://docs.sciml.ai/LinearSolve/stable/tutorials/caching_interface>
   - `stats`: statistics of the solver, such as the number of function evaluations required.
 """
 struct LinearSolution{T, N, uType, R, A, C, S} <: AbstractLinearSolution{T, N}

--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -8,7 +8,7 @@ Representation of the solution to an differential-algebraic equation defined by 
 For more information on interacting with `DESolution` types, check out the Solution Handling
 page of the DifferentialEquations.jl documentation.
 
-https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/
+<https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/>
 
 ## Fields
 

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -87,7 +87,7 @@ Representation of the solution to an ordinary differential equation defined by a
 For more information on interacting with `DESolution` types, check out the Solution Handling
 page of the DifferentialEquations.jl documentation.
 
-https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/
+<https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/>
 
 ## Fields
 

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -11,7 +11,7 @@ or of a random ordinary differential equation defined by an RODEProblem.
 For more information on interacting with `DESolution` types, check out the Solution Handling
 page of the DifferentialEquations.jl documentation.
 
-https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/
+<https://docs.sciml.ai/DiffEqDocs/stable/basics/solution>
 
 ## Fields
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -178,7 +178,7 @@ const OPTIMIZER_MISSING_ERROR_MESSAGE = """
                                         `solve(prob,Optim.BFGS())` requires `using OptimizationOptimJL` and
                                         `solve(prob,Adam())` requires `using OptimizationOptimisers`.
 
-                                        For more information, see the Optimization.jl documentation: https://docs.sciml.ai/Optimization/stable/.
+                                        For more information, see the Optimization.jl documentation: <https://docs.sciml.ai/Optimization/stable/>.
                                         """
 
 struct OptimizerMissingError <: Exception
@@ -523,7 +523,7 @@ end
 const ADJOINT_NOT_FOUND_MESSAGE = """
                                   Compatibility with reverse-mode automatic differentiation requires SciMLSensitivity.jl.
                                   Please install SciMLSensitivity.jl and do `using SciMLSensitivity`/`import SciMLSensitivity`
-                                  for this functionality. For more details, see https://sensitivity.sciml.ai/dev/.
+                                  for this functionality. For more details, see <https://sensitivity.sciml.ai/dev/>.
                                   """
 
 struct AdjointNotFoundError <: Exception end
@@ -540,7 +540,7 @@ end
 const FORWARD_SENSITIVITY_NOT_FOUND_MESSAGE = """
                                               Compatibility with forward-mode automatic differentiation requires SciMLSensitivity.jl.
                                               Please install SciMLSensitivity.jl and do `using SciMLSensitivity`/`import SciMLSensitivity`
-                                              for this functionality. For more details, see https://sensitivity.sciml.ai/dev/.
+                                              for this functionality. For more details, see <https://sensitivity.sciml.ai/dev/>.
                                               """
 
 struct ForwardSensitivityNotFoundError <: Exception end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -523,7 +523,7 @@ end
 const ADJOINT_NOT_FOUND_MESSAGE = """
                                   Compatibility with reverse-mode automatic differentiation requires SciMLSensitivity.jl.
                                   Please install SciMLSensitivity.jl and do `using SciMLSensitivity`/`import SciMLSensitivity`
-                                  for this functionality. For more details, see <https://sensitivity.sciml.ai/dev/>.
+                                  for this functionality. For more details, see <https://docs.sciml.ai/SciMLSensitivity/dev/>.
                                   """
 
 struct AdjointNotFoundError <: Exception end
@@ -540,7 +540,7 @@ end
 const FORWARD_SENSITIVITY_NOT_FOUND_MESSAGE = """
                                               Compatibility with forward-mode automatic differentiation requires SciMLSensitivity.jl.
                                               Please install SciMLSensitivity.jl and do `using SciMLSensitivity`/`import SciMLSensitivity`
-                                              for this functionality. For more details, see <https://sensitivity.sciml.ai/dev/>.
+                                              for this functionality. For more details, see <https://docs.sciml.ai/SciMLSensitivity/dev/>.
                                               """
 
 struct ForwardSensitivityNotFoundError <: Exception end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
  None applicable
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Use `<`angle brackets`>` for when the hyperlink text is the URL itself, and update hyperlink targets.
