### PR TITLE
Fix admonition header in Array_and_Number.md

### DIFF
--- a/docs/src/interfaces/Array_and_Number.md
+++ b/docs/src/interfaces/Array_and_Number.md
@@ -4,7 +4,7 @@ We live in a society, and therefore there are rules. In this tutorial we outline
 the rules which are required on container and number types which are allowable
 in SciML tools.
 
-!!! warn
+!!! warning
     
     In general as of 2023, strict adherence to this interface is an early work-in-progress.
     If anything does not conform to the documented interface, please open an issue.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`warn` not recognized by Documenter, needs to be `warning`