### PR TITLE
Fix ensemble analysis/error-calc regressions for RecursiveArrayTools v4

### DIFF
--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -9,14 +9,18 @@ $(SIGNATURES)
 
 Returns an iterator of each simulation at time step i
 """
-get_timestep(sim, i) = (sol.u[i] for sol in sim)
+# Under RecursiveArrayTools v4, iterating an `AbstractVectorOfArray`
+# (and thus an `EnsembleSolution`) yields scalar column-major elements rather
+# than the per-trajectory solutions. Iterate `sim.u` explicitly so these
+# helpers continue to walk over each trajectory's solution object.
+get_timestep(sim, i) = (sol.u[i] for sol in sim.u)
 
 """
 $(SIGNATURES)
 
 Returns an iterator of each simulation at time point t
 """
-get_timepoint(sim, t) = (sol(t) for sol in sim)
+get_timepoint(sim, t) = (sol(t) for sol in sim.u)
 
 """
 $(SIGNATURES)
@@ -131,7 +135,7 @@ $(SIGNATURES)
 Computes the mean at each time step
 """
 function timeseries_steps_mean(sim)
-    return DiffEqArray([timestep_mean(sim, i) for i in 1:length(sim.u[1])], sim.u[1].t)
+    return DiffEqArray([timestep_mean(sim, i) for i in 1:length(sim.u[1].t)], sim.u[1].t)
 end
 
 """
@@ -140,7 +144,7 @@ $(SIGNATURES)
 Computes the median at each time step
 """
 function timeseries_steps_median(sim)
-    return DiffEqArray([timestep_median(sim, i) for i in 1:length(sim.u[1])], sim.u[1].t)
+    return DiffEqArray([timestep_median(sim, i) for i in 1:length(sim.u[1].t)], sim.u[1].t)
 end
 
 """
@@ -149,7 +153,7 @@ $(SIGNATURES)
 Computes the quantile q at each time step
 """
 function timeseries_steps_quantile(sim, q)
-    return DiffEqArray([timestep_quantile(sim, q, i) for i in 1:length(sim.u[1])], sim.u[1].t)
+    return DiffEqArray([timestep_quantile(sim, q, i) for i in 1:length(sim.u[1].t)], sim.u[1].t)
 end
 
 """
@@ -161,7 +165,7 @@ function timeseries_steps_meanvar(sim)
     m, v = timestep_meanvar(sim, 1)
     means = [m]
     vars = [v]
-    for i in 2:length(sim.u[1])
+    for i in 2:length(sim.u[1].t)
         m, v = timestep_meanvar(sim, i)
         push!(means, m)
         push!(vars, v)
@@ -177,11 +181,11 @@ Computes the covariance matrix and means at each time step
 function timeseries_steps_meancov(sim)
     return reshape(
         [
-            timestep_meancov(sim, i, j) for i in 1:length(sim.u[1])
-                for j in 1:length(sim.u[1])
+            timestep_meancov(sim, i, j) for i in 1:length(sim.u[1].t)
+                for j in 1:length(sim.u[1].t)
         ],
-        length(sim.u[1]),
-        length(sim.u[1])
+        length(sim.u[1].t),
+        length(sim.u[1].t)
     )
 end
 
@@ -193,11 +197,11 @@ Computes the correlation matrix and means at each time step
 function timeseries_steps_meancor(sim)
     return reshape(
         [
-            timestep_meancor(sim, i, j) for i in 1:length(sim.u[1])
-                for j in 1:length(sim.u[1])
+            timestep_meancor(sim, i, j) for i in 1:length(sim.u[1].t)
+                for j in 1:length(sim.u[1].t)
         ],
-        length(sim.u[1]),
-        length(sim.u[1])
+        length(sim.u[1].t),
+        length(sim.u[1].t)
     )
 end
 
@@ -209,11 +213,11 @@ Computes the weighted covariance matrix and means at each time step
 function timeseries_steps_weighted_meancov(sim, W)
     return reshape(
         [
-            timestep_meancov(sim, W, i, j) for i in 1:length(sim.u[1])
-                for j in 1:length(sim.u[1])
+            timestep_meancov(sim, W, i, j) for i in 1:length(sim.u[1].t)
+                for j in 1:length(sim.u[1].t)
         ],
-        length(sim.u[1]),
-        length(sim.u[1])
+        length(sim.u[1].t),
+        length(sim.u[1].t)
     )
 end
 
@@ -290,7 +294,7 @@ function SciMLBase.EnsembleSummary(
         sim::SciMLBase.AbstractEnsembleSolution{T, N},
         t = sim.u[1].t; quantiles = [0.05, 0.95]
     ) where {T, N}
