### PR TITLE
Fix stray/missing backticks and backslashes in strings

### DIFF
--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -26,7 +26,7 @@ to numbers or vectors for `u₀`; one is allowed to provide `u₀` as arbitrary 
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
   the specialization level. See the [specialization levels section of the SciMLBase documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Levels)
-  for more details. The default is `AutoSpecialize.
+  for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction documentation.
 

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -70,7 +70,7 @@ SDDEProblem{isinplace,specialize}(f,g[, u0], h, tspan[, p]; <keyword arguments>)
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
 the specialization level. See the [specialization levels section of the SciMLBase documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Levels)
-for more details. The default is `AutoSpecialize.
+for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction documentation.
 

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -41,7 +41,7 @@ with initial condition `u0`.
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
   the specialization level. See the [specialization levels section of the SciMLBase documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Levels)
-  for more details. The default is `AutoSpecialize.
+  for more details. The default is `AutoSpecialize`.
 
 Parameters are optional, and if not given then a `NullParameters()` singleton
 will be used which will throw nice errors if you try to index non-existent

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -8,7 +8,7 @@ Statistics from the nonlinear equation solver about the solution process.
   - nf: Number of function evaluations.
   - njacs: Number of Jacobians created during the solve.
   - nfactors: Number of factorzations of the jacobian required for the solve.
-  - nsolve: Number of linear solves `W\b` required for the solve.
+  - nsolve: Number of linear solves `W\\b` required for the solve.
   - nsteps: Total number of iterations for the nonlinear solver.
 """
 mutable struct NLStats

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -14,7 +14,7 @@ Statistics from the differential equation solver about the solution process.
     it is zero.
   - nw: The number of W=I-gamma*J (or W=I/gamma-J) matrices constructed during the solving
     process.
-  - nsolve: The number of linear solves `W\b` required for the integration.
+  - nsolve: The number of linear solves `W\\b` required for the integration.
   - njacs: Number of Jacobians calculated during the integration.
   - nnonliniter: Total number of iterations for the nonlinear solvers.
   - nnonlinconvfail: Number of nonlinear solver convergence failures.

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -48,7 +48,7 @@ solve(prob::OptimizationProblem, alg::AbstractOptimizationAlgorithm,
     args...; kwargs...)::OptimizationSolution
 ```
 
-For information about the returned solution object, refer to the documentation for [OptimizationSolution](@ref)
+For information about the returned solution object, refer to the documentation for [`OptimizationSolution`](@ref)
 
 ## Keyword Arguments
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
  None applicable, changes verified by a Documenter.jl render.
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add closing backticks and escape backslashes.
