### PR TITLE
Fix SubArray FunctionWrapper type mismatch

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -150,13 +150,16 @@ mutable struct ODEProblem{uType, tType, isinplace, P, F, K, PT} <:
         _u0 = prepare_initial_state(u0)
         _tspan = promote_tspan(tspan)
         if !(f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
+            # Create a prototype with the canonical array type for function wrapping
+            # This ensures SubArrays and other array views work correctly
+            _u0_prototype = similar(_u0)
             if iip
                 ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_iip(f,
-                    (_u0, _u0, p,
+                    (_u0_prototype, _u0_prototype, p,
                         _tspan[1])))
             else
                 ff = ODEFunction{iip, FunctionWrapperSpecialize}(wrapfun_oop(f,
-                    (_u0, p,
+                    (_u0_prototype, p,
                         _tspan[1])))
             end
         end

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -246,12 +246,16 @@ function remake(prob::ODEProblem; f = missing,
 
     if specialization(f) === FunctionWrapperSpecialize
         ptspan = promote_tspan(tspan)
+        # Create a prototype with the canonical array type for function wrapping
+        # This ensures SubArrays and other array views work correctly
+        newu0_prototype = similar(newu0)
         if iip
             f = remake(
-                f; f = wrapfun_iip(unwrapped_f(f.f), (newu0, newu0, newp, ptspan[1])))
+                f; f = wrapfun_iip(unwrapped_f(f.f), (
+                    newu0_prototype, newu0_prototype, newp, ptspan[1])))
         else
             f = remake(
-                f; f = wrapfun_oop(unwrapped_f(f.f), (newu0, newu0, newp, ptspan[1])))
+                f; f = wrapfun_oop(unwrapped_f(f.f), (newu0_prototype, newp, ptspan[1])))
         end
     end
 
@@ -653,7 +657,8 @@ function remake(prob::DAEProblem; f = missing,
     iip = isinplace(prob)
 
     prob = if kwargs === missing
-        DAEProblem{iip}(f, du0, newu0, tspan, newp; differential_vars, prob.kwargs..., _kwargs...)
+        DAEProblem{iip}(
+            f, du0, newu0, tspan, newp; differential_vars, prob.kwargs..., _kwargs...)
     else
         DAEProblem{iip}(f, du0, newu0, tspan, newp; differential_vars, kwargs...)
     end


### PR DESCRIPTION
## Summary

Fixes SciML/OrdinaryDiffEq.jl#2900

This PR fixes a type mismatch error when using `FunctionWrapperSpecialize` with SubArrays as initial conditions.

## Problem

When creating an ODEProblem with explicit FunctionWrapperSpecialize and a SubArray as the initial condition, the FunctionWrapper was created with SubArray types in its signature. However, during integration, the solver uses regular Array types internally, causing a `NoFunctionWrapperFoundError`.

## Solution

The fix creates a prototype array using `similar(u0)` before passing to `wrapfun_iip` and `wrapfun_oop`. The `similar()` function returns a regular Array type even when called on a SubArray, ensuring the FunctionWrapper is created with the canonical array type that will be used during integration.

## Changes

- `src/problems/ode_problems.jl`: Updated `ODEProblem{iip, FunctionWrapperSpecialize}` constructor to use prototype array
- `src/remake.jl`: Updated `remake` function for FunctionWrapperSpecialize problems to use prototype array

## Test Plan

Tested with the reproduction case from the issue (requires both this PR and SciML/DiffEqBase.jl#1219):
```julia
using OrdinaryDiffEqTsit5: Tsit5, ODEProblem, init

u₀ = @view [0, π / 60][:]
tspan = (0.0, 6.3)

function simplependulum(du, u, p, t)
    du[1] = u[2]
    du[2] = -(9.81 / 1.00) * u[1]
end

prob = ODEProblem(simplependulum, u₀, tspan)
init(prob, Tsit5(); reltol = 1e-6)  # Now works without error
```

## Related PR

- SciML/DiffEqBase.jl#1219 - Fixes the AutoSpecialize case

🤖 Generated with [Claude Code](https://claude.com/claude-code)