### PR TITLE
Fix `ntuple(Val(-1))` in RODE calculate_solution_errors! for scalar noise

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.4.1"
+version = "3.4.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -218,17 +218,6 @@ function calculate_solution_errors!(
             end
         else
             for i in eachindex(sol.t)
-                # Use `sol.W.u[i]` rather than `sol.W[:, i]` to avoid routing
-                # through `RecursiveArrayTools.size(::AbstractVectorOfArray)` on
-                # the `AbstractDiffEqArray` path. For scalar-valued noise the
-                # noise container can have `N == 0` (e.g. `NoiseGrid` built from
-                # a `Vector{<:Number}`), which causes `size` to call
-                # `ntuple(Val(N - 1))` — i.e. `ntuple(Val(-1))` — and throw
-                # `ArgumentError: tuple length should be ≥ 0, got -1` from the
-                # RAT v4 `size` definition. Direct `.u[i]` access returns the
-                # saved noise value for time `sol.t[i]` for both scalar and
-                # vector-valued noise and is equivalent to `sol.W[:, i]` on the
-                # vector-valued branch where the prior code was safe.
                 push!(
                     sol.u_analytic,
                     f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W.u[i])

--- a/src/solutions/rode_solutions.jl
+++ b/src/solutions/rode_solutions.jl
@@ -218,9 +218,20 @@ function calculate_solution_errors!(
             end
         else
             for i in eachindex(sol.t)
+                # Use `sol.W.u[i]` rather than `sol.W[:, i]` to avoid routing
+                # through `RecursiveArrayTools.size(::AbstractVectorOfArray)` on
+                # the `AbstractDiffEqArray` path. For scalar-valued noise the
+                # noise container can have `N == 0` (e.g. `NoiseGrid` built from
+                # a `Vector{<:Number}`), which causes `size` to call
+                # `ntuple(Val(N - 1))` — i.e. `ntuple(Val(-1))` — and throw
+                # `ArgumentError: tuple length should be ≥ 0, got -1` from the
+                # RAT v4 `size` definition. Direct `.u[i]` access returns the
+                # saved noise value for time `sol.t[i]` for both scalar and
+                # vector-valued noise and is equivalent to `sol.W[:, i]` on the
+                # vector-valued branch where the prior code was safe.
                 push!(
                     sol.u_analytic,
-                    f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W[:, i])
+                    f.analytic(sol.prob.u0, sol.prob.p, sol.t[i], sol.W.u[i])
                 )
             end
         end

--- a/test/downstream/rode_calculate_solution_errors.jl
+++ b/test/downstream/rode_calculate_solution_errors.jl
@@ -23,7 +23,6 @@ using Test
 # The fix replaces `sol.W[:, i]` with `sol.W.u[i]`, which is equivalent on the
 # vector-valued branch and handles scalar-valued noise without consulting
 # `size`.
-
 # Scalar out-of-place SDE with analytic solution, matching SDEProblemLibrary's
 # `prob_sde_additive` shape.
 f_additive(u, p, t) = @. p[2] / sqrt(1 + t) - u / (2 * (1 + t))