-    if sim.u[1] isa SciMLSolution
+    if sim.u[1] isa SciMLBase.AbstractSciMLSolution
         m, v = timeseries_point_meanvar(sim, t)
         med = timeseries_point_median(sim, t)
         qlow = timeseries_point_quantile(sim, quantiles[1], t)
@@ -302,7 +306,7 @@ function SciMLBase.EnsembleSummary(
         qhigh = timeseries_steps_quantile(sim, quantiles[2])
     end
 
-    trajectories = length(sim)
+    trajectories = length(sim.u)
     return EnsembleSummary{
         T, N, typeof(t), typeof(m), typeof(v), typeof(med), typeof(qlow),
         typeof(qhigh),

--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -9,10 +9,6 @@ $(SIGNATURES)
 
 Returns an iterator of each simulation at time step i
 """
-# Under RecursiveArrayTools v4, iterating an `AbstractVectorOfArray`
-# (and thus an `EnsembleSolution`) yields scalar column-major elements rather
-# than the per-trajectory solutions. Iterate `sim.u` explicitly so these
-# helpers continue to walk over each trajectory's solution object.
 get_timestep(sim, i) = (sol.u[i] for sol in sim.u)
 
 """

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -162,9 +162,6 @@ function calculate_ensemble_errors(
     res = norm(m_final - m_final_analytic)
     weak_errors[:weak_final] = res
     if weak_timeseries_errors
-        # Under RecursiveArrayTools v4, `length(sol)` for an `AbstractVectorOfArray`
-        # returns `prod(size(sol))` (total scalar count), not the number of
-        # timesteps. Use `length(sol.u)` to iterate over timesteps.
         if analyticvoa
             ts_weak_errors = [
                 mean([u[j].u[i] - u[j].u_analytic.u[i] for j in 1:length(u)])

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -162,15 +162,18 @@ function calculate_ensemble_errors(
     res = norm(m_final - m_final_analytic)
     weak_errors[:weak_final] = res
     if weak_timeseries_errors
+        # Under RecursiveArrayTools v4, `length(sol)` for an `AbstractVectorOfArray`
+        # returns `prod(size(sol))` (total scalar count), not the number of
+        # timesteps. Use `length(sol.u)` to iterate over timesteps.
         if analyticvoa
             ts_weak_errors = [
                 mean([u[j].u[i] - u[j].u_analytic.u[i] for j in 1:length(u)])
-                    for i in 1:length(u[1])
+                    for i in 1:length(u[1].u)
             ]
         else
             ts_weak_errors = [
                 mean([u[j].u[i] - u[j].u_analytic[i] for j in 1:length(u)])
-                    for i in 1:length(u[1])
+                    for i in 1:length(u[1].u)
             ]
         end
         ts_l2_errors = [sqrt.(sum(abs2, err) / length(err)) for err in ts_weak_errors]


### PR DESCRIPTION
## Summary

Under RecursiveArrayTools v4, `AbstractVectorOfArray <: AbstractArray`, so `length(sol)` returns `prod(size(sol))` (total scalar count) rather than the number of timesteps, and iterating a solution yields scalar column-major elements instead of per-timestep / per-trajectory values.

Several `SciMLBase` ensemble helpers still assumed the v3 semantics, producing `BoundsError`s or iterating scalars:

- `calculate_ensemble_errors` (weak timeseries branch): `for i in 1:length(u[1])` now uses `length(u[1].u)` so it iterates over timesteps, not `prod(size)`. This is the direct cause of the `BoundsError: attempt to access 9-element Vector{Matrix{Float64}} at index [10]` observed in OrdinaryDiffEq.jl CI run 24859020070.
- `get_timestep` / `get_timepoint`: iterate `sim.u` rather than `sim` so each `sol` is a trajectory solution rather than a scalar from the flattened ensemble.
- `timeseries_steps_*` helpers (`_mean`, `_median`, `_quantile`, `_meanvar`, `_meancov`, `_meancor`, `_weighted_meancov`): replace `length(sim.u[1])` with `length(sim.u[1].t)` (number of timesteps) in range construction and reshape dimensions.
- `EnsembleSummary`: `length(sim)` -> `length(sim.u)` for trajectory count; replace undefined deprecated alias `SciMLSolution` (removed in v3 commit 2020d08c7) with `SciMLBase.AbstractSciMLSolution`.

The corresponding `lib/DiffEqBase/test/downstream/ensemble.jl` and `ensemble_analysis.jl` tests in SciML/OrdinaryDiffEq.jl exercise these code paths and fail without this fix. They pass locally with these changes applied.

A companion PR on OrdinaryDiffEq.jl migrates the indexing in those test files themselves (`sim[i, j]`, `length(sim)`, etc.) for the same RAT v4 semantics change.

## Test plan

- [x] Local run of `lib/DiffEqBase/test/downstream/ensemble.jl` and `ensemble_analysis.jl` passes end-to-end
- [ ] SciMLBase CI

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>