### PR TITLE
Fix integer time-step indexing under AD (#1325)

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -58,6 +58,19 @@ function ChainRulesCore.rrule(
     return VA[sym, j], ODESolution_getindex_pullback
 end
 
+# `sol[i::Integer]` returns the state vector at time step `i`, not a
+# state-variable slice. A dedicated rrule prevents the broader
+# `getindex(VA::ODESolution, sym)` rule below from mis-treating `i` as a
+# state index (#1325). Dispatch picks this more-specific method for
+# integer arguments.
+function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, i::Integer)
+    function ODESolution_time_step_pullback(Δ)
+        Δ′ = [k == i ? Δ : zero(x) for (x, k) in zip(VA.u, 1:length(VA))]
+        return (NoTangent(), Δ′, NoTangent())
+    end
+    return VA.u[i], ODESolution_time_step_pullback
+end
+
 function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, sym)
     function ODESolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -275,6 +275,11 @@ end
 @is_primitive MinimalCtx Tuple{
     typeof(getindex), AbstractTimeseriesSolution, AbstractVector,
 }
+# `sol[i::Integer]` returns the state vector at time step `i` (a different
+# operation from `sol[sym]`). A dedicated, more-specific primitive routes
+# integer time-step indexing to the correct scatter so the generic symbolic
+# rrule above does not mis-treat `i` as a state-variable index (#1325).
+@is_primitive MinimalCtx Tuple{typeof(getindex), AbstractTimeseriesSolution, Integer}
 
 # Differentiate the observed function `getter(sym, u, p, t)` once with
 # Mooncake. The pullback `pb(dy)` mutates the fdata captured in the input
