### PR TITLE
Use DEFAULT_SPECIALIZATION for ODEFunction convenience constructors

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2887,10 +2887,10 @@ function ODEFunction{iip, specialize}(
 end
 
 function ODEFunction{iip}(f; kwargs...) where {iip}
-    return ODEFunction{iip, FullSpecialize}(f; kwargs...)
+    return ODEFunction{iip, DEFAULT_SPECIALIZATION}(f; kwargs...)
 end
 ODEFunction{iip}(f::ODEFunction; kwargs...) where {iip} = f
-ODEFunction(f; kwargs...) = ODEFunction{isinplace(f, 4), FullSpecialize}(f; kwargs...)
+ODEFunction(f; kwargs...) = ODEFunction{isinplace(f, 4), DEFAULT_SPECIALIZATION}(f; kwargs...)
 ODEFunction(f::ODEFunction; kwargs...) = f
 
 function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
@@ -3194,7 +3194,7 @@ end
 
 SplitFunction(f1, f2; kwargs...) = SplitFunction{isinplace(f2, 4)}(f1, f2; kwargs...)
 function SplitFunction{iip}(f1, f2; kwargs...) where {iip}
-    return SplitFunction{iip, FullSpecialize}(
+    return SplitFunction{iip, DEFAULT_SPECIALIZATION}(
         ODEFunction(f1), ODEFunction{iip}(f2);
         kwargs...
     )
@@ -3298,7 +3298,7 @@ function DynamicalODEFunction(f1, f2 = nothing; kwargs...)
     return DynamicalODEFunction{isinplace(f1, 5)}(f1, f2; kwargs...)
 end
 function DynamicalODEFunction{iip}(f1, f2; kwargs...) where {iip}
-    return DynamicalODEFunction{iip, FullSpecialize}(
+    return DynamicalODEFunction{iip, DEFAULT_SPECIALIZATION}(
         ODEFunction{iip}(f1),
         ODEFunction{iip}(f2); kwargs...
     )


### PR DESCRIPTION
## Summary

- Change `ODEFunction`, `SplitFunction`, and `DynamicalODEFunction` convenience constructors to use `DEFAULT_SPECIALIZATION` (`AutoSpecialize`) instead of `FullSpecialize`
- This was previously reverted from v2 (#1299) due to downstream issues in OrdinaryDiffEq.jl that need to be fixed in v7
- Part of SciMLBase v3 breaking changes

## Changes

In `src/scimlfunctions.jl`:
- `ODEFunction{iip}(f; kwargs...)`: `FullSpecialize` -> `DEFAULT_SPECIALIZATION`
- `ODEFunction(f; kwargs...)`: `FullSpecialize` -> `DEFAULT_SPECIALIZATION`
- `SplitFunction{iip}(f1, f2; kwargs...)`: `FullSpecialize` -> `DEFAULT_SPECIALIZATION`
- `DynamicalODEFunction{iip}(f1, f2; kwargs...)`: `FullSpecialize` -> `DEFAULT_SPECIALIZATION`

## Test plan

- [ ] CI passes on the v3 branch
- [ ] Downstream OrdinaryDiffEq.jl v7 tests pass with this change

Generated with [Claude Code](https://claude.com/claude-code)