### PR TITLE
Fix getindex(::ODESolution, ::Integer) rrules under RAT v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.7.0"
+version = "3.7.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -58,17 +58,32 @@ function ChainRulesCore.rrule(
     return VA[sym, j], ODESolution_getindex_pullback
 end
 
-# `sol[i::Integer]` returns the state vector at time step `i`, not a
-# state-variable slice. A dedicated rrule prevents the broader
-# `getindex(VA::ODESolution, sym)` rule below from mis-treating `i` as a
-# state index (#1325). Dispatch picks this more-specific method for
-# integer arguments.
+# `sol[i::Integer]`: under RecursiveArrayTools v4 `AbstractVectorOfArray`
+# subtypes `AbstractArray`, so linear integer indexing returns the i-th
+# scalar element in column-major order over the underlying state-by-time
+# layout, NOT the i-th timestep vector. A dedicated rrule is still
+# needed to keep dispatch from falling through to the broader
+# `getindex(VA::ODESolution, sym)` rule below (which would mis-interpret
+# `i` as a state-variable index; #1325). The pullback scatters the
+# scalar cotangent into the matching slot of `VA.u`.
 function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, i::Integer)
-    function ODESolution_time_step_pullback(Δ)
-        Δ′ = [k == i ? Δ : zero(x) for (x, k) in zip(VA.u, 1:length(VA))]
+    inds = Tuple(CartesianIndices(size(VA))[i])
+    front_inds = Base.front(inds)
+    step_idx = last(inds)
+    y = VA.u[step_idx][front_inds...]
+    function ODESolution_scalar_pullback(Δ)
+        Δ′ = map(enumerate(VA.u)) do (k, x)
+            if k == step_idx
+                δu = zero(x)
+                δu[front_inds...] = Δ
+                δu
+            else
+                zero(x)
+            end
+        end
         return (NoTangent(), Δ′, NoTangent())
     end
