### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/test/downstream/comprehensive_indexing.jl
+++ b/test/downstream/comprehensive_indexing.jl
@@ -1090,7 +1090,7 @@ end
 @testset "SDDEs" begin
     function oscillator(; name, k = 1.0, τ = 0.01)
         @parameters k = k τ = τ
-        @brownian a
+        @brownians a
         @variables x(..) = 0.1 + t y(t) = 0.1 + t jcn(t) delx(t)
         eqs = [
             D(x(t)) ~ y + a,

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -492,7 +492,6 @@ for (f, kws, iip) in (
             (intf, (;), false),
             (IntegralFunction(intf), (;), false),
             (IntegralFunction(intf, 1.0), (;), false),
-            (intfiip, (; nout = 3), true),
             (IntegralFunction(intfiip, zeros(3)), (;), true),
         ),
         domain in (((0.0, 1.0),), (([0.0], [1.0]),))


### PR DESCRIPTION
## Summary

- Remove deprecated `nout` keyword usage in `IntegralProblem` test construction in `test/function_building_error_messages.jl`. The test loop already has equivalent coverage via `IntegralFunction(intfiip, zeros(3))` on the next line, so the deprecated path was redundant.
- Replace deprecated `@brownian` macro with `@brownians` in `test/downstream/comprehensive_indexing.jl` (SDDE test).

These two changes eliminate the deprecation warnings that appear in CI logs when running with `--depwarn=yes`:

1. **`nout` and `batch` keywords deprecated** - 8 occurrences in Core tests (all Julia versions)
2. **`@brownian` is deprecated, use `@brownians` instead** - in SymbolicIndexingInterface tests

### Note on remaining `AbstractDiffEqArray` `getindex` deprecation

The CI also shows a deprecation warning:
> `Base.getindex(VA::AbstractDiffEqArray{T, N, A}, i::Int)` is deprecated, use `VA.u[i]` instead.

This originates from RecursiveArrayTools.jl and is triggered indirectly through Julia's broadcasting internals (`_broadcast_getindex`), so it cannot be fixed in SciMLBase.

## Test plan

- [x] Ran `Pkg.test()` with `--depwarn=yes` locally - all tests pass
- [x] Verified no `nout`/`batch` deprecation warnings remain in test output
- [x] Verified Runic formatting passes on changed files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)