### PR TITLE
Add Mooncake tangent_type overrides for OverrideInitData and ODENLStepData

### DIFF
--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -6,6 +6,15 @@ import Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
     @from_rrule, @zero_adjoint, @mooncake_overlay, MinimalCtx,
     NoPullback
 
+# OverrideInitData and ODENLStepData are solver/initialization infrastructure
+# embedded in ODEFunction type parameters. They are not differentiable, but their
+# deeply nested type parameters (NonlinearProblem, RuntimeGeneratedFunction,
+# InitializationMetadata, etc.) cause Mooncake's abstract interpretation to hang
+# during type inference. Marking them NoTangent avoids generating tangent code
+# for these fields entirely.
+Mooncake.tangent_type(::Type{<:SciMLBase.OverrideInitData}) = Mooncake.NoTangent
+Mooncake.tangent_type(::Type{<:SciMLBase.ODENLStepData}) = Mooncake.NoTangent
+
 @zero_adjoint MinimalCtx Tuple{typeof(SciMLBase.numargs), Any}
 @is_primitive MinimalCtx Tuple{
     typeof(SciMLBase.set_mooncakeoriginator_if_mooncake), SciMLBase.ChainRulesOriginator,


### PR DESCRIPTION
## Summary
- Add `Mooncake.tangent_type` overrides returning `NoTangent` for `OverrideInitData` and `ODENLStepData` in `SciMLBaseMooncakeExt`

## Motivation

`OverrideInitData` (DAE initialization) and `ODENLStepData` (custom NL step) are solver infrastructure types embedded in `ODEFunction` type parameters. They contain deeply nested type parameters (`NonlinearProblem`, `RuntimeGeneratedFunction`, `InitializationMetadata`, `ReconstructInitializeprob`, etc.) that are not differentiable.

When Mooncake traces through code that touches `ODEFunction` (e.g., field access on an `ODEProblem`), it generates tangent code for all fields including these. The enormous type parameter trees cause Mooncake's abstract interpretation and LLVM compilation to hang.

ModelingToolkitBase already has similar overrides for `System`, `ImmutableDict`, `GeneratedFunctionWrapper`, and `ObservedFunctionCache` in its Mooncake extension (PRs #4331, #4365). These two types were missing because they live in SciMLBase.

Part of the fix for SciML/SciMLSensitivity.jl#1358 and chalk-lab/Mooncake.jl#1097.

## Test plan
- [ ] Verify precompilation succeeds
- [ ] Verify existing Mooncake-related tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)