### PR TITLE
Add @from_rrule for ODESolution symbolic indexing in Mooncake extension

### DIFF
--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -1,7 +1,9 @@
 module SciMLBaseMooncakeExt
 
 using SciMLBase, Mooncake
-using SciMLBase: ADOriginator, ChainRulesOriginator, MooncakeOriginator
+using SciMLBase: ADOriginator, ChainRulesOriginator, MooncakeOriginator,
+    ODESolution, RODESolution, ODEProblem, SDEProblem, EnsembleSolution,
+    NonlinearProblem, IntervalNonlinearProblem
 import Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
     @from_rrule, @zero_adjoint, @mooncake_overlay, MinimalCtx,
     NoPullback
@@ -20,5 +22,18 @@ function rrule!!(
     return zero_fcodual(SciMLBase.MooncakeOriginator()), NoPullback(f, X)
 end
 
+# ============================================================================
+# Import ChainRulesCore rrules for Mooncake via @from_rrule
+# These enable Mooncake to use the existing ChainRulesCore differentiation rules
+# for symbolic indexing on ODESolution objects.
+# See: https://github.com/SciML/SciMLBase.jl/issues/1207
+# ============================================================================
+
+# ODESolution symbolic indexing: sol[sym]
+@from_rrule(
+    MinimalCtx,
+    Tuple{typeof(getindex), ODESolution, Any},
+    true,
+)
 
 end


### PR DESCRIPTION
## Summary

- Adds `@from_rrule` macro to import the ChainRulesCore rrule for `getindex(::ODESolution, sym)` to Mooncake
- Enables `sol[sym]` patterns to work with Mooncake's reverse-mode AD by reusing the existing ChainRulesCore implementation

## Motivation

This is a first step toward addressing #1207 (Mooncake AD backend incompatibility with SymbolicIndexingInterface).

The existing ChainRulesCore extension already has a proper rrule for symbolic indexing. By using Mooncake's `@from_rrule` macro, we can import this rule for use with Mooncake without duplicating the implementation.

## Limitations

- This only handles `sol[sym]` (2-argument getindex). The 3-argument version `sol[sym, j::Integer]` uses `RuleConfig` for AD nesting via `rrule_via_ad`, which may need additional work.
- The deeper issue of Mooncake needing custom tangent types for the complex `ODESolution` type hierarchy may still require additional work.

## Test plan

- [ ] Verify extension loads without error: `using SciMLBase, Mooncake`
- [ ] Run existing Mooncake tests to check for regressions
- [ ] Test symbolic indexing gradients with Mooncake (currently marked as `@test_broken` in `test/downstream/adjoints.jl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)