### PR TITLE
Revert AutoSpecialize default for SciMLFunction constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.153.0"
+version = "2.153.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2896,10 +2896,10 @@ function ODEFunction{iip, specialize}(
 end
 
 function ODEFunction{iip}(f; kwargs...) where {iip}
-    return ODEFunction{iip, DEFAULT_SPECIALIZATION}(f; kwargs...)
+    return ODEFunction{iip, FullSpecialize}(f; kwargs...)
 end
 ODEFunction{iip}(f::ODEFunction; kwargs...) where {iip} = f
-ODEFunction(f; kwargs...) = ODEFunction{isinplace(f, 4), DEFAULT_SPECIALIZATION}(f; kwargs...)
+ODEFunction(f; kwargs...) = ODEFunction{isinplace(f, 4), FullSpecialize}(f; kwargs...)
 ODEFunction(f::ODEFunction; kwargs...) = f
 
 function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
@@ -3206,7 +3206,7 @@ end
 
 SplitFunction(f1, f2; kwargs...) = SplitFunction{isinplace(f2, 4)}(f1, f2; kwargs...)
 function SplitFunction{iip}(f1, f2; kwargs...) where {iip}
-    return SplitFunction{iip, DEFAULT_SPECIALIZATION}(
+    return SplitFunction{iip, FullSpecialize}(
         ODEFunction(f1), ODEFunction{iip}(f2);
         kwargs...
     )
@@ -3313,7 +3313,7 @@ function DynamicalODEFunction(f1, f2 = nothing; kwargs...)
     return DynamicalODEFunction{isinplace(f1, 5)}(f1, f2; kwargs...)
 end
 function DynamicalODEFunction{iip}(f1, f2; kwargs...) where {iip}
-    return DynamicalODEFunction{iip, DEFAULT_SPECIALIZATION}(
+    return DynamicalODEFunction{iip, FullSpecialize}(
         ODEFunction{iip}(f1),
         ODEFunction{iip}(f2); kwargs...
     )


### PR DESCRIPTION
## Summary
- Reverts only the `ODEFunction`, `SplitFunction`, and `DynamicalODEFunction` convenience constructors back to `FullSpecialize` (from #1298)
- All other function types (`NonlinearFunction`, `SDEFunction`, `DiscreteFunction`, `DAEFunction`, `RODEFunction`, etc.) keep `DEFAULT_SPECIALIZATION` as intended
- Bumps version to 2.153.1

The ODEFunction change exposed multiple breaking issues in OrdinaryDiffEq.jl CI:

1. **BigFloat tableau `c` promotes `t` past `FunctionWrapper` signatures** — requires tableau constructors to take separate state/time types
2. **`GradientTracer` type not in wrapper signatures** — AutoSparse sparsity detection passes tracer types through the wrapped function
3. **`MatrixOperator` jac_prototype causes `promote_op` → `Union{}`** — `promote_f` can't handle operator-based Jacobians
4. **Hard DAE numerical accuracy regression** — wrapping changes numerical path for DAE + callback problems

Deferring ODEFunction AutoSpecialize default to v4 where these can be addressed properly.

## Test plan
- OrdinaryDiffEq.jl CI should return to green once this is released
- Other function types remain on DEFAULT_SPECIALIZATION and are unaffected