### PR TITLE
Get rid of `promote_tspan` in ForwardDiffExt

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -375,25 +375,6 @@ function anyeltypedual(::Type{T},
     T
 end
 
-function promote_tspan(u0::AbstractArray{<:ForwardDiff.Dual}, p, tspan, prob, kwargs)
-    if (haskey(kwargs, :callback) && has_continuous_callback(kwargs[:callback])) ||
-       (haskey(prob.kwargs, :callback) && has_continuous_callback(prob.kwargs[:callback]))
-        return _promote_tspan(eltype(u0).(tspan), kwargs)
-    else
-        return _promote_tspan(tspan, kwargs)
-    end
-end
-
-function promote_tspan(u0::AbstractArray{<:Complex{<:ForwardDiff.Dual}}, p, tspan, prob,
-        kwargs)
-    return _promote_tspan(real(eltype(u0)).(tspan), kwargs)
-end
-
-function promote_tspan(u0::AbstractArray{<:ForwardDiff.Dual}, p,
-        tspan::Tuple{<:ForwardDiff.Dual, <:ForwardDiff.Dual}, prob, kwargs)
-    return _promote_tspan(tspan, kwargs)
-end
-
 value(x::Type{ForwardDiff.Dual{T, V, N}}) where {T, V, N} = V
 value(x::ForwardDiff.Dual) = value(ForwardDiff.value(x))
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

These belong in DiffEqBase. 