### PR TITLE
make `successful_retcode` public

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1067,7 +1067,6 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Public traits
 
-@public has_init
-@public has_step
+@public has_init, has_step, successful_retcode
 
 end


### PR DESCRIPTION
I believe this was always intended to be public. @ChrisRackauckas can you confirm?