### PR TITLE
Unify ODE solution types: DAESolution, RODESolution as ODESolution aliases

### DIFF
--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -1,89 +1,8 @@
 """
-$(TYPEDEF)
-
-Representation of the solution to an differential-algebraic equation defined by an DAEProblem.
-
-## DESolution Interface
-
-For more information on interacting with `DESolution` types, check out the Solution Handling
-page of the DifferentialEquations.jl documentation.
-
-<https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/>
-
-## Fields
-
-  - `u`: the representation of the DAE solution. Given as an array of solutions, where `u[i]`
-    corresponds to the solution at time `t[i]`. It is recommended in most cases one does not
-    access `sol.u` directly and instead use the array interface described in the Solution
-    Handling page of the DifferentialEquations.jl documentation.
-  - `du`: the representation of the derivatives of the DAE solution.
-  - `t`: the time points corresponding to the saved values of the DAE solution.
-  - `prob`: the original DAEProblem that was solved.
-  - `alg`: the algorithm type used by the solver.
-  - `stats`: statistics of the solver, such as the number of function evaluations required,
-    number of Jacobians computed, and more.
-  - `retcode`: the return code from the solver. Used to determine whether the solver solved
-    successfully, whether it terminated early due to a user-defined callback, or whether it
-    exited due to an error. For more details, see
-    [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
+DAESolution is an alias for ODESolution. DAE solutions are represented using the unified
+ODESolution type, with the `du` field storing the derivative values.
 """
