### PR TITLE
Add `checkkwarg` that takes Dict of allowed kwargs

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -109,6 +109,21 @@ function checkkwargs(kwargshandle; kwargs...)
     end
 end
 
+function checkkwargs(kwargshandle, allowed; kwargs...)
+    if any(x -> x ∉ allowed, keys(kwargs))
+        if kwargshandle == KeywordArgError
+            throw(CommonKwargError(kwargs))
+        elseif kwargshandle == KeywordArgWarn
+            @warn KWARGWARN_MESSAGE
+            unrecognized = setdiff(keys(kwargs), allowed)
+            print("Unrecognized keyword arguments: ")
+            printstyled(unrecognized; bold = true, color = :red)
+            print("\n\n")
+        else
+            @assert kwargshandle == KeywordArgSilent
+        end
+    end
+end
 """
     $(TYPEDSIGNATURES)
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This will allow for per package allowed kwargs, so that solve for NonlinearProblems won't take ODE kwargs, vice versa, and etc. 
