### PR TITLE
Add @non_differentiable for numargs and isinplace

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -7,6 +7,13 @@ import ChainRulesCore: NoTangent, @non_differentiable, zero_tangent, rrule_via_a
 using SymbolicIndexingInterface
 using RecursiveArrayTools: AbstractVectorOfArray
 
+# numargs and isinplace use `methods()` for runtime reflection and are not differentiable.
+# Mooncake already has @zero_adjoint for numargs; this is the ChainRules/Zygote equivalent.
+@non_differentiable SciMLBase.numargs(::Any)
+@non_differentiable SciMLBase.isinplace(::Any, ::Any)
+@non_differentiable SciMLBase.isinplace(::Any, ::Any, ::Any)
+@non_differentiable SciMLBase.isinplace(::Any, ::Any, ::Any, ::Any)
+
 function ChainRulesCore.rrule(
         config::ChainRulesCore.RuleConfig{
             >:ChainRulesCore.HasReverseMode,


### PR DESCRIPTION
## Summary

- Add `@non_differentiable` declarations for `numargs` and `isinplace` in the ChainRulesCore extension
- These functions use `methods()` for runtime reflection and are inherently non-differentiable
- The Mooncake extension already had `@zero_adjoint` for `numargs`; this adds the ChainRules/Zygote equivalent

## Problem

When Zygote differentiates through `ODEProblem(f, u0, tspan)` with a bare function `f` (not an `ODEFunction`), the constructor calls:

```
ODEProblem(f, u0, tspan)
  → isinplace(f, 4)       # generic dispatch
    → numargs(f)           # calls methods(f) — pure reflection
```

Zygote tries to AD through `methods()` → `Base.MethodList` constructor, which causes a `BoundsError` in the backward pass. This was observed as a test failure in [RecursiveArrayTools.jl CI](https://github.com/SciML/RecursiveArrayTools.jl/actions/runs/22478138678/job/65109508864?pr=541) on Julia 1.12.

## Test plan

- [x] SciMLBase tests pass locally
- [x] RecursiveArrayTools adjoint tests pass locally with this fix (previously errored)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)