### PR TITLE
[v2-backport] Fix integer time-step indexing under AD (#1325)

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -58,6 +58,19 @@ function ChainRulesCore.rrule(
     return VA[sym, j], ODESolution_getindex_pullback
 end
 
+# `sol[i::Integer]` returns the state vector at time step `i`, not a
+# state-variable slice. A dedicated rrule prevents the broader
+# `getindex(VA::ODESolution, sym)` rule below from mis-treating `i` as a
+# state index (#1325). Dispatch picks this more-specific method for
+# integer arguments.
+function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, i::Integer)
+    function ODESolution_time_step_pullback(Δ)
+        Δ′ = [k == i ? Δ : zero(x) for (x, k) in zip(VA.u, 1:length(VA))]
+        return (NoTangent(), Δ′, NoTangent())
+    end
+    return VA.u[i], ODESolution_time_step_pullback
+end
+
 function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, sym)
     function ODESolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -275,6 +275,11 @@ end
 @is_primitive MinimalCtx Tuple{
     typeof(getindex), AbstractTimeseriesSolution, AbstractVector,
 }
+# `sol[i::Integer]` returns the state vector at time step `i` (a different
+# operation from `sol[sym]`). A dedicated, more-specific primitive routes
+# integer time-step indexing to the correct scatter so the generic symbolic
+# rrule above does not mis-treat `i` as a state-variable index (#1325).
+@is_primitive MinimalCtx Tuple{typeof(getindex), AbstractTimeseriesSolution, Integer}
 
 # Differentiate the observed function `getter(sym, u, p, t)` once with
 # Mooncake. The pullback `pb(dy)` mutates the fdata captured in the input
@@ -394,6 +399,30 @@ function rrule!!(
     end
 
     return CoDual(y, y_fdata), _scatter_pullback
+end
+
+# Integer time-step indexing: `sol[i::Integer]` returns the state vector at
+# time step `i`. The output cotangent is accumulated into `sol_fdata.u[i]`
+# in-place. More specific than the `sym::CoDual` rrule above, so Julia
+# dispatches here for integer arguments (#1325).
+function rrule!!(
+        ::CoDual{typeof(getindex)},
+        sol::CoDual{<:AbstractTimeseriesSolution},
+        i::CoDual{<:Integer},
+    )
+    VA = sol.x
+    ip = i.x
+    y = VA[ip]
+    y_fdata = zero(y)
+    sol_fdata = sol.dx
+
+    function _time_step_pullback(::NoRData)
+        u_dest = sol_fdata.data.u[ip]
+        @. u_dest += y_fdata
+        return (NoRData(), NoRData(), NoRData())
+    end
+
+    return CoDual(y, y_fdata), _time_step_pullback
 end
 
 # Vector of symbols: `sol[[sym1, sym2, ...]]` returns a `Vector{Vector{T}}`

--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -295,3 +295,42 @@ end
         end
     end
 end
+
+@testset "Integer time-step indexing under AD (issue #1325)" begin
+    function lotka_volterra!(du, u, p, t)
+        x, y = u
+        du[1] = (p[1] - p[2] * y) * x
+        du[2] = (p[4] * x - p[3]) * y
+    end
+
+    lv_prob = ODEProblem(
+        lotka_volterra!, [1.0, 1.0], (0.0, 10.0), [1.5, 1.0, 3.0, 1.0]
+    )
+
+    function lv_logp(θ)
+        predicted = solve(
+            lv_prob, Tsit5(); p = θ, saveat = 0.1, abstol = 1.0e-6, reltol = 1.0e-6
+        )
+        lp = 0.0
+        for i in eachindex(predicted)
+            lp += sum(predicted[i])
+        end
+        return lp
+    end
+
+    θ0 = [1.5, 1.0, 3.0, 1.0]
+    grad_fd = DifferentiationInterface.gradient(lv_logp, AutoForwardDiff(), θ0)
+
+    for backend in MOONCAKE_BACKENDS
+        @testset "$(backend_name(backend))" begin
+            grad = DifferentiationInterface.gradient(lv_logp, backend, θ0)
+            @test grad ≈ grad_fd rtol = 1.0e-4
+        end
+    end
+    for backend in ZYGOTE_BACKENDS
+        @testset "$(backend_name(backend))" begin
+            grad = DifferentiationInterface.gradient(lv_logp, backend, θ0)
+            @test grad ≈ grad_fd rtol = 1.0e-4
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- v2-backport counterpart of #1327 (master). Fixes the `BoundsError` under Mooncake when iterating `eachindex(sol)` and indexing `sol[i]`, reported against v2.155.0 in #1325.
- Only Mooncake and ChainRulesCore extensions need changes on this branch — the Zygote `@adjoint Base.getindex(VA::ODESolution, i::Int)` that was removed on v3 is still present here and already handles the time-step case correctly.
- Regression test mirrors the issue MWE.

Issue: https://github.com/SciML/SciMLBase.jl/issues/1325
Companion: #1327

## Verification

- [x] Reproduced `BoundsError: attempt to access 2-element Vector{Float64} at index [101]` on unpatched v2.155.0 (exact MWE from #1325).
- [x] After patch, Mooncake gradient matches ForwardDiff exactly: `[8.304244028181515, -159.48401961551903, 75.20316229897975, -339.1951631373029]`.
- [x] Zygote also passes (no Zygote changes on this branch; verifies no regression via CRC path).
- [x] `runic` format-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)