### PR TITLE
Bump version to 2.131.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.130.0"
+version = "2.131.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Version Bump

Bumping version from 2.130.0 to 2.131.0 to prepare for release.

### Changes since v2.130.0
- Expand PrecompileTools workload for faster TTFX (PR #1193)
- Bump minimum Moshi compat to 0.3.5 to fix Downgrade CI (PR #1190)
- Fix admonition header in Array_and_Number.md (PR #1189)

### Registration Command

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)