### PR TITLE
Add comprehensive docstrings for DAE initialization algorithms

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -345,17 +345,78 @@ $(TYPEDEF)
 abstract type DAEInitializationAlgorithm <: AbstractSciMLAlgorithm end
 
 """
-$(TYPEDEF)
+    struct NoInit <: DAEInitializationAlgorithm
+
+An initialization algorithm that completely skips the initialization phase. The solver
+will use the provided initial conditions directly without any consistency checks or
+modifications.
+
+⚠️ **Warning**: Using `NoInit()` with inconsistent initial conditions will likely cause
+solver failures or incorrect results. Only use this when you are absolutely certain
+your initial conditions satisfy all DAE constraints.
+
+This is useful when:
+- You know your initial conditions are already perfectly consistent
+- You want to avoid the computational cost of initialization
+- You are debugging solver issues and want to isolate initialization from integration
+
+## Example
+```julia
+prob = DAEProblem(f, du0_consistent, u0_consistent, tspan)
+sol = solve(prob, IDA(), initializealg = NoInit())
+```
 """
 struct NoInit <: DAEInitializationAlgorithm end
 
 """
-$(TYPEDEF)
+    struct CheckInit <: DAEInitializationAlgorithm
+
+An initialization algorithm that only checks if the initial conditions are consistent
+with the DAE constraints, without attempting to modify them. If the conditions are not
+consistent within the solver's tolerance, an error will be thrown.
+
+This is useful when:
+- You have already computed consistent initial conditions
+- You want to verify the consistency of your initial guess
+- You want to ensure no automatic modifications are made to your initial conditions
+
+## Example
+```julia
+prob = DAEProblem(f, du0, u0, tspan)
+sol = solve(prob, IDA(), initializealg = CheckInit())
+```
 """
 struct CheckInit <: DAEInitializationAlgorithm end
 
 """
-$(TYPEDEF)
+    struct OverrideInit <: DAEInitializationAlgorithm
+
+An initialization algorithm that uses a separate initialization problem to find
+consistent initial conditions. This is typically used with ModelingToolkit.jl
+which can generate specialized initialization problems based on the model structure.
+
+When using `OverrideInit`, the problem must have `initialization_data` that contains
+an `initializeprob` field with the initialization problem to solve.
+
+This algorithm is particularly useful for:
+- High-index DAEs that have been index-reduced
+- Systems with complex initialization requirements
+- ModelingToolkit models with custom initialization equations
+
+## Fields
+- `abstol`: Absolute tolerance for the initialization solver
+- `reltol`: Relative tolerance for the initialization solver
+- `nlsolve`: Nonlinear solver to use for initialization
+
+## Example
+```julia
+# Typically used automatically with ModelingToolkit
+@named sys = ODESystem(eqs, t, vars, params)
+sys = structural_simplify(sys)
+prob = DAEProblem(sys, [], (0.0, 1.0), [])
+# Will automatically use OverrideInit if initialization_data exists
+sol = solve(prob, IDA())
+```
 """
 struct OverrideInit{T1, T2, F} <: DAEInitializationAlgorithm
     abstol::T1


### PR DESCRIPTION
## Summary

This PR adds comprehensive docstrings for the DAE initialization algorithms defined in SciMLBase that previously only had placeholder TYPEDEF documentation.

## Changes

Added full docstrings for:
1. **`NoInit`**: Includes strong warning about usage risks
2. **`CheckInit`**: Documents verification-only behavior  
3. **`OverrideInit`**: Documents ModelingToolkit integration use case

Each docstring includes:
- Clear description of the algorithm's purpose
- Use cases and when to apply each algorithm
- Code examples
- Warnings where appropriate (especially for NoInit)
- Field documentation for OverrideInit

## Related PRs

- DiffEqBase algorithms: https://github.com/SciML/DiffEqBase.jl/pull/1212
- DiffEqBase docstring updates: https://github.com/SciML/DiffEqBase.jl/pull/1214  
- DiffEqDocs documentation: https://github.com/SciML/DiffEqDocs.jl/pull/812
- Sundials updates: https://github.com/SciML/Sundials.jl/pull/505
- OrdinaryDiffEq support: https://github.com/SciML/OrdinaryDiffEq.jl/pull/2873

## Note

The DiffEqBase PR #1214 has been updated to remove these docstrings from there since they belong in SciMLBase where the types are defined.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>