--- a/test/downstream/rode_calculate_solution_errors.jl
+++ b/test/downstream/rode_calculate_solution_errors.jl
@@ -1,0 +1,82 @@
+using StochasticDiffEq, DiffEqNoiseProcess, SciMLBase
+using Random
+using Test
+
+# Regression tests for `SciMLBase.calculate_solution_errors!(::AbstractRODESolution)`.
+#
+# Two separate failure modes were reported on RAT v4:
+#
+# 1. SciMLBase#1321: `for i in 1:length(sol)` overran `sol.t` / `sol.W` because
+#    RAT v4 dropped the `length(::AbstractVectorOfArray)` specialization, so
+#    `length(sol)` became the total scalar count rather than the number of
+#    saved time points. Fixed by switching to `for i in eachindex(sol.t)`.
+#
+# 2. This test file: even with the loop bounded correctly, the indexing
+#    expression `sol.W[:, i]` routes through
+#    `RecursiveArrayTools._getindex(::AbstractDiffEqArray, ::NotSymbolic,
+#    ::Colon, ::Int)` which calls `size(::AbstractVectorOfArray)`, which on
+#    RAT v4 computes `ntuple(Val(N - 1))`. For a scalar-valued `NoiseGrid`
+#    built from a `Vector{<:Number}`, `N == 0` (because `ndims(W[1]) == 0`),
+#    producing `ntuple(Val(-1))` and throwing
+#    `ArgumentError: tuple length should be ≥ 0, got -1`.
+#
+# The fix replaces `sol.W[:, i]` with `sol.W.u[i]`, which is equivalent on the
+# vector-valued branch and handles scalar-valued noise without consulting
+# `size`.
+
+# Scalar out-of-place SDE with analytic solution, matching SDEProblemLibrary's
+# `prob_sde_additive` shape.
+f_additive(u, p, t) = @. p[2] / sqrt(1 + t) - u / (2 * (1 + t))
+σ_additive(u, p, t) = @. p[1] * p[2] / sqrt(1 + t)
+additive_analytic(u0, p, t, W) = @. u0 / sqrt(1 + t) + p[2] * (t + p[1] * W) / sqrt(1 + t)
+ff_additive = SDEFunction(f_additive, σ_additive, analytic = additive_analytic)
+p = (0.1, 0.05)
+
+@testset "Scalar RODESolution calculate_solution_errors! with NoiseGrid (N=0)" begin
+    # NoiseGrid built from a Vector{Float64} has N=0 — this is the path that
+    # used to hit `ntuple(Val(-1))`.
+    dt = 1.0e-2
+    n = round(Int, 1 / dt)
+    Random.seed!(12345)
+    Wvals = [0.0; cumsum(sqrt(dt) * randn(n + 1))]
+    Zvals = [0.0; cumsum(sqrt(dt) * randn(n + 1))]
+    ts = collect(0:dt:(1 + dt))
+
+    Wgrid = NoiseGrid(ts, Wvals, Zvals)
+    @test ndims(Wgrid) == 0  # scalar-valued NoiseGrid carries N=0
+
+    prob = SDEProblem(ff_additive, σ_additive, 1.0, (0.0, 1.0), p; noise = Wgrid)
+
+    # The bug used to fire inside `solve!`'s `calculate_solution_errors!`
+    # postamble when an analytic solution is present.
+    sol = solve(prob, SRA(), dt = dt, adaptive = false)
+    @test SciMLBase.successful_retcode(sol)
+    @test haskey(sol.errors, :final)
+    @test haskey(sol.errors, :l∞)
+    @test haskey(sol.errors, :l2)
+    @test isfinite(sol.errors[:final])
+    @test isfinite(sol.errors[:l∞])
+    @test isfinite(sol.errors[:l2])
+
+    # Explicitly exercise calculate_solution_errors! on the already-built
+    # solution to lock down the regression.
+    empty!(sol.errors)
+    SciMLBase.calculate_solution_errors!(sol; timeseries_errors = true, dense_errors = true)
+    @test isfinite(sol.errors[:final])
+    @test isfinite(sol.errors[:l∞])
+    @test isfinite(sol.errors[:l2])
+    @test isfinite(sol.errors[:L∞])
+    @test isfinite(sol.errors[:L2])
+end
+
+@testset "Scalar RODESolution calculate_solution_errors! with default NoiseProcess (N=1)" begin
+    # The default WienerProcess-based path lands in the same `else` branch
+    # of calculate_solution_errors! but with N=1. Ensure the fix doesn't
+    # regress it.
+    prob = SDEProblem(ff_additive, σ_additive, 1.0, (0.0, 1.0), p)
+    sol = solve(prob, SRA(), dt = 0.01, adaptive = false)
+    @test SciMLBase.successful_retcode(sol)
+    @test isfinite(sol.errors[:final])
+    @test isfinite(sol.errors[:l∞])
+    @test isfinite(sol.errors[:l2])
+end

