### PR TITLE
Remove redundant getproperty overloads on solution types

### DIFF
--- a/src/solutions/dae_solutions.jl
+++ b/src/solutions/dae_solutions.jl
@@ -75,12 +75,6 @@ function ConstructionBase.setproperties(sol::DAESolution, patch::NamedTuple)
     )
 end
 
-Base.@propagate_inbounds function Base.getproperty(x::AbstractDAESolution, s::Symbol)
-    if s === :ps
-        return ParameterIndexingProxy(x)
-    end
-    return getfield(x, s)
-end
 
 function build_solution(
         prob::AbstractDAEProblem, alg, t, u, du = nothing;

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -145,12 +145,6 @@ function ConstructionBase.setproperties(sol::ODESolution, patch::NamedTuple)
     )
 end
 
-Base.@propagate_inbounds function Base.getproperty(x::AbstractODESolution, s::Symbol)
-    if s === :ps
-        return ParameterIndexingProxy(x)
-    end
-    return getfield(x, s)
-end
 
 # FIXME: Remove the defaults for resid and original on a breaking release
 function ODESolution{T, N}(

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -76,12 +76,6 @@ function ConstructionBase.setproperties(sol::RODESolution, patch::NamedTuple)
     )
 end
 
-Base.@propagate_inbounds function Base.getproperty(x::AbstractRODESolution, s::Symbol)
-    if s === :ps
-        return ParameterIndexingProxy(x)
-    end
-    return getfield(x, s)
-end
 
 function (sol::RODESolution)(
         t, ::Type{deriv} = Val{0}; idxs = nothing,


### PR DESCRIPTION
## Summary
- Remove `getproperty` definitions on `AbstractODESolution`, `AbstractDAESolution`, and `AbstractRODESolution` that are redundant with the existing `getproperty` on `AbstractSolution` (Union type in `solution_interface.jl`)
- All three definitions were identical (check for `:ps`, fallthrough to `getfield`) and already covered by the parent type's definition
- Reduces method table invalidations when SciMLBase loads, since each redundant `getproperty` on an abstract type creates extra dispatch entries that invalidate compiled code in dependencies like RecursiveArrayTools

## Context
`getproperty` is one of the hottest methods in Julia's dispatch. Defining it on multiple abstract types in the same hierarchy (`AbstractRODESolution <: AbstractODESolution <: AbstractTimeseriesSolution`, all covered by `AbstractSolution`) causes unnecessary invalidation cascades. The `AbstractSolution` definition already handles all of these.

## Test plan
- [x] SciMLBase loads successfully
- [x] `sol.ps` still works via the `AbstractSolution` getproperty
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)