### PR TITLE
Relax Zygote compat from 0.7.10 to 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -125,7 +125,7 @@ Statistics = "1.10"
 SymbolicIndexingInterface = "0.3.36"
 Tables = "1.11"
 Tracker = "0.2"
-Zygote = "0.7.10"
+Zygote = "0.7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Relaxes Zygote compat from `0.7.10` (strict) to `0.7` (allows any 0.7.x).

## Problem

The strict `Zygote = "0.7.10"` requirement prevents downstream packages like NeuralPDE from using older Zygote versions to work around a Julia base bug.

When Zygote 0.7.10 differentiates through Cubature's `integrands` function (which uses `@cfunction` with type parameters), it triggers:
```
UndefVarError: `spvals` not defined in `Base.Meta`
```

This is caused by a typo in Julia's `base/meta.jl` line 412 that has existed since 2018.

## Why relax to 0.7?

Relaxing to `0.7` allows the resolver to potentially select an earlier 0.7.x version that might avoid triggering the bug path, or at minimum gives downstream packages flexibility to experiment with version combinations.

## Related

- NeuralPDE CI failures: https://github.com/SciML/NeuralPDE.jl/pull/1020
- Similar relaxation in Integrals.jl: https://github.com/SciML/Integrals.jl/pull/309

## Test plan

- [ ] CI passes with relaxed Zygote compat

🤖 Generated with [Claude Code](https://claude.ai/code)