### PR TITLE
Export OptimizationSolution and other concrete solution types

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -997,10 +997,12 @@ export isinplace
 
 export solve, solve!, init, discretize, symbolic_discretize
 
-export LinearProblem, IntervalNonlinearProblem,
-    IntegralProblem, SampledIntegralProblem, OptimizationProblem
+export LinearProblem, LinearSolution, IntervalNonlinearProblem,
+    IntegralProblem, IntegralSolution, SampledIntegralProblem,
+    OptimizationProblem, OptimizationSolution
 
-export NonlinearProblem, SCCNonlinearProblem, NonlinearLeastSquaresProblem
+export NonlinearProblem, NonlinearSolution,
+    SCCNonlinearProblem, NonlinearLeastSquaresProblem
 
 export DiscreteProblem, ImplicitDiscreteProblem
 export SteadyStateProblem, SteadyStateSolution
@@ -1017,7 +1019,7 @@ export DDEProblem
 export DynamicalDDEFunction, DynamicalDDEProblem,
     SecondOrderDDEProblem
 export SDDEProblem
-export PDEProblem
+export PDEProblem, PDETimeSeriesSolution, PDENoTimeSolution
 export IncrementingODEProblem
 
 export BVProblem, TwoPointBVProblem, SecondOrderBVProblem, TwoPointSecondOrderBVProblem


### PR DESCRIPTION
## Summary

Closes #1329.

Exports the concrete solution types listed in the issue so users can use them without the `SciMLBase.` qualifier, mirroring sibling types like `ODESolution`, `DAESolution`, `RODESolution`, etc. that were already exported:

- `OptimizationSolution`
- `LinearSolution`
- `IntegralSolution`
- `NonlinearSolution` (previously only reachable via its `SteadyStateSolution` alias)
- `PDETimeSeriesSolution`
- `PDENoTimeSolution`

## Test plan

- [x] `GROUP=Core` tests pass locally
- [x] `GROUP=QA` (Aqua, including `test_undefined_exports`) passes locally
