### PR TITLE
Preserve concrete type of .original in solution_new_original_retcode

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -679,9 +679,22 @@ end
 function solution_new_original_retcode(
         sol::ODESolution{T, N}, original, retcode, resid
     ) where {T, N}
-    @reset sol.original = original
-    @reset sol.retcode = retcode
-    return @set sol.resid = resid
+    # Reconstruct the ODESolution directly rather than going through the
+    # `@reset` / `ConstructionBase.setproperties` chain. The `@reset` form
+    # expands into three sequential `setproperties` calls, each of which
+    # threads through `merge(getproperties(sol), patch)` and back through
+    # `ODESolution{T, N}(...)`. That call graph exceeds Julia's inference
+    # limits for non-trivial callers (e.g. a `::NonlinearSolution` bare
+    # annotation on the caller), causing the rebuilt solution's type to
+    # widen all the way to `ODESolution` (bare UnionAll). A single direct
+    # inner-constructor call preserves the concrete type parameters that
+    # inference can derive from `sol` plus the new `original`/`resid`.
+    return ODESolution{T, N}(
+        sol.u, sol.u_analytic, sol.errors, sol.t, sol.k,
+        sol.discretes, sol.prob, sol.alg, sol.interp, sol.dense,
+        sol.tslocation, sol.stats, sol.alg_choice, retcode,
+        resid, original, sol.saved_subsystem,
+    )
 end
 
 function solution_slice(sol::ODESolution{T, N}, I) where {T, N}

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -72,3 +72,45 @@ end
     @test isfinite(LinearAlgebra.norm(sol))
     @test sol ≈ sol
 end
+
+@testset "solution_new_original_retcode type inference" begin
+    # Regression test: `solution_new_original_retcode` must not widen the
+    # returned ODESolution's type parameters through the Accessors / setproperties
+    # rebuild chain even when callers annotate the `original` argument as the
+    # bare `NonlinearSolution` UnionAll (see BoundaryValueDiffEqCore.__build_solution).
+    # See https://github.com/SciML/BoundaryValueDiffEq.jl/issues/479.
+    f = (u, p, t) -> -u
+    ode = ODEProblem(f, [1.0, 2.0], (0.0, 1.0))
+    odesol = SciMLBase.build_solution(
+        ode, :NoAlgorithm, collect(0.0:0.1:1.0),
+        [[exp(-t), 2exp(-t)] for t in 0.0:0.1:1.0],
+    )
+
+    # Build a NonlinearSolution whose 7th (O = original) type parameter is
+    # pinned to `Any` --- matches NonlinearSolveBase.build_solution_less_specialize.
+    u = [1.0, 2.0]
+    resid = [0.0, 0.0]
+    nlsol = SciMLBase.NonlinearSolution{
+        Float64, 1, typeof(u), typeof(resid), Nothing, Nothing,
+        Any, Nothing, Nothing, Nothing,
+    }(u, resid, nothing, nothing, SciMLBase.ReturnCode.Success, [0.1, 0.2],
+      nothing, nothing, nothing, nothing)
+
+    # Direct concrete call: must be fully inferrable.
+    @inferred SciMLBase.solution_new_original_retcode(
+        odesol, nlsol, SciMLBase.ReturnCode.Success, resid,
+    )
+
+    # Caller with bare `::NonlinearSolution` annotation (mimicking BVDE's
+    # __build_solution): the inferred return type must NOT collapse to the
+    # bare `ODESolution` UnionAll.
+    bvde_like(o, n::SciMLBase.NonlinearSolution) = SciMLBase.solution_new_original_retcode(
+        o, n, SciMLBase.ReturnCode.Success, n.resid,
+    )
+    rt_bare = Base.return_types(bvde_like, (typeof(odesol), SciMLBase.NonlinearSolution))[1]
+    @test rt_bare !== SciMLBase.ODESolution
+
+    # And when the concrete nlsol type is known at the call site, inference
+    # must produce a fully concrete ODESolution type.
+    @inferred bvde_like(odesol, nlsol)
+end


### PR DESCRIPTION
## Summary

`solution_new_original_retcode` (src/solutions/ode_solutions.jl:679) previously rebuilt the `ODESolution` through three sequential `@reset` / `@set` calls:

```julia
@reset sol.original = original
@reset sol.retcode = retcode
return @set sol.resid = resid
```

Each of those expands into `ConstructionBase.setproperties(sol, patch)`, which funnels through `merge(getproperties(sol), patch)` and re-enters `ODESolution{T, N}(...)`. The resulting call graph exceeds Julia's inference limits for non-trivial callers, causing inference to widen the rebuilt solution's return type all the way to the bare `ODESolution` UnionAll.

Replacing the `@reset` chain with a single direct inner-constructor call that swaps only the three fields being updated restores full inference.

## Root cause

File: `src/solutions/ode_solutions.jl:679` (function `solution_new_original_retcode`).

