### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -131,6 +131,7 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 PartialFunctions = "570af359-4316-4cb7-8c74-252c00c2016b"
@@ -146,4 +147,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ForwardDiff", "MLStyle", "PartialFunctions", "Pkg", "SafeTestsets", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]
+test = ["Aqua", "ExplicitImports", "ForwardDiff", "MLStyle", "PartialFunctions", "Pkg", "SafeTestsets", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -3,16 +3,41 @@ if isdefined(Base, :Experimental) &&
         isdefined(Base.Experimental, Symbol("@max_methods"))
     @eval Base.Experimental.@max_methods 1
 end
-using ConstructionBase
-using RecipesBase, RecursiveArrayTools
-using SciMLStructures
-using SymbolicIndexingInterface
-using DocStringExtensions
-using LinearAlgebra
-using Statistics
-using Distributed
-using Markdown
-using Printf
+using ConstructionBase: ConstructionBase, getproperties
+using RecipesBase: RecipesBase, @recipe, @series
+using RecursiveArrayTools: RecursiveArrayTools, AbstractDiffEqArray,
+                            AbstractVectorOfArray, ArrayPartition, DiffEqArray,
+                            VectorOfArray, recursive_mean, tuples,
+                            vecarr_to_vectors, vecvecapply
+using SciMLStructures: SciMLStructures
+using SymbolicIndexingInterface: SymbolicIndexingInterface, ArraySymbolic,
+                                  ContinuousTimeseries, NotSymbolic,
+                                  NotTimeseries, ParameterIndexingProxy,
+                                  ParameterTimeseriesCollection,
+                                  ParameterTimeseriesIndex, ProblemState,
+                                  ScalarSymbolic, SymbolCache, Timeseries,
+                                  all_variable_symbols, current_time,
+                                  default_values, get_all_timeseries_indexes,
+                                  get_history_function, getname, getp, getsym,
+                                  getu, hasname, independent_variable_symbols,
+                                  is_markovian, is_observed, is_parameter,
+                                  is_parameter_timeseries, is_time_dependent,
+                                  is_timeseries_parameter, is_variable,
+                                  parameter_index, parameter_symbols,
+                                  parameter_values, remake_buffer,
+                                  set_parameter!, set_state!, setsym,
+                                  state_values, symbolic_container,
+                                  symbolic_evaluate, symbolic_type,
+                                  timeseries_parameter_index, variable_index,
+                                  variable_symbols,
+                                  with_updated_parameter_timeseries_values
+using DocStringExtensions: DocStringExtensions, FIELDS, SIGNATURES, TYPEDEF,
+                            TYPEDFIELDS, TYPEDSIGNATURES
+using LinearAlgebra: LinearAlgebra, /, I, convert, det, norm
+using Statistics: Statistics, mean, median
+using Distributed: Distributed, CachingPool, nworkers, pmap, workers
+using Markdown: Markdown, @doc_str
+using Printf: Printf, @printf
 import Preferences
 using PreallocationTools: get_tmp, DiffCache, FixedSizeDiffCache
 
@@ -30,17 +55,16 @@ import Moshi.Derive: @derive
 import StaticArraysCore: StaticArraysCore, SArray
 import Adapt: adapt_structure, adapt
 
-using Reexport
-using SciMLOperators
+using Reexport: Reexport, @reexport
+using SciMLOperators: SciMLOperators
 using SciMLOperators:
     AbstractSciMLOperator,
     IdentityOperator, NullOperator,
-    ScaledOperator, AddedOperator, ComposedOperator,
-    InvertedOperator, InvertibleOperator, AbstractSciMLScalarOperator
+    InvertibleOperator, AbstractSciMLScalarOperator
 
 import SciMLOperators:
-    DEFAULT_UPDATE_FUNC, update_coefficients, update_coefficients!,
-    getops, isconstant, iscached, islinear, issquare,
+    update_coefficients, update_coefficients!,
+    isconstant, iscached, islinear, issquare,
     has_adjoint, has_expmv, has_expmv!, has_exp,
     has_mul, has_mul!, has_ldiv, has_ldiv!
 

--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -1,7 +1,11 @@
 module EnsembleAnalysis
 
-using SciMLBase, Statistics, RecursiveArrayTools, StaticArraysCore
-using DocStringExtensions
+using SciMLBase
+using Statistics: Statistics, cov, median, quantile
+using RecursiveArrayTools: RecursiveArrayTools, DiffEqArray, VectorOfArray,
+                            vecarr_to_vectors
+using StaticArraysCore: StaticArraysCore
+using DocStringExtensions: DocStringExtensions, SIGNATURES
 
 # Getters
 """

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,27 @@
+using ExplicitImports
+using SciMLBase
+using Test
+
+@testset "ExplicitImports" begin
+    @testset "No implicit imports" begin
+        @test check_no_implicit_imports(
+            SciMLBase;
+            allow_unanalyzable = (
+                SciMLBase.ReturnCode,
+                SciMLBase.AlgorithmInterpretation,
+                SciMLBase.Clocks
+            )
+        ) === nothing
+    end
+
+    @testset "No stale explicit imports" begin
+        @test check_no_stale_explicit_imports(
+            SciMLBase;
+            allow_unanalyzable = (
+                SciMLBase.ReturnCode,
+                SciMLBase.AlgorithmInterpretation,
+                SciMLBase.Clocks
+            )
+        ) === nothing
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,9 @@ end
         @time @safetestset "Aqua" begin
             include("aqua.jl")
         end
+        @time @safetestset "ExplicitImports" begin
+            include("explicit_imports.jl")
+        end
     end
     if GROUP == "Core" || GROUP == "All"
         @time @safetestset "Display" begin


### PR DESCRIPTION
This PR addresses import hygiene issues identified by ExplicitImports.jl.

## Changes Made

### 1. Fixed Implicit Imports (88 total)
**src/SciMLBase.jl** - Made all imports explicit:
- `ConstructionBase`: Added explicit import for `ConstructionBase, getproperties`
- `Distributed`: Added explicit import for `Distributed, CachingPool, nworkers, pmap, workers`
- `DocStringExtensions`: Added explicit import for `DocStringExtensions, FIELDS, SIGNATURES, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES`
- `LinearAlgebra`: Added explicit import for `LinearAlgebra, /, I, convert, det, norm`
- `Markdown`: Added explicit import for `Markdown, @doc_str`
- `Printf`: Added explicit import for `Printf, @printf`
- `RecipesBase`: Added explicit import for `RecipesBase, @recipe, @series`
- `RecursiveArrayTools`: Added explicit import for all used symbols
- `Reexport`: Added explicit import for `Reexport, @reexport`
- `SciMLOperators`: Added explicit import for `SciMLOperators`
- `SciMLStructures`: Added explicit import for `SciMLStructures`
- `Statistics`: Added explicit import for `Statistics, mean, median`
- `SymbolicIndexingInterface`: Added explicit import for all 50+ used symbols

**src/ensemble/ensemble_analysis.jl** - Fixed 11 implicit imports:
- `Statistics`: Added explicit import for `Statistics, cov, median, quantile`
- `RecursiveArrayTools`: Added explicit import for `RecursiveArrayTools, DiffEqArray, VectorOfArray, vecarr_to_vectors`
- `StaticArraysCore`: Added explicit import for `StaticArraysCore`
- `DocStringExtensions`: Added explicit import for `DocStringExtensions, SIGNATURES`

### 2. Removed Stale Imports (6 total)
Removed unused imports from **src/SciMLBase.jl**:
- `AddedOperator`
- `ComposedOperator`
- `DEFAULT_UPDATE_FUNC`
- `InvertedOperator`
- `ScaledOperator`
- `getops`

### 3. Added ExplicitImports Tests
- Created **test/explicit_imports.jl** to ensure import hygiene is maintained
- Tests check for both implicit and stale imports
- Handles unanalyzable modules (ReturnCode, AlgorithmInterpretation, Clocks)
- Added to QA test group in **test/runtests.jl**
- Added ExplicitImports to test extras in **Project.toml**

## Testing

All tests pass, including the new ExplicitImports tests:
```
Test Summary:   | Pass  Total  Time
ExplicitImports |    2      2  8.4s
```

The changes ensure:
- No implicit imports (all dependencies are explicit)
- No stale imports (only used symbols are imported)
- Import hygiene is maintained in CI via automated tests

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>