### PR TITLE
Add qmax_first_step to allowed keywords

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -25,6 +25,7 @@ const allowedkeywords = (
     :beta2,
     :qmax,
     :qmin,
+    :qmax_first_step,
     :qsteady_min,
     :qsteady_max,
     :qoldinit,


### PR DESCRIPTION
## Summary

- Adds `:qmax_first_step` to the `allowedkeywords` tuple in `src/errors.jl`
- This is a companion change for the OrdinaryDiffEq.jl PR that implements a `qmax_first_step` parameter, allowing a larger step size growth factor on the first step to match Sundials CVODE behavior
- Related issue: https://github.com/SciML/DifferentialEquations.jl/issues/299

## Test plan

- [ ] CI passes (no new tests needed since this only adds a keyword to the allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)