### PR TITLE
Fix markdown syntax errors and document repeat parameter in Ensembles.md

### DIFF
--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -108,7 +108,7 @@ SciMLBase.EnsembleAnalysis.componentwise_vectors_timepoint
 
 The available functions for time steps are:
 
-```docs
+```@docs
 SciMLBase.EnsembleAnalysis.timestep_mean
 SciMLBase.EnsembleAnalysis.timestep_median
 SciMLBase.EnsembleAnalysis.timestep_quantile
@@ -151,7 +151,7 @@ timeseries_steps_weighted_meancov
 
 The available functions for the time points are:
 
-```docs
+```@docs
 SciMLBase.EnsembleAnalysis.timeseries_point_mean
 SciMLBase.EnsembleAnalysis.timeseries_point_median
 SciMLBase.EnsembleAnalysis.timeseries_point_quantile
@@ -159,6 +159,7 @@ SciMLBase.EnsembleAnalysis.timeseries_point_meanvar
 SciMLBase.EnsembleAnalysis.timeseries_point_meancov
 SciMLBase.EnsembleAnalysis.timeseries_point_meancor
 SciMLBase.EnsembleAnalysis.timeseries_point_weighted_meancov
+```
 
 ### EnsembleSummary
 
@@ -197,6 +198,12 @@ prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 For our ensemble simulation, we would like to change the initial condition around.
 This is done through the `prob_func`. This function takes in the base problem
 and modifies it to create the new problem that the trajectory actually solves.
+The `prob_func` has the signature `prob_func(prob, i, repeat)` where:
+
+- `prob` is the base problem to be modified
+- `i` is the unique trajectory index (`1` to `trajectories`)  
+- `repeat` is the repeat iteration number (starts at `1`, increments if `output_func` returned `rerun=true`)
+
 Here, we will take the base problem, multiply the initial condition by a `rand()`,
 and use that for calculating the trajectory:
 


### PR DESCRIPTION
## Summary

This PR fixes the markdown syntax errors in the "Parallel Ensemble Simulations Interface" documentation section that were making the documentation difficult to read, and adds missing documentation for the `repeat` parameter in `prob_func`.

### Changes Made

- **Fixed markdown syntax errors**: Changed incorrect `docs` to `@docs` syntax in the "Full Timeseries Statistics" section (lines 111 and 154)
- **Added missing closing backticks**: Properly closed the `@docs` code block that was missing its closing backticks
- **Documented the `repeat` parameter**: Added comprehensive documentation for the `repeat` parameter in the `prob_func` signature, explaining that it tracks iteration numbers for reruns when `output_func` returns `rerun=true`

### Details

The issue reported that the documentation starting from the "Full Timeseries Statistics" section had markdown syntax errors making it hard to read. Upon investigation, I found:

1. Two instances where `docs` was used instead of `@docs` in code blocks
2. A missing closing backtick sequence for an `@docs` block 
3. The `repeat` parameter in `prob_func` was never explained in the documentation, even though it appears in all the examples

The `repeat` parameter documentation was added based on the comprehensive docstring in `src/ensemble/ensemble_problems.jl` which explains that `repeat` is the iteration of the repeat that starts at 1 and increments if `rerun` was true.

## Test plan

- [x] Verified all markdown syntax errors are fixed
- [x] Confirmed the `repeat` parameter is now properly documented
- [x] Ensured documentation maintains consistency with existing style

Fixes #1141

🤖 Generated with [Claude Code](https://claude.ai/code)