### PR TITLE
Add backticks to docs/docstrings/error messages

### DIFF
--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -64,7 +64,7 @@ SciMLBase.FullSpecialize
     
     The specialization level must be precompile snooped in the appropriate solver
     package in order to enable the full precompilation and system image generation
-    for zero-latency usage. By default, this is only done with AutoSpecialize and
+    for zero-latency usage. By default, this is only done with `AutoSpecialize` and
     on types `u isa Vector{Float64}`, `eltype(tspan) isa Float64`, and
     `p isa Union{Vector{Float64}, SciMLBase.NullParameters}`. Precompilation snooping
     in the solvers can be done using the Preferences.jl setup on the appropriate

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -91,8 +91,8 @@ Contains a single callback whose `condition` is a continuous function. The callb
     if the starting condition is less than the tolerance from zero, then no root will be detected.
     This is to stop repeat events happening immediately after a rootfinding event.
   - `repeat_nudge = 1//100`: This is used to set the next testing point after a
-    previously found zero. Defaults to 1//100, which means after a callback, the next
-    sign check will take place at t + dt*1//100 instead of at t to avoid repeats.
+    previously found zero. Defaults to `1//100`, which means after a callback, the next
+    sign check will take place at `t + dt*1//100` instead of at `t` to avoid repeats.
   - `initializealg = nothing`: In the context of a DAE, this is the algorithm that is used
     to run initialization after the effect. The default of `nothing` defers to the initialization
     algorithm provided in the `solve`.

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -208,7 +208,7 @@ const NOISE_SIZE_MESSAGE = """
                            Noise sizes are incompatible. The expected number of noise terms in the defined
                            `noise_rate_prototype` does not match the number of noise terms in the defined
                            `AbstractNoiseProcess`. Please ensure that
-                           size(prob.noise_rate_prototype,2) == length(prob.noise.W[1]).
+                           `size(prob.noise_rate_prototype,2) == length(prob.noise.W[1])`.
 
                            Note: Noise process definitions require that users specify `u0`, and this value is
                            directly used in the definition. For example, if `noise = WienerProcess(0.0,0.0)`,

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -40,9 +40,9 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array.
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
+* `alias_du0::Union{Bool, Nothing}`: alias the `du0` array for DAEs. Defaults to `false`.
+* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
 * `alias::Union{Bool, Nothing}`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`
 
 """

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -27,20 +27,20 @@ IntegralProblem(f,domain,p=NullParameters(); nout=nothing, batch=nothing, kwargs
 IntegralProblem(f,lb,ub,p=NullParameters(); nout=nothing, batch=nothing, kwargs...)
 ```
 
-- f: the integrand, callable function `y = f(u,p)` for out-of-place (default) or an
+- `f`: the integrand, callable function `y = f(u,p)` for out-of-place (default) or an
   `IntegralFunction` or `BatchIntegralFunction` for inplace and batching optimizations.
 - domain: an object representing an integration domain, i.e. the tuple `(lb, ub)`.
-- lb: DEPRECATED: Either a number or vector of lower bounds.
-- ub: DEPRECATED: Either a number or vector of upper bounds.
-- p: The parameters associated with the problem.
-- nout: DEPRECATED (see `IntegralFunction`): length of the vector output of the integrand
+- `lb`: DEPRECATED: Either a number or vector of lower bounds.
+- `ub`: DEPRECATED: Either a number or vector of upper bounds.
+- `p`: The parameters associated with the problem.
+- `nout`: DEPRECATED (see `IntegralFunction`): length of the vector output of the integrand
   (by default the integrand is assumed to be scalar)
-- batch: DEPRECATED (see `BatchIntegralFunction`): number of points the integrand can
+- `batch`: DEPRECATED (see `BatchIntegralFunction`): number of points the integrand can
   evaluate simultaneously (by default there is no batching)
-- kwargs: Keyword arguments copied to the solvers.
+- `kwargs`: Keyword arguments copied to the solvers.
 
-Additionally, we can supply iip like IntegralProblem{iip}(...) as true or false to declare at
-compile time whether the integrator function is in-place.
+Additionally, we can supply iip like `IntegralProblem{iip}(...)` as `true` or `false`
+to declare at compile time whether the integrator function is in-place.
 
 ### Fields
 
@@ -142,12 +142,12 @@ assigned by a quadrature rule, which depend on sampling points `x`.
 ```
 SampledIntegralProblem(y::AbstractArray, x::AbstractVector; dim=ndims(y), kwargs...)
 ```
-- y: The sampled integrand, must be a subtype of `AbstractArray`.
+- `y`: The sampled integrand, must be a subtype of `AbstractArray`.
   It is assumed that the values of `y` along dimension `dim`
   correspond to the integrand evaluated at sampling points `x`
-- x: Sampling points, must be a subtype of `AbstractVector`.
-- dim: Dimension along which to integrate. Defaults to the last dimension of `y`.
-- kwargs: Keyword arguments copied to the solvers.
+- `x`: Sampling points, must be a subtype of `AbstractVector`.
+- `dim`: Dimension along which to integrate. Defaults to the last dimension of `y`.
+- `kwargs`: Keyword arguments copied to the solvers.
 
 ### Fields
 

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -54,7 +54,7 @@ Documentation Page: <https://docs.sciml.ai/LinearSolve/stable/basics/LinearProbl
 
 ## Mathematical Specification of a Linear Problem
 
-### Concrete LinearProblem
+### Concrete `LinearProblem`
 
 To define a `LinearProblem`, you simply need to give the `AbstractMatrix` ``A``
 and an `AbstractVector` ``b`` which defines the linear system:

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -212,7 +212,7 @@ end
 """
 $(SIGNATURES)
 
-Define a NonlinearProblem problem from SteadyStateProblem
+Define a `NonlinearProblem` problem from `SteadyStateProblem`
 """
 function NonlinearProblem(prob::AbstractNonlinearProblem)
     NonlinearProblem{isinplace(prob)}(prob.f, prob.u0, prob.p)
@@ -395,7 +395,7 @@ to solve in order solve the system in the optimized split form.
 
 ## Representation
 
-The representation of the SCCNonlinearProblem is via an ordered collection
+The representation of the `SCCNonlinearProblem` is via an ordered collection
 of `NonlinearProblem`s, `probs`, with an attached explicit function for pre-processing
 a cache. This can be interpreted as follows:
 
@@ -658,7 +658,7 @@ function ImmutableNonlinearProblem(f, u0, p = NullParameters(); kwargs...)
 end
 
 """
-Define a ImmutableNonlinearProblem problem from SteadyStateProblem.
+Define a `ImmutableNonlinearProblem` problem from `SteadyStateProblem`.
 """
 function ImmutableNonlinearProblem(prob::AbstractNonlinearProblem)
     return ImmutableNonlinearProblem{SciMLBase.isinplace(prob)}(prob.f, prob.u0, prob.p)

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -185,9 +185,9 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
+* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
+* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a `JumpProcess`
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDDEAliasSpecifier` to `alias`
 
 """

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -233,9 +233,9 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
+* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
+* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a `JumpProcess`.
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SDEAliasSpecifier` to `alias`
 
 """

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -146,9 +146,9 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 ### Keywords 
 * `alias_p::Union{Bool, Nothing}`
 * `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
+* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
+* `alias_du0::Union{Bool, Nothing}`: alias the `du0` array for DAEs. Defaults to `false`.
+* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
 * `alias::Union{Bool, Nothing}`: sets all fields of the `SteadStateAliasSpecifier` to `alias`
 
 """

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -1,7 +1,7 @@
 """
 $(TYPEDEF)
 
-Representation of the solution to an linear system Ax=b defined by a LinearProblem
+Representation of the solution to an linear system `Ax=b` defined by a `LinearProblem`
 
 ## Fields
 
@@ -48,7 +48,7 @@ end
 """
 $(TYPEDEF)
 
-Representation of the solution to an quadrature integral_lb^ub f(x) dx defined by a IntegralProblem
+Representation of the solution to an quadrature integral_lb^ub f(x) dx defined by a `IntegralProblem`
 
 ## Fields
 

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -5,11 +5,11 @@ Statistics from the nonlinear equation solver about the solution process.
 
 ## Fields
 
-  - nf: Number of function evaluations.
-  - njacs: Number of Jacobians created during the solve.
-  - nfactors: Number of factorzations of the jacobian required for the solve.
-  - nsolve: Number of linear solves `W\\b` required for the solve.
-  - nsteps: Total number of iterations for the nonlinear solver.
+  - `nf`: Number of function evaluations.
+  - `njacs`: Number of Jacobians created during the solve.
+  - `nfactors`: Number of factorzations of the jacobian required for the solve.
+  - `nsolve`: Number of linear solves `W\\b` required for the solve.
+  - `nsteps`: Total number of iterations for the nonlinear solver.
 """
 mutable struct NLStats
     nf::Int

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -5,23 +5,23 @@ Statistics from the differential equation solver about the solution process.
 
 ## Fields
 
-  - nf: Number of function evaluations. If the differential equation is a split function,
+  - `nf`: Number of function evaluations. If the differential equation is a split function,
     such as a `SplitFunction` for implicit-explicit (IMEX) integration, then `nf` is the
     number of function evaluations for the first function (the implicit function)
-  - nf2: If the differential equation is a split function, such as a `SplitFunction`
+  - `nf2`: If the differential equation is a split function, such as a `SplitFunction`
     for implicit-explicit (IMEX) integration, then `nf2` is the number of function
     evaluations for the second function, i.e. the function treated explicitly. Otherwise
     it is zero.
-  - nw: The number of W=I-gamma*J (or W=I/gamma-J) matrices constructed during the solving
-    process.
-  - nsolve: The number of linear solves `W\\b` required for the integration.
-  - njacs: Number of Jacobians calculated during the integration.
-  - nnonliniter: Total number of iterations for the nonlinear solvers.
-  - nnonlinconvfail: Number of nonlinear solver convergence failures.
-  - ncondition: Number of calls to the condition function for callbacks.
-  - naccept: Number of accepted steps.
-  - nreject: Number of rejected steps.
-  - maxeig: Maximum eigenvalue over the solution. This is only computed if the
+  - `nw`: The number of `W=I-gamma*J` (or `W=I/gamma-J`) matrices constructed
+    during the solving process.
+  - `nsolve`: The number of linear solves `W\\b` required for the integration.
+  - `njacs`: Number of Jacobians calculated during the integration.
+  - `nnonliniter`: Total number of iterations for the nonlinear solvers.
+  - `nnonlinconvfail`: Number of nonlinear solver convergence failures.
+  - `ncondition`: Number of calls to the condition function for callbacks.
+  - `naccept`: Number of accepted steps.
+  - `nreject`: Number of rejected steps.
+  - `maxeig`: Maximum eigenvalue over the solution. This is only computed if the
     method is an auto-switching algorithm.
 """
 mutable struct DEStats

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -9,7 +9,7 @@ const NONCONCRETE_ELTYPE_MESSAGE = """
                                    all the same. If this was intentional, for example,
                                    using Unitful.jl with different unit values, then use
                                    an array type which has fast broadcast support for
-                                   heterogeneous values such as the ArrayPartition
+                                   heterogeneous values such as the `ArrayPartition`
                                    from RecursiveArrayTools.jl. For example:
 
                                    ```julia


### PR DESCRIPTION

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Make it clearer which parts of the messages may reasonably appear in code, or is a Julia-specific name.