@@ -394,6 +399,30 @@ function rrule!!(
     end
 
     return CoDual(y, y_fdata), _scatter_pullback
+end
+
+# Integer time-step indexing: `sol[i::Integer]` returns the state vector at
+# time step `i`. The output cotangent is accumulated into `sol_fdata.u[i]`
+# in-place. More specific than the `sym::CoDual` rrule above, so Julia
+# dispatches here for integer arguments (#1325).
+function rrule!!(
+        ::CoDual{typeof(getindex)},
+        sol::CoDual{<:AbstractTimeseriesSolution},
+        i::CoDual{<:Integer},
+    )
+    VA = sol.x
+    ip = i.x
+    y = VA[ip]
+    y_fdata = zero(y)
+    sol_fdata = sol.dx
+
+    function _time_step_pullback(::NoRData)
+        u_dest = sol_fdata.data.u[ip]
+        @. u_dest += y_fdata
+        return (NoRData(), NoRData(), NoRData())
+    end
+
+    return CoDual(y, y_fdata), _time_step_pullback
 end
 
 # Vector of symbols: `sol[[sym1, sym2, ...]]` returns a `Vector{Vector{T}}`

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -52,6 +52,22 @@ end
     out, EnsembleSolution_adjoint
 end
 
+# `sol[i::Integer]` returns the state vector at time step `i`, not a
+# state-variable slice. A dedicated adjoint prevents the broader
+# `Base.getindex(VA::ODESolution, sym)` method below from mis-treating `i`
+# as a state index (#1325). Dispatch prefers this more-specific method for
+# integer arguments.
+@adjoint function Base.getindex(VA::ODESolution, i::Integer)
+    function ODESolution_time_step_pullback(Δ)
+        Δ′ = [
+            k == i ? Δ : Zygote.FillArrays.Fill(zero(eltype(x)), size(x))
+                for (x, k) in zip(VA.u, 1:length(VA))
+        ]
+        return (Δ′, nothing)
+    end
+    return VA.u[i], ODESolution_time_step_pullback
+end
+
 @adjoint function Base.getindex(VA::ODESolution, sym)
     function ODESolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym

--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -295,3 +295,42 @@ end
         end
     end
 end
+
+@testset "Integer time-step indexing under AD (issue #1325)" begin
+    function lotka_volterra!(du, u, p, t)
+        x, y = u
+        du[1] = (p[1] - p[2] * y) * x
+        du[2] = (p[4] * x - p[3]) * y
+    end
+
+    lv_prob = ODEProblem(
+        lotka_volterra!, [1.0, 1.0], (0.0, 10.0), [1.5, 1.0, 3.0, 1.0]
+    )
+
+    function lv_logp(θ)
+        predicted = solve(
+            lv_prob, Tsit5(); p = θ, saveat = 0.1, abstol = 1.0e-6, reltol = 1.0e-6
+        )
+        lp = 0.0
+        for i in eachindex(predicted)
+            lp += sum(predicted[i])
+        end
+        return lp
+    end
+
+    θ0 = [1.5, 1.0, 3.0, 1.0]
+    grad_fd = DifferentiationInterface.gradient(lv_logp, AutoForwardDiff(), θ0)
+
+    for backend in MOONCAKE_BACKENDS
+        @testset "$(backend_name(backend))" begin
+            grad = DifferentiationInterface.gradient(lv_logp, backend, θ0)
+            @test grad ≈ grad_fd rtol = 1.0e-4
+        end
+    end
+    for backend in ZYGOTE_BACKENDS
+        @testset "$(backend_name(backend))" begin
+            grad = DifferentiationInterface.gradient(lv_logp, backend, θ0)
+            @test grad ≈ grad_fd rtol = 1.0e-4
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- Restores correct behavior of `sol[i::Integer]` under reverse-mode AD. The broad `getindex` rrules in the Mooncake, Zygote, and ChainRulesCore extensions were catching integer time-step indexing and mis-treating the integer as a *state-variable* index, producing `BoundsError` on problems where `length(t) > length(u[1])` — the surface reported in #1325.
- Adds more-specific `::Integer` methods in each AD extension. Julia dispatch picks them over the broad symbolic rules for integer inputs; the symbolic path (`sol[sym]`) is unchanged.
- Adds a regression test mirroring the MWE in #1325 (Mooncake + Zygote gradients of a Lotka–Volterra `logp` that iterates `eachindex(sol)` and indexes `sol[i]`).

Issue: https://github.com/SciML/SciMLBase.jl/issues/1325

### Root cause

After the Mooncake ext was backported from the v3 line (v2.155.0, PR #1318), the scalar `rrule!!(::CoDual{typeof(getindex)}, ::CoDual{<:AbstractTimeseriesSolution}, ::CoDual)` unconditionally routed non-symbolic `sym` through `_scatter_symbol_timeseries!`, which treats the passed integer as a state-variable index. The same pattern was already latent in the ChainRulesCore extension (`rrule(::typeof(getindex), VA::ODESolution, sym)`). In v3, the Zygote `@adjoint Base.getindex(VA::ODESolution, i::Int)` that used to guard this case was removed along with the `iterate`/`tuples` overloads, so Zygote on master is also affected (the v2 backport PR only needs Mooncake/CRC fixes because that adjoint still exists there).

### Fix

Each AD extension now has a dedicated time-step rrule/adjoint for `::Integer`:

- `ext/SciMLBaseMooncakeExt.jl`: new `@is_primitive` + `rrule!!` for `(getindex, AbstractTimeseriesSolution, Integer)` that scatters `Δ` into `sol_fdata.data.u[i]` in-place.
- `ext/SciMLBaseZygoteExt.jl`: restores `@adjoint Base.getindex(VA::ODESolution, i::Integer)` (widened from the old `::Int`).
- `ext/SciMLBaseChainRulesCoreExt.jl`: new `rrule(::typeof(getindex), VA::ODESolution, i::Integer)`.

### Companion PR for v2 line

A narrower backport targeting `v2-backport` is opened separately: Mooncake + CRC only (v2-backport still carries the pre-v3 `::Int` Zygote adjoint, so no Zygote change needed there).

## Test plan

- [x] Reproduce the #1325 `BoundsError` on unpatched v2.155.0 (`BoundsError: attempt to access 2-element Vector{Float64} at index [101]`).
- [x] Verify the patched extension makes Mooncake and Zygote gradients of the MWE match ForwardDiff exactly on the v2-backport env.
- [x] `runic` format-check clean.
- [ ] Master-line downstream `observables_autodiff.jl` — blocked locally on the existing RecursiveArrayTools v4 ↔ OrdinaryDiffEq compat gap. The ext files are byte-identical between v2.155.0 and v3.4.3 for the Mooncake portion, and the Zygote adjoint is a restore of the pre-v3 method; manual verification via the v2 backport covers the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)