### PR TITLE
Add syntax highlight tags in Markdown code blocks

### DIFF
--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -65,7 +65,7 @@ Note that algebraic equations can be specified by using a singular mass matrix.
 
 ### Constructors
 
-```
+```julia
 DDEProblem(f[, u0], h, tspan[, p]; <keyword arguments>)
 DDEProblem{isinplace,specialize}(f[, u0], h, tspan[, p]; <keyword arguments>)
 ```
@@ -112,7 +112,7 @@ of the form:
 
 ### Constructors
 
-```
+```julia
 DynamicalDDEProblem(f1, f2[, v0, u0], h, tspan[, p]; <keyword arguments>)
 DynamicalDDEProblem{isinplace}(f1, f2[, v0, u0], h, tspan[, p]; <keyword arguments>)
 ```
@@ -164,8 +164,8 @@ u' = v \\
 
 ### Constructors
 
-```
-SecondOrderDDEProblem(f, [, du0, u0], h, tspan[, p]; <keyword arguments>)
+```julia
+SecondOrderDDEProblem(f[, du0, u0], h, tspan[, p]; <keyword arguments>)
 SecondOrderDDEProblem{isinplace}(f, [, du0, u0], h, tspan[, p]; <keyword arguments>)
 ```
 

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -20,7 +20,7 @@ which are `Number`s or `AbstractVector`s with the same geometry as `u`.
 
 ### Constructors
 
-```
+```julia
 IntegralProblem(f::AbstractIntegralFunction,domain,p=NullParameters(); kwargs...)
 IntegralProblem(f::AbstractIntegralFunction,lb,ub,p=NullParameters(); kwargs...)
 IntegralProblem(f,domain,p=NullParameters(); nout=nothing, batch=nothing, kwargs...)
@@ -139,7 +139,7 @@ assigned by a quadrature rule, which depend on sampling points `x`.
 
 ### Constructors
 
-```
+```julia
 SampledIntegralProblem(y::AbstractArray, x::AbstractVector; dim=ndims(y), kwargs...)
 ```
 - `y`: The sampled integrand, must be a subtype of `AbstractArray`.

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -62,7 +62,7 @@ Note that algebraic equations can be specified by using a singular mass matrix.
 
 ### Constructors
 
-```
+```julia
 SDDEProblem(f,g[, u0], h, tspan[, p]; <keyword arguments>)
 SDDEProblem{isinplace,specialize}(f,g[, u0], h, tspan[, p]; <keyword arguments>)
 ```


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Mostly add highlighting to type constructors
