### PR TITLE
Fix markdown lists in docstrings

### DIFF
--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -14,8 +14,8 @@ EnsembleProblem(prob::AbstractSciMLProblem;
 ## Positional Arguments
 
   - `prob`: The canonical problem of the ensemble problem. This is the prob that is seeded
-  into each `prob_func` call to be used as the one that is manipulated/changed for each
-  run of the ensemble.
+    into each `prob_func` call to be used as the one that is manipulated/changed for each
+    run of the ensemble.
 
 ## Keyword Arguments
 
@@ -103,12 +103,12 @@ Each field controls how the ensemble behaves during simulation.
 
 ## Arguments
 
-    - `prob`: The original base problem to replicate or modify.
-    - `prob_func`: A function that defines how to generate each subproblem.
-    - `output_func`: A function to post-process each individual simulation result.
-    - `reduction`: A function to combine results from all simulations.
-    - `u_init`: The initial container used to accumulate the results.
-    - `safetycopy`: Whether to copy the problem when creating subproblems (to avoid unintended modifications).
+  - `prob`: The original base problem to replicate or modify.
+  - `prob_func`: A function that defines how to generate each subproblem.
+  - `output_func`: A function to post-process each individual simulation result.
+  - `reduction`: A function to combine results from all simulations.
+  - `u_init`: The initial container used to accumulate the results.
+  - `safetycopy`: Whether to copy the problem when creating subproblems (to avoid unintended modifications).
 """
 struct EnsembleProblem{T, T2, T3, T4, T5} <: AbstractEnsembleProblem
     prob::T


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
  None applicable
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

In the two(?) docstrings for `EnsembleProblem`, the first one has list fragmentation, since the list content is not all indented at the same level after the list marker (`-`).
In the second list, the 4-space indent is detected by Documenter.jl as a code block and the list aspect ignored.