-    return VA.u[i], ODESolution_time_step_pullback
+    return y, ODESolution_scalar_pullback
 end
 
 function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, sym)

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -401,10 +401,13 @@ function rrule!!(
     return CoDual(y, y_fdata), _scatter_pullback
 end
 
-# Integer time-step indexing: `sol[i::Integer]` returns the state vector at
-# time step `i`. The output cotangent is accumulated into `sol_fdata.u[i]`
-# in-place. More specific than the `sym::CoDual` rrule above, so Julia
-# dispatches here for integer arguments (#1325).
+# Integer linear indexing: under RecursiveArrayTools v4
+# `AbstractVectorOfArray` subtypes `AbstractArray`, so `sol[i::Integer]`
+# returns the i-th scalar element in column-major order over the
+# state-by-time layout, NOT the i-th timestep vector. The forward returns
+# that scalar; the pullback accumulates the scalar cotangent into the
+# matching slot of `sol_fdata.data.u`. More specific than the `sym::CoDual`
+# rrule above, so Julia dispatches here for integer arguments (#1325).
 function rrule!!(
         ::CoDual{typeof(getindex)},
         sol::CoDual{<:AbstractTimeseriesSolution},
@@ -416,13 +419,17 @@ function rrule!!(
     y_fdata = zero(y)
     sol_fdata = sol.dx
 
-    function _time_step_pullback(::NoRData)
-        u_dest = sol_fdata.data.u[ip]
-        @. u_dest += y_fdata
+    inds = Tuple(CartesianIndices(size(VA))[ip])
+    front_inds = Base.front(inds)
+    step_idx = last(inds)
+
+    function _scalar_pullback(::NoRData)
+        u_dest = sol_fdata.data.u[step_idx]
+        u_dest[front_inds...] += y_fdata
         return (NoRData(), NoRData(), NoRData())
     end
 
-    return CoDual(y, y_fdata), _time_step_pullback
+    return CoDual(y, y_fdata), _scalar_pullback
 end
 
 # Vector of symbols: `sol[[sym1, sym2, ...]]` returns a `Vector{Vector{T}}`

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -52,20 +52,33 @@ end
     out, EnsembleSolution_adjoint
 end
 
-# `sol[i::Integer]` returns the state vector at time step `i`, not a
-# state-variable slice. A dedicated adjoint prevents the broader
-# `Base.getindex(VA::ODESolution, sym)` method below from mis-treating `i`
-# as a state index (#1325). Dispatch prefers this more-specific method for
-# integer arguments.
+# `sol[i::Integer]`: under RecursiveArrayTools v4 `AbstractVectorOfArray`
+# subtypes `AbstractArray`, so linear integer indexing returns the i-th
+# scalar element in column-major order over the underlying state-by-time
+# layout (i.e. `VA[CartesianIndices(size(VA))[i]]`), NOT the i-th timestep
+# vector. A dedicated adjoint is still needed here to keep dispatch from
+# falling through to the broader `Base.getindex(VA::ODESolution, sym)`
+# rule below (which would mis-interpret `i` as a state-variable index;
+# #1325). The pullback scatters the scalar cotangent into the matching
+# slot of `VA.u`.
 @adjoint function Base.getindex(VA::ODESolution, i::Integer)
-    function ODESolution_time_step_pullback(Δ)
-        Δ′ = [
-            k == i ? Δ : Zygote.FillArrays.Fill(zero(eltype(x)), size(x))
-                for (x, k) in zip(VA.u, 1:length(VA))
-        ]
+    inds = Tuple(CartesianIndices(size(VA))[i])
+    front_inds = Base.front(inds)
+    step_idx = last(inds)
+    y = VA.u[step_idx][front_inds...]
+    function ODESolution_scalar_pullback(Δ)
+        Δ′ = map(enumerate(VA.u)) do (k, x)
+            if k == step_idx
+                δu = zero(x)
+                δu[front_inds...] = Δ
+                δu
+            else
+                Zygote.FillArrays.Fill(zero(eltype(x)), size(x))
+            end
+        end
         return (Δ′, nothing)
     end
-    return VA.u[i], ODESolution_time_step_pullback
+    return y, ODESolution_scalar_pullback
 end
 
 @adjoint function Base.getindex(VA::ODESolution, sym)


### PR DESCRIPTION
## Summary

`AbstractVectorOfArray` (parent of `ODESolution`) became `<: AbstractArray` in RecursiveArrayTools v4, so `sol[i::Int]` now returns the i-th scalar element in column-major order over the state-by-time layout, not the i-th timestep vector.

The ChainRules / Zygote / Mooncake rrules for `getindex(::ODESolution, ::Integer)` were never updated. Their forward returned `VA.u[i]` (per-timestep vector — v3 semantics) and the pullback iterated `1:length(VA)` (under v4, `prod(size(VA))`, the total scalar count, not timestep count). Concretely:

- **Zygote** (`ext/SciMLBaseZygoteExt.jl:60–69`): forward result no longer matches `VA[i]`; gradients silently computed against a different function than the user wrote.
- **Mooncake** (`ext/SciMLBaseMooncakeExt.jl:408–426`): pullback indexed `sol_fdata.data.u[i]` for `i` past the number of timesteps and threw `BoundsError`. Surfaced in [OrdinaryDiffEq.jl PR #3576](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3576)'s `test (AD, 1.11)` autodiff_events / Zygote subtest.
- **ChainRules** (`ext/SciMLBaseChainRulesCoreExt.jl:66–72`): same divergence as Zygote.

## Fix

All three rrules now match v4 semantics:

- **Forward**: scalar element via `VA.u[step_idx][front_inds...]` where `(front_inds..., step_idx) = Tuple(CartesianIndices(size(VA))[i])`.
- **Pullback**: scatter the scalar cotangent into `Δ′[step_idx][front_inds...]` (allocate per-timestep zeros for all other slots; FillArrays for Zygote, `zero(x)` for ChainRules / Mooncake matching their existing conventions).

The dedicated Integer rrule is still needed — removing it would let the broader `getindex(::ODESolution, sym)` rule below misinterpret an `Int` as a state-variable index (#1325).

## Knock-on effect

Once this lands, the `u[end][end]` → `u.u[end][end]` workaround added in [OrdinaryDiffEq.jl PR #3576](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3576) for `test/ad/autodiff_events.jl::test_f2` becomes unnecessary. (Without this fix, that workaround is needed because the broken rrule produces a `BoundsError`; with this fix, `u[end][end]` errors synchronously when `u[end]` is a scalar — which is correct user-visible behavior under v4.)

## Test plan

- [ ] `test/downstream/observables_autodiff.jl::"Integer time-step indexing under AD (issue #1325)"` continues to pass on Mooncake / Zygote backends with `grad ≈ grad_fd`.
- [ ] `OrdinaryDiffEq.jl/test/ad/autodiff_events.jl` Zygote / Mooncake gradient testsets pass against this branch (with the `u[end][end]` workaround in place — proving the rrule is now correct — and after reverting that workaround — proving the rrule is sufficient).