--- a/test/downstream/rode_calculate_solution_errors.jl
+++ b/test/downstream/rode_calculate_solution_errors.jl
@@ -2,27 +2,6 @@ using StochasticDiffEq, DiffEqNoiseProcess, SciMLBase
 using Random
 using Test
 
-# Regression tests for `SciMLBase.calculate_solution_errors!(::AbstractRODESolution)`.
-#
-# Two separate failure modes were reported on RAT v4:
-#
-# 1. SciMLBase#1321: `for i in 1:length(sol)` overran `sol.t` / `sol.W` because
-#    RAT v4 dropped the `length(::AbstractVectorOfArray)` specialization, so
-#    `length(sol)` became the total scalar count rather than the number of
-#    saved time points. Fixed by switching to `for i in eachindex(sol.t)`.
-#
-# 2. This test file: even with the loop bounded correctly, the indexing
-#    expression `sol.W[:, i]` routes through
-#    `RecursiveArrayTools._getindex(::AbstractDiffEqArray, ::NotSymbolic,
-#    ::Colon, ::Int)` which calls `size(::AbstractVectorOfArray)`, which on
-#    RAT v4 computes `ntuple(Val(N - 1))`. For a scalar-valued `NoiseGrid`
-#    built from a `Vector{<:Number}`, `N == 0` (because `ndims(W[1]) == 0`),
-#    producing `ntuple(Val(-1))` and throwing
-#    `ArgumentError: tuple length should be ≥ 0, got -1`.
-#
-# The fix replaces `sol.W[:, i]` with `sol.W.u[i]`, which is equivalent on the
-# vector-valued branch and handles scalar-valued noise without consulting
-# `size`.
 # Scalar out-of-place SDE with analytic solution, matching SDEProblemLibrary's
 # `prob_sde_additive` shape.
 f_additive(u, p, t) = @. p[2] / sqrt(1 + t) - u / (2 * (1 + t))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,9 @@ end
         @time @safetestset "SplitODEProblem cache" begin
             include("downstream/splitodeproblem_cache.jl")
         end
+        @time @safetestset "Scalar RODESolution calculate_solution_errors!" begin
+            include("downstream/rode_calculate_solution_errors.jl")
+        end
     end
 
     if !is_APPVEYOR && GROUP == "SymbolicIndexingInterface"


### PR DESCRIPTION
## Summary

Fix `ArgumentError: tuple length should be ≥ 0, got -1` thrown from
`SciMLBase.calculate_solution_errors!(::AbstractRODESolution)` on
scalar-valued `RODESolution`s whose noise container is carried as an
`AbstractDiffEqArray{T, N, Vector{T2}}` (e.g. `NoiseProcess`, `NoiseGrid`).

## Reproducer

```julia
using StochasticDiffEq, DiffEqNoiseProcess, Random
using SDEProblemLibrary: prob_sde_additive

dt = 1e-6
n = round(Int, 1 / dt)
Random.seed!(62356236796)
Wvals = [0.0; cumsum(sqrt(dt) * randn(n + 1))]
Zvals = [0.0; cumsum(sqrt(dt) * randn(n + 1))]
ts    = collect(0:dt:(1 + dt))
W     = NoiseGrid(ts, Wvals, Zvals)     # scalar NoiseGrid -> N == 0

prob = remake(prob_sde_additive, noise = W)   # u0 = 1.0, has analytic
solve(prob, SRA(); dt = dt, adaptive = false)
# ArgumentError: tuple length should be ≥ 0, got -1
#   [1] ntuple ntuple.jl:71
#   [3] size RecursiveArrayTools vector_of_array.jl:879
#   [4] _getindex vector_of_array.jl:611
#   [5] getindex vector_of_array.jl:806
#   [6] calculate_solution_errors! rode_solutions.jl:221
```

## Root cause

