### PR TITLE
Fix anyeltypedual method ambiguity on AbstractVectorOfArray

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -294,7 +294,9 @@ function anyeltypedual(
     return Any
 end
 
-function anyeltypedual(sol::RecursiveArrayTools.AbstractDiffEqArray, counter = 0)
+function anyeltypedual(
+        sol::RecursiveArrayTools.AbstractVectorOfArray, ::Type{Val{counter}} = Val{0}
+    ) where {counter}
     return diffeqmapreduce(anyeltypedual, promote_dual, (sol.u, sol.t))
 end
 


### PR DESCRIPTION
## Summary
- Fixes method ambiguity when calling `anyeltypedual` on `DiffEqArray` with `Val{counter}` argument
- Changes the `anyeltypedual` method signature from `(sol::AbstractDiffEqArray, counter = 0)` to `(sol::AbstractVectorOfArray, ::Type{Val{counter}} = Val{0}) where {counter}`, matching the pattern used by all other specializations in the extension
- Broadens the type constraint from `AbstractDiffEqArray` to `AbstractVectorOfArray`

Fixes #1267

## Test plan
- [x] Verified the MRE from the issue no longer errors
- [x] Full `Pkg.test()` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)