### PR TITLE
feat: Add Zygote adjoint for Base.getindex(::LinearSolution, ::Integer)

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -263,6 +263,15 @@ end
     sol.u, solu_adjoint
 end
 
+@adjoint function Base.getindex(sol::SciMLBase.LinearSolution, i::Integer)
+    function LinearSolution_getindex_pullback(Δ)
+        du = zero(sol.u)
+        du[i] = Δ
+        (SciMLBase.build_linear_solution(sol.cache.alg, du, sol.resid, sol.cache), nothing)
+    end
+    sol[i], LinearSolution_getindex_pullback
+end
+
 @adjoint function literal_getproperty(
         sol::SciMLBase.OptimizationSolution,
         ::Val{:u}


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

#### Problem

`LinearSolution <: AbstractNoTimeSolution <: AbstractArray`, so Zygote ignores any `ChainRulesCore.rrule` defined for `Base.getindex` on it. This is a known Zygote limitation (FluxML/Zygote.jl#811) where hardcoded `AbstractArray` getindex adjoints take priority over CRC rules, causing AD through `sol[i]` to silently fall back to Zygote's generic array adjoint, which fails because it doesn't know how to construct a `LinearSolution` cotangent.

#### Fix

Add an explicit `Zygote.@adjoint` for `Base.getindex(sol::LinearSolution, i::Integer)` in `SciMLBaseZygoteExt.jl`, alongside the existing `literal_getproperty` adjoint for `LinearSolution`. The pullback zeroes out `sol.u`, sets index `i` to the incoming cotangent `Δ`, and reconstructs a proper `LinearSolution` tangent via `build_linear_solution`.

#### Context

Identified while working on adjoint support in LinearSolve.jl (SciML/LinearSolve.jl#885). The fix cannot live in LinearSolve because both `Base.getindex` and `LinearSolution` are owned by other packages, placing it there would be type piracy.
