### PR TITLE
Add timer_outputs field to NonlinearSolution

### DIFF
--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -54,8 +54,9 @@ or the steady state solution to a differential equation defined by a SteadyState
   - `left`: if the solver is bracketing method, this is the final left bracket value.
   - `right`: if the solver is bracketing method, this is the final right bracket value.
   - `stats`: statistics of the solver, such as the number of function evaluations required.
-"""
-struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr} <:
+  - `timer_outputs`: timing information collected by the solver.
+  """
+struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr, TO} <:
     AbstractNonlinearSolution{T, N}
     u::uType
     resid::R
@@ -67,18 +68,19 @@ struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr} <:
     right::uType2
     stats::S
     trace::Tr
+    timer_outputs::TO
 end
 
-function NonlinearSolution(u, resid, prob, alg, retcode, original, left, right, stats, trace)
+function NonlinearSolution(u, resid, prob, alg, retcode, original, left, right, stats, trace, timer_outputs = nothing)
     T = eltype(eltype(u))
     N = ndims(u)
 
     return NonlinearSolution{
         T, N, typeof(u), typeof(resid), typeof(prob), typeof(alg),
-        typeof(original), typeof(left), typeof(stats), typeof(trace),
+        typeof(original), typeof(left), typeof(stats), typeof(trace), typeof(timer_outputs),
     }(
         u, resid, prob, alg,
-        retcode, original, left, right, stats, trace
+        retcode, original, left, right, stats, trace, timer_outputs
     )
 end
 


### PR DESCRIPTION
This PR implements the infrastructure change requested in #685. 

It adds the `timer_outputs` field to the `NonlinearSolution` struct to allow solvers to store diagnostic timing information (e.g., from `TimerOutputs.jl`).

Key changes:
- Added `TO` parametric type to `NonlinearSolution` for type stability.
- Added `timer_outputs` field to the struct.
- Updated the `NonlinearSolution` constructor with a default value of `nothing` to ensure backward compatibility with existing solvers.
