### PR TITLE
Fix type instability in remake for AutoSpecialize ODEFunctions

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -126,45 +126,22 @@ end
 """
     $(TYPEDSIGNATURES)
 
-Reconstruct `new_func` preserving the abstract type parameters from `orig_func`.
-This function is only called when `orig_func` has type-erased parameters (detected by
-`_has_type_erased_params`). For each field type parameter (positions 3+), if the original
-has a more abstract type than the result, the original's abstract type is preserved.
+Reconstruct `source` with the exact type `TargetType`, copying all field values.
+The return type depends only on `TargetType` (which must be known at compile time),
+NOT on the type of `source`. This makes it fully inferrable even when the compiler
+only has partial type information for `source`.
 
-This prevents `remake` from undoing type erasure intentionally applied by `promote_f` for
-AutoSpecialize compilation caching.
+Used to preserve type erasure from `promote_f`/`unwrapped_f` for AutoSpecialize:
+the keyword constructor in `remake` narrows abstract type parameters back to concrete
+types, and this function restores the original erased type by reconstructing the struct
+with the same field values but the desired abstract type parameters.
 """
-function _rebuild_preserving_type_erasure(orig_func, new_func)
-    OrigType = typeof(orig_func)
-    NewType = typeof(new_func)
-
-    # Only apply when both are the same base function type
-    if parameterless_type(OrigType) !== parameterless_type(NewType)
-        return new_func
-    end
-
-    orig_params = OrigType.parameters
-    new_params = NewType.parameters
-
-    # Must have same number of type parameters
-    if length(orig_params) != length(new_params)
-        return new_func
-    end
-
-    # For each field type parameter, preserve the original's more abstract type
-    rebuilt_params = collect(Any, new_params)
-    for i in 3:length(orig_params)
-        op = orig_params[i]
-        np = new_params[i]
-        if op !== np && np <: op
-            rebuilt_params[i] = op
-        end
-    end
-
-    PT = parameterless_type(NewType)
-    ErasedType = PT{rebuilt_params...}
-    vals = ntuple(i -> getfield(new_func, i), fieldcount(NewType))
-    return ErasedType(vals...)
+@generated function _reconstruct_as_type(
+        ::Type{TargetType}, source
+) where {TargetType <: AbstractSciMLFunction}
+    nf = fieldcount(TargetType)
+    field_exprs = [:(getfield(source, $i)) for i in 1:nf]
+    return :($(TargetType)($(field_exprs...)))
 end
 
 """
@@ -279,8 +256,15 @@ function remake(
     # parameters to maintain compilation caching benefits.
     # The _has_type_erased_params check is @generated and resolves at compile time,
     # so this branch is eliminated entirely for the common non-erased case.
+    #
+    # Check both `func` (the original function being remade) and `forig` (the incoming
+    # `f` keyword argument, if it was an AbstractSciMLFunction). When `get_concrete_problem`
+    # calls `remake(prob; f=promoted_f)`, the promoted_f from `unwrapped_f` has type-erased
+    # params but the original `prob.f` does not — so we must check `forig` too.
     if _has_type_erased_params(typeof(func))
-        return _rebuild_preserving_type_erasure(func, result)
+        return _reconstruct_as_type(typeof(func), result)
+    elseif forig isa AbstractSciMLFunction && _has_type_erased_params(typeof(forig))
+        return _reconstruct_as_type(typeof(forig), result)
     end
     return result
 end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2911,8 +2911,8 @@ function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
             typeof(f.jac), Nothing, Nothing, typeof(f.jac_prototype),
             typeof(f.sparsity), Nothing, Nothing, typeof(f.W_prototype),
             Nothing,
-            Any, typeof(f.colorvec),
-            typeof(f.sys), Union{Nothing, OverrideInitData}, Union{Nothing, ODENLStepData},
+            typeof(f.observed), typeof(f.colorvec),
+            typeof(f.sys), typeof(f.initialization_data), typeof(f.nlstep_data),
         }(
             newf, f.mass_matrix, f.analytic, f.tgrad, f.jac,
             f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact,


### PR DESCRIPTION
## Summary

- **`unwrapped_f` for `AutoSpecialize`** unnecessarily widened `observed`, `initialization_data`, and `nlstep_data` type parameters to `Any`/`Union{Nothing, OverrideInitData}`/`Union{Nothing, ODENLStepData}`. These are metadata fields that don't need erasure for compilation caching. Changed to `typeof(f.observed)`, `typeof(f.initialization_data)`, `typeof(f.nlstep_data)`.
- **`_rebuild_preserving_type_erasure`** replaced with `_reconstruct_as_type`, a `@generated` function whose return type depends only on the known `TargetType` (not on the potentially-abstract source type), making it fully inferrable.
- **`remake(func::AbstractSciMLFunction; ...)`** now also checks the incoming `f` kwarg (`forig`) for type-erased params, not just the original `func`. This handles the `get_concrete_problem` -> `remake(prob; f=promoted_f)` path where `promoted_f` has erasure but `prob.f` does not.

## Motivation

The type widening in `unwrapped_f` caused a chain of inference failures:
1. `promote_f` creates an ODEFunction with `Union{Nothing, OverrideInitData}` for `initialization_data`
2. `remake(prob::ODEProblem; f=fp)` passes this to `remake_initialization_data`, producing a `Union{Nothing, OverrideInitData}` local
3. `maybe_eager_initialize_problem` receives this Union type and returns `Tuple{Any, Any}`
4. `@reset prob.u0 = u0` with `Any` makes the whole return type `Any`

This caused `@inferred solve(prob)` and `@inferred solve(prob, Tsit5())` to fail. After this fix, both pass.

## Test plan

- [x] All 4413 SciMLBase remake tests pass
- [x] All SciMLBase tests pass
- [x] OrdinaryDiffEqDefault tests pass (41/41), including `@inferred solve(prob_ode_2Dlinear)` which was previously failing
- [x] `@inferred solve(prob, Tsit5())` passes
- [x] `@inferred solve(prob)` (default solver) passes
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)