### PR TITLE
Fix nested ForwardDiff tag mismatch in UJacobianWrapper for Rosenbrock solvers

### DIFF
--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -8,7 +8,7 @@ import SciMLBase:
     AbstractTimeseriesSolution, NonlinearProblem, NonlinearLeastSquaresProblem,
     ODEProblem, SDEProblem, RODEProblem, DDEProblem, PDEProblem, DAEProblem,
     RecursiveArrayTools, totallength, sse, anyeltypedual, reduce_tup,
-    unitfulvalue, _promote_jac_p
+    unitfulvalue, _promote_jac_p!
 
 eltypedual(x) = eltype(x) <: ForwardDiff.Dual
 isdualtype(::Type{<:ForwardDiff.Dual}) = true
@@ -460,16 +460,16 @@ function SciMLBase.totallength(x::ForwardDiff.Dual)
         sum(SciMLBase.totallength, ForwardDiff.partials(x))
 end
 
-function _promote_jac_p(p::AbstractArray{<:ForwardDiff.Dual}, u::AbstractArray{<:ForwardDiff.Dual}, f)
-    if hasfield(typeof(f), :f) && getfield(f, :f) isa SciMLBase.FunctionWrappersWrappers.FunctionWrappersWrapper
-        return p
-    end
+function _promote_jac_p!(ff::SciMLBase.UJacobianWrapper, u::AbstractArray{<:ForwardDiff.Dual})
+    p = ff.p
+    p isa AbstractArray{<:ForwardDiff.Dual} || return p
+    hasfield(typeof(ff.f), :f) && getfield(ff.f, :f) isa SciMLBase.FunctionWrappersWrappers.FunctionWrappersWrapper && return p
     DualU = eltype(u)
-    DualP = eltype(p)
-    if !(DualP <: DualU)
-        return DualU.(p)
-    end
-    return p
+    eltype(p) <: DualU && return p
+    cached = ff._promoted_p
+    cached isa AbstractArray{DualU} && return cached
+    ff._promoted_p = DualU.(p)
+    return ff._promoted_p
 end
 
 end

--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -460,7 +460,10 @@ function SciMLBase.totallength(x::ForwardDiff.Dual)
         sum(SciMLBase.totallength, ForwardDiff.partials(x))
 end
 
-function _promote_jac_p(p::AbstractArray{<:ForwardDiff.Dual}, u::AbstractArray{<:ForwardDiff.Dual})
+function _promote_jac_p(p::AbstractArray{<:ForwardDiff.Dual}, u::AbstractArray{<:ForwardDiff.Dual}, f)
+    if hasfield(typeof(f), :f) && getfield(f, :f) isa SciMLBase.FunctionWrappersWrappers.FunctionWrappersWrapper
+        return p
+    end
     DualU = eltype(u)
     DualP = eltype(p)
     if !(DualP <: DualU)

--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -8,7 +8,7 @@ import SciMLBase:
     AbstractTimeseriesSolution, NonlinearProblem, NonlinearLeastSquaresProblem,
     ODEProblem, SDEProblem, RODEProblem, DDEProblem, PDEProblem, DAEProblem,
     RecursiveArrayTools, totallength, sse, anyeltypedual, reduce_tup,
-    unitfulvalue
+    unitfulvalue, _promote_jac_p
 
 eltypedual(x) = eltype(x) <: ForwardDiff.Dual
 isdualtype(::Type{<:ForwardDiff.Dual}) = true
@@ -458,6 +458,15 @@ sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.part
 function SciMLBase.totallength(x::ForwardDiff.Dual)
     return SciMLBase.totallength(ForwardDiff.value(x)) +
         sum(SciMLBase.totallength, ForwardDiff.partials(x))
+end
+
+function _promote_jac_p(p::AbstractArray{<:ForwardDiff.Dual}, u::AbstractArray{<:ForwardDiff.Dual})
+    DualU = eltype(u)
+    DualP = eltype(p)
+    if !(DualP <: DualU)
+        return DualU.(p)
+    end
+    return p
 end
 
 end

--- a/src/function_wrappers.jl
+++ b/src/function_wrappers.jl
@@ -82,8 +82,8 @@ function UJacobianWrapper{iip}(f::F, t, p) where {F, iip}
 end
 UJacobianWrapper(f::F, t, p) where {F} = UJacobianWrapper{isinplace(f, 4)}(f, t, p)
 
-(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, _promote_jac_p(ff.p, uprev), ff.t)
-_promote_jac_p(p, u) = p
+(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, _promote_jac_p(ff.p, uprev, ff.f), ff.t)
+_promote_jac_p(p, u, f) = p
 function (ff::UJacobianWrapper{true})(uprev)
     (du1 = similar(uprev); ff.f(du1, uprev, ff.p, ff.t); du1)
 end

--- a/src/function_wrappers.jl
+++ b/src/function_wrappers.jl
@@ -82,7 +82,8 @@ function UJacobianWrapper{iip}(f::F, t, p) where {F, iip}
 end
 UJacobianWrapper(f::F, t, p) where {F} = UJacobianWrapper{isinplace(f, 4)}(f, t, p)
 
-(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, ff.p, ff.t)
+(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, _promote_jac_p(ff.p, uprev), ff.t)
+_promote_jac_p(p, u) = p
 function (ff::UJacobianWrapper{true})(uprev)
     (du1 = similar(uprev); ff.f(du1, uprev, ff.p, ff.t); du1)
 end

--- a/src/function_wrappers.jl
+++ b/src/function_wrappers.jl
@@ -75,15 +75,16 @@ mutable struct UJacobianWrapper{iip, fType, tType, P} <: AbstractWrappedFunction
     f::fType
     t::tType
     p::P
+    _promoted_p::Any
 end
 
 function UJacobianWrapper{iip}(f::F, t, p) where {F, iip}
-    return UJacobianWrapper{iip, F, typeof(t), typeof(p)}(f, t, p)
+    return UJacobianWrapper{iip, F, typeof(t), typeof(p)}(f, t, p, nothing)
 end
 UJacobianWrapper(f::F, t, p) where {F} = UJacobianWrapper{isinplace(f, 4)}(f, t, p)
 
-(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, _promote_jac_p(ff.p, uprev, ff.f), ff.t)
-_promote_jac_p(p, u, f) = p
+(ff::UJacobianWrapper{true})(du1, uprev) = ff.f(du1, uprev, _promote_jac_p!(ff, uprev), ff.t)
+_promote_jac_p!(ff, u) = ff.p
 function (ff::UJacobianWrapper{true})(uprev)
     (du1 = similar(uprev); ff.f(du1, uprev, ff.p, ff.t); du1)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Fix for https://github.com/SciML/OrdinaryDiffEq.jl/issues/3381
When NonlinearSolve computes a Jacobian over an ODE solve,` p `enters as D`ual{NLTag}` and Rosenbrock's internal ForwardDiff seeds `u `as `Dual{OrdEqTag, Dual{NLTag}, CS}`. UJacobianWrapper passes these mismatched types to the user function. p[1]*u[1] produces `Dual{NLTag} `outer due to tag precedence, but du expects `Dual{OrdEqTag}` outer, so the assignment crashes.
This promote p to match `eltype(u)` in UJacobianWrapper before calling f