### PR TITLE
fix unitfulvalue shadowing

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -7,7 +7,8 @@ import SciMLBase:
     wrapfun_oop, wrapfun_iip, isdualtype, value, DualEltypeChecker,
     AbstractTimeseriesSolution, NonlinearProblem, NonlinearLeastSquaresProblem,
     ODEProblem, SDEProblem, RODEProblem, DDEProblem, PDEProblem, DAEProblem,
-    RecursiveArrayTools, totallength, sse, anyeltypedual, reduce_tup
+    RecursiveArrayTools, totallength, sse, anyeltypedual, reduce_tup,
+    unitfulvalue
 
 eltypedual(x) = eltype(x) <: ForwardDiff.Dual
 isdualtype(::Type{<:ForwardDiff.Dual}) = true


### PR DESCRIPTION
Fixes:

```julia
using OrdinaryDiffEqRosenbrock
using ForwardDiff
using LinearAlgebra: Diagonal
function dudt(du, u, p, t)
    du[1] = -p*u[1]
    du[2] = -u[2]
    return nothing
end
daefunc = ODEFunction(dudt, mass_matrix=FulbrightPores.Diagonal([1.0, 0.0]))
u0 = [0.5, 1.0]
tspan = (0.0, 50.0)

get_ode(p) = solve(ODEProblem(dudt, u0, tspan, p), Rodas4())
get_dae(p) = solve(ODEProblem(daefunc, u0, tspan, p), Rodas4())
ForwardDiff.derivative(get_ode, 1.0)
ForwardDiff.derivative(get_dae, 1.0)
```

which had the tolerances with Dual values when they should have been non-dual.
