### PR TITLE
Exclude QA tests from All group for downstream testing compatibility

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -35,6 +35,9 @@ jobs:
           - "SymbolicIndexingInterface"
           - "QA"
           - "Python"
+        exclude:
+          - version: "pre"
+            group: "QA"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       group: "${{ matrix.group }}"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ function activate_python_env()
 end
 
 @time begin
-    if GROUP == "QA" || GROUP == "All"
+    if GROUP == "QA"
         @time @safetestset "Aqua" begin
             include("aqua.jl")
         end


### PR DESCRIPTION
## Summary
- Modified `test/runtests.jl` to only run QA tests when `GROUP="QA"` (not when `GROUP="All"`)
- Added exclude for QA tests on Julia `"pre"` version in CI

Aqua tests do not work properly in downstream testing scenarios, so QA tests should only run when explicitly requested.

## Test plan
- [ ] Verify CI passes for Core, Downstream, SymbolicIndexingInterface groups
- [ ] Verify QA tests run correctly on Julia 1 and lts versions
- [ ] Verify QA tests are skipped on Julia pre version

🤖 Generated with [Claude Code](https://claude.com/claude-code)