The pre-fix `else` branch of `calculate_solution_errors!` did
`sol.W[:, i]`, which under RAT v4 dispatches to
`RecursiveArrayTools._getindex(::AbstractDiffEqArray{T, N}, ::NotSymbolic,
::Colon, ::Int)`. That method calls `size(sol.W)`, which in RAT v4 is

```julia
@inline function Base.size(VA::AbstractVectorOfArray{T, N}) where {T, N}
    isempty(VA.u) && return ntuple(_ -> 0, Val(N))
    leading = ntuple(Val(N - 1)) do d
        maximum(size(u, d) for u in VA.u)
    end
    return (leading..., length(VA.u))
end
```

For a scalar-valued `NoiseGrid` built from a `Vector{<:Number}`,
`ndims(W[1]) == 0` so `N == 0`, and `ntuple(Val(N - 1))` becomes
`ntuple(Val(-1))` → `ArgumentError` from `ntuple.jl:73`. The crash fires
inside `solve!`'s `calculate_solution_errors!` postamble on every scalar
`SDEProblem` / `RODEProblem` with an analytic solution and a scalar
`NoiseGrid`.

This surfaces in `StochasticDiffEq.jl`'s
`test/reversal_tests.jl` — the forward/reverse sweeps exercise
`SRA/SRA1/SRA2/SRA3/SOSRA/SOSRA2/SKenCarp` over
`SDEProblemLibrary.prob_sde_additive` (u0 = 1.0) with a scalar
`NoiseGrid(ts, W::Vector{Float64}, Z::Vector{Float64})`. It was first
exposed on the `StochasticDiffEq_Interface{1,2,3}` CI matrix of
`SciML/OrdinaryDiffEq.jl#3519` once SciMLBase 3.4.x + RAT 4.2.0 resolved
there, because that PR's `StochasticDiffEqImplicit` change propagated the
`StochasticDiffEq` sublib matrix.

## Why this is separate from #1321

SciMLBase #1321 (merged as 3.3.1) fixed a different RAT-v4 regression in
the same function: `for i in 1:length(sol)` overran `sol.t` / `sol.W`
because RAT v4 dropped the `length(::AbstractVectorOfArray)` specialization
and `length(sol)` became the total scalar count, not the number of saved
time points. Symptom: `BoundsError: attempt to access 101-element
Vector{Float64} at index [102]` on multi-d RODE states. Fix: switch to
`for i in eachindex(sol.t)`.

This PR's symptom is different: the loop bound is correct, but the
indexing expression `sol.W[:, i]` consults `size(sol.W)` on a VoA with
`N == 0` and throws `ArgumentError`/`ntuple(Val(-1))` before any loop
bound matters. It only surfaces on **scalar** RODE states with
`NoiseProcess`/`NoiseGrid` storage, which #1321 did not touch.

## Fix

Replace `sol.W[:, i]` with `sol.W.u[i]` in
`calculate_solution_errors!`. On the vector-valued branch
`sol.W[:, i]` already resolves to `A.u[i]` (the whole inner array at time
index `i`), so `.u[i]` is equivalent and avoids the `size` call entirely.
For scalar-valued noise `.u[i]` returns the saved scalar at `sol.t[i]`
directly, which is exactly what `f.analytic(u0, p, t, W)` expects on
scalar SDE/RODE problems.

Version bump: 3.4.1 → 3.4.2 (patch; bugfix only).

## Test plan

- [x] New regression test in
      `test/downstream/rode_calculate_solution_errors.jl` reproduces the
      crash with a scalar `NoiseGrid` + `prob_sde_additive`-shaped
      `SDEProblem` + `SRA()`, and locks in both the implicit solve-time
      path and a direct `calculate_solution_errors!` call. Also verifies
      the default `NoiseProcess` (N=1) path still works.
- [x] MWE passes locally on Julia 1.12.6 with the fix; crashes without it.
- [ ] CI confirms `StochasticDiffEq_Interface{1,2,3}` groups on the
      OrdinaryDiffEq.jl monorepo.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>