### PR TITLE
Fix unwrapped_f type parameter mismatch for AutoSpecialize ODEFunction

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2921,10 +2921,10 @@ function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
         ODEFunction{
             isinplace(f), specialization(f), typeof(newf), typeof(f.mass_matrix),
             typeof(f.analytic), typeof(f.tgrad),
-            typeof(f.jac), Nothing, Nothing, typeof(f.jac_prototype),
-            typeof(f.sparsity), Nothing, Nothing, typeof(f.W_prototype),
-            Nothing,
-            Nothing,
+            typeof(f.jac), typeof(f.jvp), typeof(f.vjp), typeof(f.jac_prototype),
+            typeof(f.sparsity), typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.W_prototype),
+            typeof(f.paramjac),
+            typeof(f.vjp_p),
             typeof(f.observed), typeof(f.colorvec),
             typeof(f.sys), typeof(f.initialization_data), typeof(f.nlstep_data),
         }(

--- a/test/convert_tests.jl
+++ b/test/convert_tests.jl
@@ -49,6 +49,38 @@ end
     @test nlprob.kwargs[:b] == prob.kwargs[:b]
 end
 
+@testset "unwrapped_f preserves non-nothing fields for AutoSpecialize" begin
+    analytic_fn = (u0, p, t) -> u0 .* exp(-t)
+    jvp_fn = (Jv, u, p, t, v) -> nothing
+
+    # AutoSpecialize with analytic + jvp should not error
+    f = ODEFunction{true, SciMLBase.AutoSpecialize}(
+        (du, u, p, t) -> (du .= -u);
+        analytic = analytic_fn,
+        jvp = jvp_fn
+    )
+    uf = SciMLBase.unwrapped_f(f)
+    @test uf.analytic === analytic_fn
+    @test uf.jvp === jvp_fn
+
+    # AutoSpecialize with only analytic
+    f2 = ODEFunction{true, SciMLBase.AutoSpecialize}(
+        (du, u, p, t) -> (du .= -u);
+        analytic = analytic_fn
+    )
+    uf2 = SciMLBase.unwrapped_f(f2)
+    @test uf2.analytic === analytic_fn
+    @test uf2.jvp === nothing
+
+    # AutoSpecialize with no extra fields
+    f3 = ODEFunction{true, SciMLBase.AutoSpecialize}(
+        (du, u, p, t) -> (du .= -u)
+    )
+    uf3 = SciMLBase.unwrapped_f(f3)
+    @test uf3.analytic === nothing
+    @test uf3.jvp === nothing
+end
+
 @testset "Convert ODEProblem with kwargs to SteadyStateProblem" begin
     function lorenz!(du, u, p, t)
         du[1] = p[1] * (u[2] - u[1])


### PR DESCRIPTION
## Summary

- Fix `unwrapped_f` for `AutoSpecialize` ODEFunction incorrectly hardcoding `Nothing` as the type parameter for `jvp`, `vjp`, `Wfact`, `Wfact_t`, `paramjac`, and `vjp_p` fields while copying the actual (potentially non-nothing) field values
- Use `typeof(f.field)` for all fields instead, matching the `FullSpecialize` branch behavior
- Add regression test for `unwrapped_f` with non-nothing fields under `AutoSpecialize`

## Bug

When `discretize` is called with `analytic = pdesys.analytic_func`, the resulting `ODEFunction` carries non-nothing auxiliary fields. During `get_concrete_problem → promote_f → unwrapped_f`, the `AutoSpecialize` branch constructs a new `ODEFunction` with `Nothing` type parameters for several fields but passes the actual non-nothing values, triggering:

```
Error: cannot convert a value to nothing for assignment
```

The fix preserves the actual field types. When a field is `nothing`, `typeof(nothing) === Nothing` so the type erasure behavior is preserved.

Reference: https://github.com/SciML/SciMLBenchmarks.jl/pull/1477

## Test plan

- [x] New regression test: `unwrapped_f preserves non-nothing fields for AutoSpecialize`
- [x] All existing SciMLBase tests pass (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)