### PR TITLE
Fix BVProblem type instability: infer nlls=false for StandardBVProblem

### DIFF
--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -186,7 +186,9 @@ struct BVProblem{uType, tType, isinplace, nlls, P, F, LB, UB, LC, UC, PT, S, K} 
                 if f.bcresid_prototype !== nothing
                     _nlls = length(f.bcresid_prototype) != length(__u0)
                 else
-                    _nlls = Nothing # Cannot reliably infer
+                    # For StandardBVProblem without bcresid_prototype, the solver
+                    # creates a residual matching u0 size, so it is not NLLS.
+                    _nlls = false
                 end
             end
         else


### PR DESCRIPTION
## Summary

One-line fix for the type instability reported in SciML/BoundaryValueDiffEq.jl#454.

## Problem

In the `BVProblem` inner constructor, for `StandardBVProblem` without `bcresid_prototype`:

```julia
_nlls = Nothing # Cannot reliably infer
```

This `Nothing` type parameter propagates to `__internal_nlsolve_problem` in BoundaryValueDiffEq, which dispatches on it and returns `Union{NonlinearProblem, NonlinearLeastSquaresProblem}` — poisoning the entire solve chain with type instability.

## Fix

```diff
- _nlls = Nothing # Cannot reliably infer
+ _nlls = false   # Without bcresid_prototype, residual matches u0 size
```

This is correct because `__get_bcresid_prototype(::StandardBVProblem, prob, u)` creates `zero(u)` when `bcresid_prototype` is not provided — so `length(bcresid_prototype) == length(u0)` always holds, meaning it's never NLLS.

## Result

Before: `@inferred solve(prob, MIRK5(; jac_alg); dt=0.2)` fails unless user passes `nlls=Val(false)`
After: passes without any workaround

Companion PR: SciML/BoundaryValueDiffEq.jl#455 (test updates)

## Test plan

- [x] `BVProblem(f!, bc!, u0, tspan, p)` now has `nlls=false` instead of `Nothing`
- [x] `@inferred solve(prob, MIRK5(; jac_alg); dt=0.2)` passes
- [x] Existing BoundaryValueDiffEq type stability tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)