### PR TITLE
Make all string interpolations lazy in `check_error`

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -646,36 +646,36 @@ function check_error(integrator::DEIntegrator)
              true))
             if verbose isa Bool 
                 if isdefined(integrator, :EEst)
-                    EEst = ", and step error estimate = $(integrator.EEst)"
+                    EEst = lazy", and step error estimate = $(integrator.EEst)"
                 else
                     EEst = ""
                 end
-                @warn "dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable."
+                @warn lazy"dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable."
             else
                 EEst = if isdefined(integrator, :EEst)
-                    ", and step error estimate = $(integrator.EEst)"
+                    lazy", and step error estimate = $(integrator.EEst)"
                 else
                     ""
                 end
-                @SciMLMessage(LazyString("dt(", integrator.dt, ") <= dtmin(", opts.dtmin, ") at t=", integrator.t, EEst, ". Aborting. There is either an error in your model specification or the true solution is unstable."), verbose, :dt_min_unstable)
+                @SciMLMessage(lazy"dt($(integrator.dt) <= dtmin($(opts.dtmin)), at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable.", verbose, :dt_min_unstable)
             end
             return ReturnCode.DtLessThanMin
         elseif !step_accepted && integrator.t isa AbstractFloat &&
                abs(integrator.dt) <= abs(eps(integrator.t))
             if verbose isa Bool 
                 if isdefined(integrator, :EEst)
-                    EEst = ", and step error estimate = $(integrator.EEst)"
+                    EEst = lazy", and step error estimate = $(integrator.EEst)"
                 else
                     EEst = ""
                 end
-                @warn "At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u)))."
+                @warn lazy"At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u)))."
             else
                 EEst = if isdefined(integrator, :EEst)
-                    ", and step error estimate = $(integrator.EEst)"
+                    lazy", and step error estimate = $(integrator.EEst)"
                 else
                     ""
                 end
-                @SciMLMessage(LazyString("At t=", integrator.t, ", dt was forced below floating point epsilon ", integrator.dt, EEst, ". Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of ", eltype(integrator.u), ")."), verbose, :dt_epsilon)
+                @SciMLMessage(lazy"At t= $(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or the true solution can not be represented in the precision of $(eltype(integrator.u)).", verbose, :dt_epsilon)
             end
             return ReturnCode.Unstable
         end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context


