### PR TITLE
fix: throw ArgumentError when ensemblealg is passed as a kwarg (#1130)

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -383,8 +383,12 @@ end
 
 function solve(prob::EnsembleProblem, args...; kwargs...)
     if haskey(kwargs, :ensemblealg)
-        throw(ArgumentError("ensemblealg must be passed as a positional argument, not a keyword argument. " *
-                            "Correct usage: solve(prob, alg, ensemblealg; kwargs...)"))
+        throw(
+            ArgumentError(
+                "ensemblealg must be passed as a positional argument, not a keyword argument. " *
+                    "Correct usage: solve(prob, alg, ensemblealg; kwargs...)"
+            )
+        )
     end
 
     alg = extract_alg(args, kwargs, kwargs)


### PR DESCRIPTION
Resolves #1130
## Description

This PR adds a validation check in the solve interface for EnsembleProblem. If a user accidentally passes ensemblealg as a keyword argument instead of a positional one, it now explicitly throws an ArgumentError.

This prevents the silent failure where the kwarg was swallowed and the solver defaulted to the CPU, making debugging much easier for users (especially when dealing with EnsembleGPUArray).

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API

## Additional context

I tested this locally to ensure that valid positional arguments (e.g., solve(eprob, Tsit5(), EnsembleThreads(); trajectories=2)) continue to work seamlessly, while invalid kwarg usage throws the new ArgumentError.

Please let me know if you would like me to add a specific @test_throws case for this in the test suite, and I'd be happy to include it!
