### PR TITLE
Fix hardcoded Nothing type for analytic functions in AutoSpecialize

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2907,7 +2907,7 @@ function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
     elseif specialization(f) === AutoSpecialize
         ODEFunction{
             isinplace(f), specialization(f), typeof(newf), typeof(f.mass_matrix),
-            Nothing, typeof(f.tgrad),
+            typeof(f.analytic), typeof(f.tgrad),
             typeof(f.jac), Nothing, Nothing, typeof(f.jac_prototype),
             typeof(f.sparsity), Nothing, Nothing, typeof(f.W_prototype),
             Nothing,


### PR DESCRIPTION
Hi @ChrisRackauckas ,

This PR fixes an issue where the `analytic` field's type was hardcoded as `Nothing` in `AutoSpecialize` within `scimlfunctions.jl` (line 2910). 
Changing it to `typeof(f.analytic)` allows analytic functions to be passed correctly without throwing a `MethodError`.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Discussed earlier on Slack. Prepared this quick PR to save time!