### PR TITLE
Add DAEProblem{iip, specialize} two-parameter constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.4.0"
+version = "3.4.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -109,6 +109,15 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
     function DAEProblem{iip}(f, du0, u0, tspan, p = NullParameters(); kwargs...) where {iip}
         return DAEProblem(DAEFunction{iip}(f), du0, u0, tspan, p; kwargs...)
     end
+
+    @add_kwonly function DAEProblem{iip, specialize}(
+            f, du0, u0, tspan, p = NullParameters();
+            kwargs...
+        ) where {iip, specialize}
+        return DAEProblem{iip}(
+            DAEFunction{iip, specialize}(f), du0, u0, tspan, p; kwargs...
+        )
+    end
 end
 
 function DAEProblem(f::AbstractDAEFunction, du0, u0, tspan, p = NullParameters(); kwargs...)

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -107,7 +107,9 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
     end
 
     function DAEProblem{iip}(f, du0, u0, tspan, p = NullParameters(); kwargs...) where {iip}
-        return DAEProblem(DAEFunction{iip}(f), du0, u0, tspan, p; kwargs...)
+        return DAEProblem(
+            DAEFunction{iip, DEFAULT_SPECIALIZATION}(f), du0, u0, tspan, p; kwargs...
+        )
     end
 
     @add_kwonly function DAEProblem{iip, specialize}(

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -73,6 +73,41 @@ prob_bvp = BVProblem(simplependulum!, bc!, [pi / 2, pi / 2], (0, 1.0))
     end
 end
 
+@testset "DAEProblem{iip, specialize} two-parameter constructor" begin
+    function simple_dae!(resid, du, u, p, t)
+        resid[1] = du[1] - u[1]
+        resid[2] = u[1] + u[2] - 1.0
+        return nothing
+    end
+    du0 = [1.0, 0.0]
+    u0 = [1.0, 0.0]
+    tspan = (0.0, 1.0)
+
+    # Construction succeeds and locks in FullSpecialize
+    prob = DAEProblem{true, SciMLBase.FullSpecialize}(simple_dae!, du0, u0, tspan)
+    @test prob isa DAEProblem
+    @test prob.f isa DAEFunction{true, SciMLBase.FullSpecialize}
+    @test SciMLBase.specialization(prob.f) === SciMLBase.FullSpecialize
+    @test SciMLBase.isinplace(prob) === true
+    @test prob.du0 == du0
+    @test prob.u0 == u0
+    @test prob.tspan === (0.0, 1.0)
+
+    # With explicit parameters and kwargs
+    prob_p = DAEProblem{true, SciMLBase.FullSpecialize}(
+        simple_dae!, du0, u0, tspan, 1.0; differential_vars = [true, false]
+    )
+    @test prob_p.p === 1.0
+    @test prob_p.differential_vars == [true, false]
+    @test SciMLBase.specialization(prob_p.f) === SciMLBase.FullSpecialize
+
+    # f is callable through the wrapped DAEFunction
+    resid = zeros(2)
+    prob.f(resid, du0, u0, nothing, 0.0)
+    @test resid[1] ≈ du0[1] - u0[1]
+    @test resid[2] ≈ u0[1] + u0[2] - 1.0
+end
+
 # test for tspan promotion in DiscreteProblem
 let
     p = (0.1 / 1000, 0.01)


### PR DESCRIPTION
## Motivation

`ODEProblem{iip, specialize}(f, u0, tspan, p; kwargs...)` has long accepted the two-parameter form so callers can lock in a specialization level at the problem type. `DAEProblem` is documented the same way:

> `DAEProblem{isinplace,specialize}(f,du0,u0,tspan,p=NullParameters();kwargs...)`

but only `DAEProblem{iip}(...)` was actually defined. Calling `DAEProblem{true, FullSpecialize}(f, du0, u0, tspan)` currently throws:

```
MethodError: no method matching (SciMLBase.DAEProblem{true, SciMLBase.FullSpecialize})(::typeof(simple_dae!), ::Vector{Float64}, ::Vector{Float64}, ::Tuple{Float64, Float64})
The type `SciMLBase.DAEProblem{true, SciMLBase.FullSpecialize}` exists, but no method is defined for this combination of argument types when trying to construct it.
```

The motivating call site is a JET type-stability test in [OrdinaryDiffEq.jl PR #3512](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3512) (`lib/OrdinaryDiffEqNonlinearSolve/test/qa/jet.jl`) which pins `FullSpecialize` so JET doesn't flag the `cfunction` indirection inside the default `FunctionWrappersWrapper`.

## Fix

Add the missing constructor to `src/problems/dae_problems.jl`, wrapping `f` as `DAEFunction{iip, specialize}(f)` and forwarding to the existing `DAEProblem{iip}` constructor. `DAEFunction{iip, specialize}` already exists, so no new scimlfunction API is needed.

```julia
@add_kwonly function DAEProblem{iip, specialize}(
        f, du0, u0, tspan, p = NullParameters();
        kwargs...
    ) where {iip, specialize}
    return DAEProblem{iip}(
        DAEFunction{iip, specialize}(f), du0, u0, tspan, p; kwargs...
    )
end
```

Purely additive — no breaking changes. Version bumped to 3.4.1.

## Test plan

- [x] New `@testset "DAEProblem{iip, specialize} two-parameter constructor"` in `test/problem_building_test.jl` verifies construction, type of `prob.f`, `SciMLBase.specialization(prob.f) === FullSpecialize`, propagation of `p`/`differential_vars` kwargs, and that the wrapped `f` is still callable.
- [x] Full `Pkg.test()` passes locally on Julia 1.12.6 (Problem building tests: 34/34; Remake: 4414/4414; etc.).
- [x] MWE confirmed: `DAEProblem{true, FullSpecialize}(simple_dae!, du0, u0, (0.0, 1.0)).f isa DAEFunction{true, FullSpecialize}`.