The Accessors lowering `@reset sol.original = x` -> `setproperties(sol, (; original = x))` hits `ConstructionBase.setproperties(::ODESolution, ::NamedTuple)` at line 136, which does `merge(getproperties(sol), patch)` followed by another `ODESolution{T, N}(...)` call. When three of these are chained, inference walks past its abstract-interpretation budget and the result widens.

The widening only manifests when the caller's argument types are not fully concrete to inference at the call site --- for example `BoundaryValueDiffEqCore.__build_solution(prob, odesol, nlsol::SciMLBase.NonlinearSolution)`, whose bare `::NonlinearSolution` annotation is what `@inferred solve(bvp, MIRK6(...); dt = 0.2)` feeds into. See [SciML/BoundaryValueDiffEq.jl#479](https://github.com/SciML/BoundaryValueDiffEq.jl/issues/479).

## Minimal reproducer (SciMLBase-only)

```julia
using SciMLBase
using SciMLBase: ODESolution, NonlinearSolution, ReturnCode, LinearInterpolation,
                 solution_new_original_retcode
using Test

# NonlinearSolution with O = Any (mimics NonlinearSolveBase.build_solution_less_specialize).
u = [1.0, 2.0]; resid = [0.0, 0.0]
nlsol = NonlinearSolution{
    Float64, 1, typeof(u), typeof(resid), Nothing, Nothing,
    Any, Nothing, Nothing, Nothing,
}(u, resid, nothing, nothing, ReturnCode.Success, [0.1, 0.2],
  nothing, nothing, nothing, nothing)

# Minimal ODESolution with original = nothing.
t = [0.0, 1.0]; ut = [[0.0], [1.0]]
odesol = ODESolution{Float64, 2}(
    ut, nothing, nothing, t, nothing, nothing, nothing, nothing,
    LinearInterpolation(t, ut), false, 0, nothing, nothing,
    ReturnCode.Default, nothing, nothing, nothing,
)

# Mimic BoundaryValueDiffEqCore.__build_solution's bare annotation.
bvde_like(o, n::NonlinearSolution) =
    solution_new_original_retcode(o, n, ReturnCode.Success, n.resid)

Base.return_types(bvde_like, (typeof(odesol), NonlinearSolution))[1]
```

**Before (on master):** `ODESolution` (bare UnionAll --- full widening).

**After (this PR):**
```
ODESolution{Float64, 2, Vector{Vector{Float64}}, Nothing, Nothing, Vector{Float64},
 Nothing, Nothing, Nothing, Nothing,
 LinearInterpolation{Vector{Float64}, Vector{Vector{Float64}}},
 Nothing, Nothing, _A,
 NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr}, Nothing
} where {_A, T, N, uType, R, P, A, O, uType2, S, Tr}
```

And with a concrete `typeof(nlsol)` at the call site:
```
ODESolution{Float64, 2, Vector{Vector{Float64}}, ..., Vector{Float64},
            NonlinearSolution{Float64, 1, Vector{Float64}, Vector{Float64},
                              Nothing, Nothing, Any, Nothing, Nothing, Nothing},
            Nothing}
```
fully concrete --- `@inferred bvde_like(odesol, nlsol)` passes.

## Design choice: (b) narrow rebuild over (a) setproperties override

The task considered two fix shapes:
- (a) Override `ConstructionBase.setproperties(::ODESolution, ::NamedTuple)` to thread concrete types better.
- (b) Replace `solution_new_original_retcode` to bypass the Accessors / setproperties path entirely.

This PR takes (b). Rationale:
- This is the single hot-path rebuild where the widening actually bites (confirmed by the MWE above).
- (b) is a local change; (a) would touch every Accessors-based rebuild of `ODESolution` (slice, retcode-only, tslocation-only) and risks changing behavior for other callers.
- The existing `ConstructionBase.setproperties` method at line 136 is kept intact for other consumers.

## Downstream validation

The downstream BoundaryValueDiffEq.jl test environment currently cannot be resolved against SciMLBase master (RAT/OrdinaryDiffEqTsit5 register a SciMLBase v3 vs v4 incompatibility unrelated to this PR), so `@inferred solve(bvp, MIRK6(...); dt = 0.2)` could not be run against this branch directly from the BVDE worktree. The SciMLBase-only MWE above isolates the exact call shape that BVDE's `__build_solution` uses (bare `::NonlinearSolution` annotation) and demonstrates the widening + fix.

## Test plan

- [x] New regression test in `test/solution_interface.jl` (`@testset "solution_new_original_retcode type inference"`):
  - `@inferred solution_new_original_retcode(odesol, nlsol, ...)` for a concrete caller.
  - Asserts `Base.return_types(bvde_like, (typeof(odesol), NonlinearSolution))[1] !== ODESolution` (proves the non-widening under a bare annotation).
  - `@inferred bvde_like(odesol, nlsol)` for a concrete nlsol under a bare annotation.
  - Test fails on master, passes on this branch.
- [x] Full SciMLBase `Core` test group passes locally (Julia 1.11).