-struct DAESolution{T, N, uType, duType, uType2, DType, tType, P, A, ID, S, rateType, V} <:
-    AbstractDAESolution{T, N, uType}
-    u::uType
-    du::duType
-    u_analytic::uType2
-    errors::DType
-    t::tType
-    k::rateType
-    prob::P
-    alg::A
-    interp::ID
-    dense::Bool
-    tslocation::Int
-    stats::S
-    retcode::ReturnCode.T
-    saved_subsystem::V
-end
-
-function DAESolution{T, N}(
-        u, du, u_analytic, errors, t, k, prob, alg, interp, dense,
-        tslocation, stats, retcode, saved_subsystem
-    ) where {T, N}
-    return DAESolution{
-        T, N, typeof(u), typeof(du), typeof(u_analytic), typeof(errors),
-        typeof(t), typeof(prob), typeof(alg), typeof(interp), typeof(stats), typeof(k),
-        typeof(saved_subsystem),
-    }(
-        u, du, u_analytic, errors, t, k, prob, alg, interp, dense, tslocation, stats,
-        retcode, saved_subsystem
-    )
-end
-
-function ConstructionBase.constructorof(::Type{O}) where {T, N, O <: DAESolution{T, N}}
-    return DAESolution{T, N}
-end
-
-function ConstructionBase.setproperties(sol::DAESolution, patch::NamedTuple)
-    u = get(patch, :u, sol.u)
-    N = u === nothing ? 2 : ndims(eltype(u)) + 1
-    T = eltype(eltype(u))
-    patch = merge(getproperties(sol), patch)
-    return DAESolution{T, N}(
-        patch.u, patch.du, patch.u_analytic, patch.errors, patch.t,
-        patch.k, patch.prob, patch.alg, patch.interp, patch.dense, patch.tslocation,
-        patch.stats, patch.retcode, patch.saved_subsystem
-    )
-end
-
-Base.@propagate_inbounds function Base.getproperty(x::AbstractDAESolution, s::Symbol)
-    if s === :destats
-        Base.depwarn("`sol.destats` is deprecated. Use `sol.stats` instead.", "sol.destats")
-        return getfield(x, :stats)
-    elseif s === :ps
-        return ParameterIndexingProxy(x)
-    end
-    return getfield(x, s)
-end
+const DAESolution = ODESolution
 
 function build_solution(
         prob::AbstractDAEProblem, alg, t, u, du = nothing;
@@ -117,28 +36,42 @@ function build_solution(
         end
         Base.depwarn(msg, :build_solution)
     end
+
+    ps = parameter_values(prob)
+    if has_sys(prob.f)
+        sswf = if saved_subsystem === nothing
+            prob.f.sys
+        else
+            SavedSubsystemWithFallback(saved_subsystem, prob.f.sys)
+        end
+        discretes = create_parameter_timeseries_collection(sswf, ps, prob.tspan)
+    else
+        discretes = nothing
+    end
     return if has_analytic(prob.f)
         u_analytic = Vector{typeof(prob.u0)}()
         errors = Dict{Symbol, real(eltype(prob.u0))}()
 
-        sol = DAESolution{
-            T, N, typeof(u), typeof(du), typeof(u_analytic), typeof(errors),
-            typeof(t), typeof(prob), typeof(alg), typeof(interp), typeof(stats), typeof(k),
-            typeof(saved_subsystem),
-        }(
+        sol = ODESolution{T, N}(
             u,
             du,
             u_analytic,
             errors,
             t,
             k,
+            nothing,
+            discretes,
             prob,
             alg,
             interp,
             dense,
             0,
             stats,
+            nothing,
             retcode,
+            nothing,
+            nothing,
+            UInt64(0),
             saved_subsystem
         )
 
@@ -150,114 +83,27 @@ function build_solution(
         end
         sol
     else
-        DAESolution{
-            T, N, typeof(u), typeof(du), Nothing, Nothing, typeof(t),
-            typeof(prob), typeof(alg), typeof(interp), typeof(stats), typeof(k),
-            typeof(saved_subsystem),
-        }(
-            u, du,
+        ODESolution{T, N}(
+            u,
+            du,
             nothing,
-            nothing, t, k,
-            prob, alg,
+            nothing,
+            t,
+            k,
+            nothing,
+            discretes,
+            prob,
+            alg,
             interp,
-            dense, 0,
+            dense,
+            0,
             stats,
+            nothing,
             retcode,
+            nothing,
+            nothing,
+            UInt64(0),
             saved_subsystem
         )
     end
-end
-
-function calculate_solution_errors!(
-        sol::AbstractDAESolution;
-        fill_uanalytic = true, timeseries_errors = true,
-        dense_errors = true
-    )
-    prob = sol.prob
-    f = prob.f
-
-    if fill_uanalytic
-        for i in 1:size(sol.u, 1)
-            push!(sol.u_analytic, f.analytic(prob.du0, prob.u0, prob.p, sol.t[i]))
-        end
-    end
-
-    save_everystep = length(sol.u) > 2
-    if !isempty(sol.u_analytic)
-        sol.errors[:final] = norm(recursive_mean(abs.(sol.u[end] - sol.u_analytic[end])))
-
-        if save_everystep && timeseries_errors
-            sol.errors[:l∞] = norm(
-                maximum(
-                    vecvecapply(
-                        x -> abs.(x),
-                        sol.u - sol.u_analytic
-                    )
-                )
-            )
-            sol.errors[:l2] = norm(
-                sqrt(
-                    recursive_mean(
-                        vecvecapply(
-                            x -> float.(x) .^ 2,
-                            sol.u - sol.u_analytic
-                        )
-                    )
-                )
-            )
-            if sol.dense && dense_errors
-                densetimes = collect(range(sol.t[1]; stop = sol.t[end], length = 100))
-                interp_u = sol(densetimes)
-                interp_analytic = VectorOfArray(
-                    [
-                        f.analytic(prob.du0, prob.u0, prob.p, t)
-                            for t in densetimes
-                    ]
-                )
-                sol.errors[:L∞] = norm(
-                    maximum(
-                        vecvecapply(
-                            x -> abs.(x),
-                            interp_u - interp_analytic
-                        )
-                    )
-                )
-                sol.errors[:L2] = norm(
-                    sqrt(
-                        recursive_mean(
-                            vecvecapply(
-                                x -> float.(x) .^ 2,
-                                interp_u .-
-                                    interp_analytic
-                            )
-                        )
-                    )
-                )
-            end
-        end
-    end
-
-    return nothing
-end
-
-function build_solution(sol::AbstractDAESolution{T, N}, u_analytic, errors) where {T, N}
-    @reset sol.u_analytic = u_analytic
-    return @set sol.errors = errors
-end
-
-function solution_new_retcode(sol::AbstractDAESolution{T, N}, retcode) where {T, N}
-    return @set sol.retcode = retcode
-end
-
-function solution_new_tslocation(sol::AbstractDAESolution{T, N}, tslocation) where {T, N}
-    return @set sol.tslocation = tslocation
-end
-
-function solution_slice(sol::AbstractDAESolution{T, N}, I) where {T, N}
-    @reset sol.u = sol.u[I]
-    @reset sol.du = sol.du[I]
-    @reset sol.u_analytic = sol.u_analytic === nothing ? nothing : sol.u_analytic[I]
-    @reset sol.t = sol.t[I]
-    @reset sol.k = sol.dense ? sol.k[I] : sol.k
-    return @set sol.dense = false
 end

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -106,15 +106,17 @@ page of the DifferentialEquations.jl documentation.
     [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
 """
 struct ODESolution{
-        T, N, uType, uType2, DType, tType, rateType, discType, P, A, IType, S,
-        AC <: Union{Nothing, Vector{Int}}, R, O, V,
+        T, N, uType, duType, uType2, DType, tType, rateType, randType, discType, P, A,
+        IType, S, AC <: Union{Nothing, Vector{Int}}, R, O, V,
     } <:
     AbstractODESolution{T, N, uType}
     u::uType
+    du::duType
     u_analytic::uType2
     errors::DType
     t::tType
     k::rateType
+    W::randType
     discretes::discType
     prob::P
     alg::A
@@ -126,6 +128,7 @@ struct ODESolution{
     retcode::ReturnCode.T
     resid::R
     original::O
+    seed::UInt64
     saved_subsystem::V
 end
 
@@ -139,9 +142,10 @@ function ConstructionBase.setproperties(sol::ODESolution, patch::NamedTuple)
     T = eltype(eltype(u))
     patch = merge(getproperties(sol), patch)
     return ODESolution{T, N}(
-        patch.u, patch.u_analytic, patch.errors, patch.t, patch.k,
-        patch.discretes, patch.prob, patch.alg, patch.interp, patch.dense, patch.tslocation, patch.stats,
-        patch.alg_choice, patch.retcode, patch.resid, patch.original, patch.saved_subsystem
+        patch.u, patch.du, patch.u_analytic, patch.errors, patch.t, patch.k,
+        patch.W, patch.discretes, patch.prob, patch.alg, patch.interp, patch.dense,
+        patch.tslocation, patch.stats, patch.alg_choice, patch.retcode, patch.resid,
+        patch.original, patch.seed, patch.saved_subsystem
     )
 end
 
@@ -155,20 +159,20 @@ Base.@propagate_inbounds function Base.getproperty(x::AbstractODESolution, s::Sy
     return getfield(x, s)
 end
 
-# FIXME: Remove the defaults for resid and original on a breaking release
 function ODESolution{T, N}(
-        u, u_analytic, errors, t, k, discretes, prob, alg, interp, dense,
+        u, du, u_analytic, errors, t, k, W, discretes, prob, alg, interp, dense,
         tslocation, stats, alg_choice, retcode, resid = nothing,
-        original = nothing, saved_subsystem = nothing
+        original = nothing, seed::UInt64 = UInt64(0), saved_subsystem = nothing
     ) where {T, N}
     return ODESolution{
-        T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
-        typeof(k), typeof(discretes), typeof(prob), typeof(alg), typeof(interp),
+        T, N, typeof(u), typeof(du), typeof(u_analytic), typeof(errors), typeof(t),
+        typeof(k), typeof(W), typeof(discretes), typeof(prob), typeof(alg), typeof(interp),
         typeof(stats), typeof(alg_choice), typeof(resid), typeof(original),
         typeof(saved_subsystem),
     }(
-        u, u_analytic, errors, t, k, discretes, prob, alg, interp,
-        dense, tslocation, stats, alg_choice, retcode, resid, original, saved_subsystem
+        u, du, u_analytic, errors, t, k, W, discretes, prob, alg, interp,
+        dense, tslocation, stats, alg_choice, retcode, resid, original, seed,
+        saved_subsystem
     )
 end
 
@@ -187,8 +191,8 @@ function error_if_observed_derivative(sys, idx, ::Type)
 end
 
 function SymbolicIndexingInterface.is_parameter_timeseries(::Type{S}) where {
-        T1, T2, T3, T4, T5, T6, T7,
-        S <: ODESolution{T1, T2, T3, T4, T5, T6, T7, <:ParameterTimeseriesCollection},
+        T1, T2, T3, T4, T5, T6, T7, T8, T9,
+        S <: ODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, <:ParameterTimeseriesCollection},
     }
     return Timeseries()
 end
@@ -551,9 +555,11 @@ function build_solution(
         errors = Dict{Symbol, real(eltype(prob.u0))}()
         sol = ODESolution{T, N}(
             u,
+            nothing,
             u_analytic,
             errors,
             t, k,
+            nothing,
             discretes,
             prob,
             alg,
@@ -565,6 +571,7 @@ function build_solution(
             retcode,
             resid,
             original,
+            UInt64(0),
             saved_subsystem
         )
         if calculate_error
@@ -579,7 +586,9 @@ function build_solution(
             u,
             nothing,
             nothing,
+            nothing,
             t, k,
+            nothing,
             discretes,
             prob,
             alg,
@@ -591,27 +600,89 @@ function build_solution(
             retcode,
             resid,
             original,
+            UInt64(0),
             saved_subsystem
         )
     end
+end
+
+function _fill_uanalytic_ode!(sol, f)
+    for i in 1:size(sol.u, 1)
+        if sol.prob isa AbstractDDEProblem
+            push!(
+                sol.u_analytic,
+                f.analytic(sol.prob.u0, sol.prob.h, sol.prob.p, sol.t[i])
+            )
+        else
+            push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i]))
+        end
+    end
+end
+
+function _fill_uanalytic_dae!(sol, f)
+    prob = sol.prob
+    for i in 1:size(sol.u, 1)
+        push!(sol.u_analytic, f.analytic(prob.du0, prob.u0, prob.p, sol.t[i]))
+    end
+end
+
+function _fill_uanalytic_rode!(sol, f)
+    empty!(sol.u_analytic)
+    if f isa RODEFunction && f.analytic_full == true
+        f.analytic(sol)
+    elseif sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
+        for i in 1:length(sol)
+            push!(
+                sol.u_analytic,
+                f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i])))
+            )
+        end
+    else
+        for i in 1:length(sol)
+            push!(
+                sol.u_analytic,
+                f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i])
+            )
+        end
+    end
+end
+
+function _dense_analytic_ode(sol, f, densetimes)
+    return VectorOfArray(
+        [f.analytic(sol.prob.u0, sol.prob.p, t) for t in densetimes]
+    )
+end
+
+function _dense_analytic_dae(sol, f, densetimes)
+    prob = sol.prob
+    return VectorOfArray(
+        [f.analytic(prob.du0, prob.u0, prob.p, t) for t in densetimes]
+    )
+end
+
+function _dense_analytic_rode(sol, f, densetimes)
+    return [f.analytic(sol.u[1], sol.prob.p, t, sol.W(t)[1]) for t in densetimes]
 end
 
 function calculate_solution_errors!(
         sol::AbstractODESolution; fill_uanalytic = true,
         timeseries_errors = true, dense_errors = true
     )
-    f = sol.prob.f
+    prob = sol.prob
+
+    if prob.f isa Tuple
+        f = prob.f[1]
+    else
+        f = prob.f
+    end
 
     if fill_uanalytic
-        for i in 1:size(sol.u, 1)
-            if sol.prob isa AbstractDDEProblem
-                push!(
-                    sol.u_analytic,
-                    f.analytic(sol.prob.u0, sol.prob.h, sol.prob.p, sol.t[i])
-                )
-            else
-                push!(sol.u_analytic, f.analytic(sol.prob.u0, sol.prob.p, sol.t[i]))
-            end
+        if prob isa AbstractDAEProblem
+            _fill_uanalytic_dae!(sol, f)
+        elseif prob isa Union{AbstractRODEProblem, AbstractSDDEProblem}
+            _fill_uanalytic_rode!(sol, f)
+        else
+            _fill_uanalytic_ode!(sol, f)
         end
     end
 
@@ -641,12 +712,13 @@ function calculate_solution_errors!(
             if sol.dense && dense_errors
                 densetimes = collect(range(sol.t[1], stop = sol.t[end], length = 100))
                 interp_u = sol(densetimes)
-                interp_analytic = VectorOfArray(
-                    [
-                        f.analytic(sol.prob.u0, sol.prob.p, t)
-                            for t in densetimes
-                    ]
-                )
+                interp_analytic = if prob isa AbstractDAEProblem
+                    _dense_analytic_dae(sol, f, densetimes)
+                elseif prob isa Union{AbstractRODEProblem, AbstractSDDEProblem}
+                    _dense_analytic_rode(sol, f, densetimes)
+                else
+                    _dense_analytic_ode(sol, f, densetimes)
+                end
                 sol.errors[:L∞] = norm(
                     maximum(
                         vecvecapply(
@@ -694,6 +766,7 @@ end
 
 function solution_slice(sol::ODESolution{T, N}, I) where {T, N}
     @reset sol.u = sol.u[I]
+    @reset sol.du = sol.du === nothing ? nothing : sol.du[I]
     @reset sol.u_analytic = sol.u_analytic === nothing ? nothing : sol.u_analytic[I]
     @reset sol.t = sol.t[I]
     @reset sol.k = sol.dense ? sol.k[I] : sol.k

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -1,103 +1,11 @@
 ### Concrete Types
 
 """
-$(TYPEDEF)
-
-Representation of the solution to an stochastic differential equation defined by an SDEProblem,
-or of a random ordinary differential equation defined by an RODEProblem.
-
-## DESolution Interface
-
-For more information on interacting with `DESolution` types, check out the Solution Handling
-page of the DifferentialEquations.jl documentation.
-
-<https://docs.sciml.ai/DiffEqDocs/stable/basics/solution>
-
-## Fields
-
-  - `u`: the representation of the SDE or RODE solution. Given as an array of solutions, where `u[i]`
-    corresponds to the solution at time `t[i]`. It is recommended in most cases one does not
-    access `sol.u` directly and instead use the array interface described in the Solution
-    Handling page of the DifferentialEquations.jl documentation.
-  - `t`: the time points corresponding to the saved values of the ODE solution.
-  - `W`: the representation of the saved noise process from the solution. See [the Noise Processes
-    page of the DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/features/noise_process/).
-    Note that this noise is only saved in full if `save_noise=true` in the solver.
-  - `prob`: the original SDEProblem/RODEProblem that was solved.
-  - `alg`: the algorithm type used by the solver.
-  - `stats`: statistics of the solver, such as the number of function evaluations required,
-    number of Jacobians computed, and more.
-  - `retcode`: the return code from the solver. Used to determine whether the solver solved
-    successfully, whether it terminated early due to a user-defined callback, or whether it
-    exited due to an error. For more details, see
-    [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
+RODESolution is an alias for ODESolution. RODE/SDE solutions are represented using the
+unified ODESolution type, with the `W` field storing the noise process and `seed` storing
+the random seed.
 """
-struct RODESolution{
-        T, N, uType, uType2, DType, tType, randType, discType, P, A, IType, S,
-        AC <: Union{Nothing, Vector{Int}}, V,
-    } <:
-    AbstractRODESolution{T, N, uType}
-    u::uType
-    u_analytic::uType2
-    errors::DType
-    t::tType
-    W::randType
-    discretes::discType
-    prob::P
-    alg::A
-    interp::IType
-    dense::Bool
-    tslocation::Int
-    stats::S
-    alg_choice::AC
-    retcode::ReturnCode.T
-    seed::UInt64
-    saved_subsystem::V
-end
-
-function ConstructionBase.constructorof(::Type{O}) where {T, N, O <: RODESolution{T, N}}
-    return RODESolution{T, N}
-end
-
-function ConstructionBase.setproperties(sol::RODESolution, patch::NamedTuple)
-    u = get(patch, :u, sol.u)
-    N = u === nothing ? 2 : ndims(eltype(u)) + 1
-    T = eltype(eltype(u))
-    patch = merge(getproperties(sol), patch)
-    return RODESolution{
-        T, N, typeof(patch.u), typeof(patch.u_analytic), typeof(patch.errors),
-        typeof(patch.t), typeof(patch.W), typeof(patch.discretes),
-        typeof(patch.prob), typeof(patch.alg), typeof(patch.interp),
-        typeof(patch.stats), typeof(patch.alg_choice), typeof(patch.saved_subsystem),
-    }(
-        patch.u, patch.u_analytic, patch.errors, patch.t, patch.W, patch.discretes,
-        patch.prob, patch.alg, patch.interp, patch.dense, patch.tslocation, patch.stats,
-        patch.alg_choice, patch.retcode, patch.seed, patch.saved_subsystem
-    )
-end
-
-Base.@propagate_inbounds function Base.getproperty(x::AbstractRODESolution, s::Symbol)
-    if s === :destats
-        Base.depwarn("`sol.destats` is deprecated. Use `sol.stats` instead.", "sol.destats")
-        return getfield(x, :stats)
-    elseif s === :ps
-        return ParameterIndexingProxy(x)
-    end
-    return getfield(x, s)
-end
-
-function (sol::RODESolution)(
-        t, ::Type{deriv} = Val{0}; idxs = nothing,
-        continuity = :left
-    ) where {deriv}
-    return sol(t, deriv, idxs, continuity)
-end
-function (sol::RODESolution)(
-        v, t, ::Type{deriv} = Val{0}; idxs = nothing,
-        continuity = :left
-    ) where {deriv}
-    return sol.interp(v, t, idxs, deriv, sol.prob.p, continuity)
-end
+const RODESolution = ODESolution
 
 function build_solution(
         prob::Union{AbstractRODEProblem, AbstractSDDEProblem},
@@ -146,16 +54,13 @@ function build_solution(
     if has_analytic(f)
         u_analytic = Vector{typeof(prob.u0)}()
         errors = Dict{Symbol, real(eltype(prob.u0))}()
-        sol = RODESolution{
-            T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
-            typeof(W), typeof(discretes),
-            typeof(prob), typeof(alg), typeof(interp), typeof(stats),
-            typeof(alg_choice), typeof(saved_subsystem),
-        }(
+        sol = ODESolution{T, N}(
             u,
+            nothing,
             u_analytic,
             errors,
-            t, W,
+            t, nothing,
+            W,
             discretes,
             prob,
             alg,
@@ -165,6 +70,8 @@ function build_solution(
             stats,
             alg_choice,
             retcode,
+            nothing,
+            nothing,
             seed,
             saved_subsystem
         )
@@ -178,143 +85,28 @@ function build_solution(
 
         return sol
     else
-        return RODESolution{
-            T, N, typeof(u), Nothing, Nothing, typeof(t),
-            typeof(W), typeof(discretes), typeof(prob), typeof(alg), typeof(interp),
-            typeof(stats), typeof(alg_choice), typeof(saved_subsystem),
-        }(
-            u, nothing, nothing, t, W, discretes,
-            prob, alg, interp,
-            dense, 0, stats,
-            alg_choice, retcode, seed, saved_subsystem
+        return ODESolution{T, N}(
+            u,
+            nothing,
+            nothing,
+            nothing,
+            t, nothing,
+            W,
+            discretes,
+            prob,
+            alg,
+            interp,
+            dense,
+            0,
+            stats,
+            alg_choice,
+            retcode,
+            nothing,
+            nothing,
+            seed,
+            saved_subsystem
         )
     end
-end
-
-function save_discretes!(sol::AbstractRODESolution, t, vals, timeseries_idx)
-    RecursiveArrayTools.has_discretes(sol) || return
-    disc = RecursiveArrayTools.get_discretes(sol)
-    return _save_discretes_internal!(disc[timeseries_idx], t, vals)
-end
-
-function get_interpolated_discretes(sol::AbstractRODESolution, t, deriv, continuity)
-    is_parameter_timeseries(sol) == Timeseries() || return nothing
-
-    discs::ParameterTimeseriesCollection = RecursiveArrayTools.get_discretes(sol)
-    interp_discs = map(discs) do partition
-        hold_discrete(partition.u, partition.t, t)
-    end
-    return ParameterTimeseriesCollection(interp_discs, parameter_values(discs))
-end
-
-function SymbolicIndexingInterface.is_parameter_timeseries(::Type{S}) where {
-        T1, T2, T3, T4, T5, T6, T7,
-        S <: RODESolution{T1, T2, T3, T4, T5, T6, T7, <:ParameterTimeseriesCollection},
-    }
-    return Timeseries()
-end
-
-function calculate_solution_errors!(
-        sol::AbstractRODESolution; fill_uanalytic = true,
-        timeseries_errors = true, dense_errors = true
-    )
-    if sol.prob.f isa Tuple
-        f = sol.prob.f[1]
-    else
-        f = sol.prob.f
-    end
-
-    if fill_uanalytic
-        empty!(sol.u_analytic)
-        if f isa RODEFunction && f.analytic_full == true
-            f.analytic(sol)
-        elseif sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
-            for i in 1:length(sol)
-                push!(
-                    sol.u_analytic,
-                    f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i])))
-                )
-            end
-        else
-            for i in 1:length(sol)
-                push!(
-                    sol.u_analytic,
-                    f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i])
-                )
-            end
-        end
-    end
-
-    return if !isempty(sol.u_analytic)
-        sol.errors[:final] = norm(recursive_mean(abs.(sol.u[end] - sol.u_analytic[end])))
-        if timeseries_errors
-            sol.errors[:l∞] = norm(
-                maximum(
-                    vecvecapply(
-                        (x) -> abs.(x),
-                        sol.u - sol.u_analytic
-                    )
-                )
-            )
-            sol.errors[:l2] = norm(
-                sqrt(
-                    recursive_mean(
-                        vecvecapply(
-                            (x) -> float.(x) .^ 2,
-                            sol.u - sol.u_analytic
-                        )
-                    )
-                )
-            )
-        end
-        if dense_errors
-            densetimes = collect(range(sol.t[1], stop = sol.t[end], length = 100))
-            interp_u = sol(densetimes)
-            interp_analytic = [
-                f.analytic(sol.u[1], sol.prob.p, t, sol.W(t)[1])
-                    for t in densetimes
-            ]
-            sol.errors[:L∞] = norm(
-                maximum(
-                    vecvecapply(
-                        (x) -> abs.(x),
-                        interp_u - interp_analytic
-                    )
-                )
-            )
-            sol.errors[:L2] = norm(
-                sqrt(
-                    recursive_mean(
-                        vecvecapply(
-                            (x) -> float.(x) .^ 2,
-                            interp_u -
-                                interp_analytic
-                        )
-                    )
-                )
-            )
-        end
-    end
-end
-
-function build_solution(sol::AbstractRODESolution, u_analytic, errors)
-    @reset sol.u_analytic = u_analytic
-    return @set sol.errors = errors
-end
-
-function solution_new_retcode(sol::AbstractRODESolution, retcode)
-    return @set sol.retcode = retcode
-end
-
-function solution_new_tslocation(sol::AbstractRODESolution, tslocation)
-    return @set sol.tslocation = tslocation
-end
-
-function solution_slice(sol::AbstractRODESolution{T, N}, I) where {T, N}
-    @reset sol.u = sol.u[I]
-    @reset sol.u_analytic = sol.u_analytic === nothing ? nothing : sol.u_analytic[I]
-    @reset sol.t = sol.t[I]
-    return @set sol.dense = false
 end
 
 function sensitivity_solution(sol::AbstractRODESolution, u, t)

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -205,7 +205,7 @@ DEFAULT_PLOT_FUNC(x, y, z) = (x, y, z) # For v0.5.2 bug
 
 function isdenseplot(sol)
     return (sol.dense || sol.prob isa AbstractDiscreteProblem) &&
-        !(sol isa AbstractRODESolution) &&
+        !(sol.prob isa Union{AbstractRODEProblem, AbstractSDDEProblem}) &&
         !(
         hasfield(typeof(sol), :interp) &&
             sol.interp isa SensitivityInterpolation


### PR DESCRIPTION
## Summary

- Expands `ODESolution` to carry the union of all fields from the previously separate types: `du` (derivatives, from DAESolution), `W` (noise process, from RODESolution), and `seed` (random seed, from RODESolution)
- `DAESolution` and `RODESolution` are now `const` aliases for `ODESolution`, eliminating redundant struct definitions
- All `build_solution` dispatches create `ODESolution` directly, with problem-type dispatch determining which fields are populated
- `calculate_solution_errors!` is unified into a single implementation that branches on problem type (`AbstractDAEProblem`, `AbstractRODEProblem`/`AbstractSDDEProblem`, `AbstractDDEProblem`, or standard ODE)
- Removes ~290 lines of duplicated code across `dae_solutions.jl` and `rode_solutions.jl` (duplicate `getproperty`, `solution_new_retcode`, `solution_new_tslocation`, `solution_slice`, `ConstructionBase` methods, callable methods, etc.)
- `isdenseplot` now checks `sol.prob` type instead of `sol isa AbstractRODESolution`

## Breaking changes

- `ODESolution` struct has new fields (`du`, `W`, `seed`) which changes its type parameters
- Code dispatching on the concrete types `DAESolution` or `RODESolution` will now match any `ODESolution` (since they are aliases)
- Code dispatching on `AbstractDAESolution` or `AbstractRODESolution` with concrete solution values will no longer match (since the concrete type is always `ODESolution <: AbstractODESolution`)
- The abstract types `AbstractDAESolution`, `AbstractDDESolution`, `AbstractRODESolution` are unchanged and remain in the hierarchy for interface purposes

## Test plan

- [x] All SciMLBase unit tests pass
- [ ] Downstream solver packages (OrdinaryDiffEq, StochasticDiffEq, DASKR, Sundials) need testing for compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)