### PR TITLE
Fix adapt method for ODEFunction to adapt its contents

### DIFF
--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -30,10 +30,10 @@ end
 function adapt_structure(to, f::ODEFunction{iip}) where {iip}
     # For GPU kernels, we now support DAEs with mass matrices and initialization
     return ODEFunction{iip, FullSpecialize}(
-        f.f,
-        jac = f.jac,
-        mass_matrix = f.mass_matrix,
-        initialization_data = f.initialization_data
+        adapt(to, f.f),
+        jac = adapt(to, f.jac),
+        mass_matrix = adapt(to, f.mass_matrix),
+        initialization_data = adapt(to, f.initialization_data)
     )
 end
 


### PR DESCRIPTION
Updated adapt_structure function to support GPU kernels with DAEs by adapting mass matrices and initialization data.  Fixes https://github.com/SciML/DiffEqGPU.jl/issues/425 fixes https://github.com/SciML/DiffEqGPU.jl/issues/375

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
