### PR TITLE
fix: use sol.alg instead of sol.cache.alg in LinearSolution Zygote pullbacks

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -258,7 +258,7 @@ end
     function solu_adjoint(Δ)
         zerou = zero(sol.u)
         _Δ = @. ifelse(Δ === nothing, zerou, Δ)
-        (SciMLBase.build_linear_solution(sol.cache.alg, _Δ, sol.resid, sol.cache),)
+        (SciMLBase.build_linear_solution(sol.alg, _Δ, sol.resid, sol.cache),)
     end
     sol.u, solu_adjoint
 end
@@ -267,7 +267,7 @@ end
     function LinearSolution_getindex_pullback(Δ)
         du = zero(sol.u)
         du[i] = Δ
-        (SciMLBase.build_linear_solution(sol.cache.alg, du, sol.resid, sol.cache), nothing)
+        (SciMLBase.build_linear_solution(sol.alg, du, sol.resid, sol.cache), nothing)
     end
     sol[i], LinearSolution_getindex_pullback
 end


### PR DESCRIPTION
## Summary

- Fix `type Nothing has no field alg` error in `LinearSolution` Zygote adjoint rules
- The pullbacks for `getproperty(sol, :u)` and `getindex(sol, i)` accessed `sol.cache.alg`, but `sol.cache` can be `Nothing` when LinearSolve constructs a solution without a cache
- `LinearSolution` stores `alg` directly as a field (`sol.alg`), so use that instead

## Root Cause

Introduced in PR #1238. The `LinearSolution_getindex_pullback` (line 270) and `solu_adjoint` (line 261) both used `sol.cache.alg` to pass the algorithm to `build_linear_solution`. When a `LinearSolution` is constructed with `cache=nothing` (which happens during NonlinearSolve's internal linear solves for initialization), this crashes with `type Nothing has no field alg`.

## Test plan

- [x] Fixes `test/downstream/observables_autodiff.jl` `AutoZygote` failure on Julia lts
- [ ] CI Downstream tests should pass for this path

Note: The `initialization.jl` downstream failures on Julia 1.12+/1.13 are a **separate pre-existing issue** — `NonlinearSolve`'s `NewtonRaphson()` fails to converge on Julia >= 1.12 (computing `1.955` instead of `2.0`). That has been failing since at least Feb 20 and is unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)