### PR TITLE
Don't use `do` syntax for `@SciMLMessage` in `check_error`

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -651,15 +651,13 @@ function check_error(integrator::DEIntegrator)
                     EEst = ""
                 end
                 @warn "dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable."
-            else   
-                @SciMLMessage(verbose, :dt_min_unstable) do 
-                    if isdefined(integrator, :EEst)
-                        EEst = ", and step error estimate = $(integrator.EEst)"
-                    else
-                        EEst = ""
-                    end
-                    "dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable."
-                end 
+            else
+                EEst = if isdefined(integrator, :EEst)
+                    ", and step error estimate = $(integrator.EEst)"
+                else
+                    ""
+                end
+                @SciMLMessage(LazyString("dt(", integrator.dt, ") <= dtmin(", opts.dtmin, ") at t=", integrator.t, EEst, ". Aborting. There is either an error in your model specification or the true solution is unstable."), verbose, :dt_min_unstable)
             end
             return ReturnCode.DtLessThanMin
         elseif !step_accepted && integrator.t isa AbstractFloat &&
@@ -672,14 +670,12 @@ function check_error(integrator::DEIntegrator)
                 end
                 @warn "At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u)))."
             else
-                @SciMLMessage(verbose, :dt_epsilon) do 
-                    if isdefined(integrator, :EEst)
-                        EEst = ", and step error estimate = $(integrator.EEst)"
-                    else
-                        EEst = ""
-                    end
-                    "At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u)))."
+                EEst = if isdefined(integrator, :EEst)
+                    ", and step error estimate = $(integrator.EEst)"
+                else
+                    ""
                 end
+                @SciMLMessage(LazyString("At t=", integrator.t, ", dt was forced below floating point epsilon ", integrator.dt, EEst, ". Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of ", eltype(integrator.u), ")."), verbose, :dt_epsilon)
             end
             return ReturnCode.Unstable
         end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
@ChrisRackauckas this takes care of the boxing and allocation issues in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2895