### PR TITLE
feat: add strip_solution for NonlinearSolution

### DIFF
--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -103,6 +103,13 @@ function build_solution(
     )
 end
 
+function strip_solution(sol::NonlinearSolution)
+    @reset sol.prob = (; p = nothing)
+    @reset sol.alg = nothing
+    @reset sol.original = nothing
+    return sol
+end
+
 function sensitivity_solution(sol::AbstractNonlinearSolution, u)
     # Some of the subtypes might not have a trace field
     trace = hasfield(typeof(sol), :trace) ? sol.trace : nothing


### PR DESCRIPTION
## Summary

- Adds `strip_solution(::NonlinearSolution)` following the existing `ODESolution` pattern
- Replaces `prob` with `(; p = nothing)`, `alg` with `nothing`, and `original` with `nothing`
- Produces a solution with a predictable concrete type regardless of original problem/algorithm types

## Motivation

In `SCCNonlinearSolve.jl` (SciML/NonlinearSolve.jl#834), the vector branch of `iteratively_build_sols` needs a well-typed `Vector{T}` of solutions. Currently uses `Core.Compiler.return_type` to infer `T`, and `FunctionWrapper{Nothing, Tuple{Vector{Float64}, Any}}` with `Any` because the full `NonlinearSolution` type depends on the problem type.

With `strip_solution`, the stripped type is deterministic from just the element type of `u`, eliminating the need for `Core.Compiler.return_type` and allowing concrete `FunctionWrapper` signatures.

## Test plan

- [x] Stripped solution preserves `u`, `resid`, `retcode`
- [x] Stripped solution has `prob == (; p = nothing)`, `alg === nothing`, `original === nothing`
- [x] Different problems/algorithms produce identical stripped types
- [x] Stripped type is concrete
- [x] Full SciMLBase test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)