### PR TITLE
test/python: load StochasticDiffEq + OrdinaryDiffEqDefault for v8 umbrella

### DIFF
--- a/test/python/Project.toml
+++ b/test/python/Project.toml
@@ -2,12 +2,16 @@
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqDefault = "50262376-6c5a-4cf5-baba-aaf4f84d72d7"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
 CondaPkg = "0.2.26"
 DifferentialEquations = "7.11, 8"
 OrdinaryDiffEq = "6.33, 7"
+OrdinaryDiffEqDefault = "1, 2"
 PythonCall = "0.9.14"
 SciMLBase = "2, 3"
+StochasticDiffEq = "6.83, 7"

--- a/test/python/pythoncall.jl
+++ b/test/python/pythoncall.jl
@@ -1,4 +1,10 @@
 using DifferentialEquations, PythonCall, CondaPkg
+# DifferentialEquations.jl v8 no longer pulls in StochasticDiffEq, so the
+# default SDE algorithm needs to be loaded explicitly for `solve(prob)` to
+# dispatch on `SDEProblem`. OrdinaryDiffEqDefault is also loaded explicitly
+# to make the ODE default algorithm registration robust to future slimming
+# of the umbrella package.
+using OrdinaryDiffEqDefault, StochasticDiffEq
 
 CondaPkg.add_pip("diffeqpy")
 


### PR DESCRIPTION
## Summary

The `1/lts/pre, Python` test job started failing on master after the test env picked up `DifferentialEquations` v8.0.0:

```
Use of DifferentialEquations through PythonCall with user code written in Python: Error During Test
  Got exception outside of a @test
  Python: Julia: Default algorithm choices require DifferentialEquations.jl.
  Please specify an algorithm (e.g., `solve(prob, Tsit5())` or
  `init(prob, Tsit5())` for an ODE) or import DifferentialEquations
  directly.
```

## Root cause

`DifferentialEquations.jl` v8 was slimmed down: the umbrella package no longer pulls in `StochasticDiffEq` (or `JumpProcesses`, `Sundials`, etc.). After the v7 → v8 transition, the SDE leg of `test/python/pythoncall.jl` (`prob = de.SDEProblem(f,g,u0,tspan); sol = de.solve(prob,...)`) hits `DiffEqBase`'s default-algorithm path with no SDE default registered, so it errors out. The ODE legs continued to pass because `OrdinaryDiffEqDefault` is still pulled in by the umbrella.

## Fix

- Add `StochasticDiffEq` (provides the SOSRI default for `SDEProblem` via `StochasticDiffEqCore`) and `OrdinaryDiffEqDefault` as explicit deps of the Python test env.
- `using OrdinaryDiffEqDefault, StochasticDiffEq` in `test/python/pythoncall.jl` so the default-algorithm machinery is registered regardless of what the umbrella package re-exports going forward.

No production code (`ext/SciMLBasePythonCallExt.jl`) is touched — the failure was purely in what the test env loads.

## Test plan

Local Julia 1.10 LTS run with the patched test env (matches the failing CI job):

```
$ julia +1.10 --project=test/python -e 'using Test; @testset verbose=true "PythonCall" begin include("test/python/pythoncall.jl") end'
...
Test Summary:                                                                      | Pass  Total   Time
PythonCall                                                                         |    5      5  51.6s
  Use of DifferentialEquations through PythonCall with user code written in Python |    4      4  37.0s
  promotion                                                                        |    1      1   0.3s
```

Resolved deps in the test env after the fix (`DifferentialEquations v8.0.0`, `StochasticDiffEq v7.0.0`, `OrdinaryDiffEqDefault v2.1.0`):

```
Status `/tmp/SciMLBase_python/test/python/Project.toml`
  [992eb4ea] CondaPkg v0.2.34
  [0c46a032] DifferentialEquations v8.0.0
  [1dea7af3] OrdinaryDiffEq v7.0.0
  [50262376] OrdinaryDiffEqDefault v2.1.0
  [6099a3de] PythonCall v0.9.31
  [0bca4576] SciMLBase v3.7.1
  [789caeaf] StochasticDiffEq v7.0.0
```

- [x] Reproduced the failure on master with the unpatched env (SDE leg errors with the message above; ODE legs pass).
- [x] Patched env + test, re-ran locally, all 5 PythonCall tests pass.
- [ ] CI `1/lts/pre, Python` job passes.