### PR TITLE
Drop deprecated StochasticDelayDiffEq references

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -48,7 +48,6 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: FMI}
           - {user: SciML, repo: ModelingToolkit.jl, group: Extensions}
           - {user: SciML, repo: ModelingToolkitStandardLibrary.jl, group: Core}
-          - {user: SciML, repo: StochasticDelayDiffEq.jl, group: All}
           - {user: SciML, repo: SimpleDiffEq.jl, group: All}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core1}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core2}

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -263,7 +263,7 @@ function compatible_problem_types(prob, alg)
         ODEProblem
     elseif alg isa AbstractSDEAlgorithm
         (SDEProblem, SDDEProblem)
-    elseif alg isa AbstractDDEAlgorithm # StochasticDelayDiffEq.jl just uses the SDE alg
+    elseif alg isa AbstractDDEAlgorithm
         DDEProblem
     elseif alg isa AbstractDAEAlgorithm
         DAEProblem


### PR DESCRIPTION
## Summary

`StochasticDelayDiffEq.jl` was deprecated in the OrdinaryDiffEq v7 / SciMLBase v3 ecosystem release. From the OrdinaryDiffEq.jl NEWS.md:

> **StochasticDelayDiffEq deprecated** — `StochasticDelayDiffEq.jl` is deprecated and will not receive a v7-compatible release. Users should migrate to `using DelayDiffEq` (plus `using StochasticDiffEq` where stochastic algorithms are needed).

Keeping it in the downstream CI matrix causes persistent failures since no compatible release is planned, and the inline code comment referencing it in `src/errors.jl` is now stale.

## Changes

### `.github/workflows/Downstream.yml`
**Before:**
```yaml
          - {user: SciML, repo: ModelingToolkitStandardLibrary.jl, group: Core}
          - {user: SciML, repo: StochasticDelayDiffEq.jl, group: All}
          - {user: SciML, repo: SimpleDiffEq.jl, group: All}
```
**After:**
```yaml
          - {user: SciML, repo: ModelingToolkitStandardLibrary.jl, group: Core}
          - {user: SciML, repo: SimpleDiffEq.jl, group: All}
```

### `src/errors.jl`
**Before:**
```julia
    elseif alg isa AbstractDDEAlgorithm # StochasticDelayDiffEq.jl just uses the SDE alg
```
**After:**
```julia
    elseif alg isa AbstractDDEAlgorithm
```

The comment was justifying why `SDDEProblem` is handled by `AbstractSDEAlgorithm` (line above) rather than `AbstractDDEAlgorithm`. With SDDE deprecated, the comment is misleading and no longer relevant.

## Migration path

Users of `StochasticDelayDiffEq.jl` should migrate to:
```julia
using DelayDiffEq
using StochasticDiffEq  # for stochastic algorithms
```

## Test plan

- [ ] CI passes without the `StochasticDelayDiffEq.jl` matrix entry
- [ ] No other downstream packages are affected (SDDE had no reverse-dependencies in the remaining matrix)
- [ ] `src/errors.jl` semantics are preserved — the `compatible_problem_types` function still correctly routes DDE algorithms to `DDEProblem`

🤖 Generated with [Claude Code](https://claude.com/claude-code)