### PR TITLE
Delete old `!=` method for `ReturnCode`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.135.0"
+version = "2.135.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/retcodes.jl
+++ b/src/retcodes.jl
@@ -439,8 +439,6 @@ EnumX.@enumx ReturnCode begin
     InternalLinearSolveFailed
 end
 
-Base.:(!=)(retcode::ReturnCode.T, s::Symbol) = Symbol(retcode) != s
-
 const symtrue = Symbol("true")
 const symfalse = Symbol("false")
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

It causes invalidations and this odd behaviour without the corresponding `==` method:
```julia
julia> ReturnCode.Success == :Success
false

julia> ReturnCode.Success != :Success
false
```

Should fix these invalidations seen when loading CurveFit.jl:
```julia
 inserting !=(retcode::SciMLBase.ReturnCode.T, s::Symbol) @ SciMLBase ~/.julia/packages/SciMLBase/tmJhj/src/retcodes.jl:442 invalidated:                                                                                                       
   mt_backedges: 1: signature Tuple{typeof(!=), Any, Any} triggered MethodInstance for canonicalize(::Dates.CompoundPeriod) (1 children)                                                                                                       
   backedges: 1: superseding !=(x, y) @ Base operators.jl:321 with MethodInstance for !=(::Any, ::Any) (235 children) 
```

Also see: https://github.com/SciML/SciMLBase.jl/pull/393