### PR TITLE
Fix BoundsError in RODE calculate_solution_errors! under RecursiveArrayTools v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -210,14 +210,14 @@ function calculate_solution_errors!(
         if f isa RODEFunction && f.analytic_full == true
             f.analytic(sol)
         elseif sol.W isa AbstractDiffEqArray{T, N, nothing} where {T, N}
-            for i in 1:length(sol)
+            for i in eachindex(sol.t)
                 push!(
                     sol.u_analytic,
                     f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], first(sol.W(sol.t[i])))
                 )
             end
         else
-            for i in 1:length(sol)
+            for i in eachindex(sol.t)
                 push!(
                     sol.u_analytic,
                     f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i])


### PR DESCRIPTION
## Summary

`calculate_solution_errors!(::AbstractRODESolution)` iterates

```julia
for i in 1:length(sol)
    push!(sol.u_analytic, f.analytic(…, sol.t[i], sol.W[:, i]))
end
```

This worked on RAT v3 because \`Base.length(VA::AbstractVectorOfArray)\` was specialized to return \`length(VA.u)\` — the number of saved time points.

RAT v4 made \`AbstractVectorOfArray <: AbstractArray\` and dropped that specialization, so \`length(sol)\` now falls through to \`prod(size(sol))\` — the **total number of scalar entries across the whole timeseries**. For any non-scalar SDE/RODE state (2×101 → length 202, 3×101 → 303, matrix state even bigger) the loop overruns \`sol.t\` / \`sol.W\` and throws:

```
BoundsError: attempt to access 101-element Vector{Float64} at index [102]
```

in the final \`solve!\` postamble whenever the problem has an analytic solution. This cascades into every downstream SDE/RODE test that calls \`test_convergence\` / analyticless-with-analytic setups — e.g. in SciML/OrdinaryDiffEq.jl#3502 it produced the \`StochasticDiffEq_Interface{1,2,3}\` / \`AlgConvergence{2,3}\` / \`NoncommutativeConvergence\` / \`mass_matrix\` failures simultaneously.

## Fix

Replace both \`for i in 1:length(sol)\` occurrences with \`for i in eachindex(sol.t)\`. That's semantically what the loop has always meant — iterate over the saved time points — and is equivalent on RAT v3 and v4.

## Scope

ODE and DAE \`calculate_solution_errors!\` already use \`sol.t\`-bounded forms (verified by grep); only the RODE specialization had this regression. No other \`length(sol)\` call inside SciMLBase's error-calculation path.

## Version

Patch bump \`3.3.0 → 3.3.1\`. Bugfix only; no API change.

## Test plan

- [x] Reproduced the \`BoundsError\` locally against master + RAT v4 on a 2D SDE with analytic solution (`prob_sde_2Dlinear`). Confirmed the fix eliminates the error while still correctly filling \`sol.u_analytic\` with \`length(sol.t)\` entries.
- [x] Verified with a scalar SDE + analytic (`prob_sde_linear`) — still works; scalar case previously coincidentally had the right count because \`prod(size(sol)) == length(sol.t)\` for scalar state.
- [ ] CI on this PR.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>