### PR TITLE
Fix VectorContinuousCallback kwarg ctor argument order

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -326,9 +326,8 @@ function VectorContinuousCallback(
         idxs,
         rootfind, interp_points,
         save_positions, dtrelax,
-        maybe_discontinuity,
         abstol, reltol, repeat_nudge, initializealg, saved_clock_partitions,
-        initialize_save_discretes
+        maybe_discontinuity, initialize_save_discretes
     )
 end
 

--- a/test/callback_constructors.jl
+++ b/test/callback_constructors.jl
@@ -1,0 +1,36 @@
+using SciMLBase
+using Test
+
+# Regression: the 4-arg `VectorContinuousCallback` keyword constructor used to
+# forward arguments to the inner positional constructor in the wrong order,
+# placing `maybe_discontinuity` in the slot expected for `abstol`.
+@testset "VectorContinuousCallback 4-arg kwarg constructor" begin
+    cond(out, u, t, integ) = (out[1] = u[1]; out[2] = u[2])
+    aff!(integ, idx) = nothing
+
+    cb = VectorContinuousCallback(cond, aff!, nothing, 2)
+    @test cb isa VectorContinuousCallback
+
+    cb_kw = VectorContinuousCallback(cond, aff!, nothing, 2;
+        save_positions = (true, false),
+        rootfind = SciMLBase.LeftRootFind,
+        abstol = 1e-9, reltol = 0.0,
+        saved_clock_partitions = (),
+        maybe_discontinuity = false,
+        initialize_save_discretes = false)
+    @test cb_kw.save_positions == BitVector([true, false])
+    @test cb_kw.abstol == 1e-9
+    @test cb_kw.maybe_discontinuity == false
+    @test cb_kw.initialize_save_discretes == false
+    @test cb_kw.saved_clock_partitions == ()
+end
+
+# Sanity check: the 3-arg form (which already had the right order) still works.
+@testset "VectorContinuousCallback 3-arg kwarg constructor" begin
+    cond(out, u, t, integ) = (out[1] = u[1])
+    aff!(integ, idx) = nothing
+
+    cb = VectorContinuousCallback(cond, aff!, 1; abstol = 1e-12)
+    @test cb.abstol == 1e-12
+    @test cb.maybe_discontinuity == true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,9 @@ end
         @time @safetestset "Clocks" begin
             include("clock.jl")
         end
+        @time @safetestset "Callback constructors" begin
+            include("callback_constructors.jl")
+        end
     end
 
     if !is_APPVEYOR &&


### PR DESCRIPTION
> ⚠️ **Draft / please ignore until reviewed by @ChrisRackauckas.**

## Summary

The 4-arg keyword constructor for `VectorContinuousCallback` (`callbacks.jl:309–333`) forwards `maybe_discontinuity` into the slot the inner positional constructor expects to be `abstol`. As a result the kwarg path lands on a method signature that does not exist:

```
MethodError: no method matching SciMLBase.VectorContinuousCallback(
    ::cond, ::affect!, ::Nothing, ::Int64,
    ::INITIALIZE_DEFAULT, ::FINALIZE_DEFAULT, ::Nothing, ::RootfindOpt,
    ::Int64, ::Tuple{Bool,Bool}, ::Int64, ::Bool, ::Float64, ::Int64,
    ::Rational{Int64}, ::Nothing, ::Tuple{}, ::Bool)
```

The 3-arg form already has the correct order; only the 4-arg form was wrong. The regression was introduced in `a0eb6d22781c4bd1ee4cc3487fbbafd0aec41743` when `is_discontinuity` (later renamed `maybe_discontinuity`) and `initialize_save_discretes` were merged in from two parallel branches and the merge resolution placed the new arg in the wrong slot. First released on master / SciMLBase v3.9.0.

## What this PR does

- Reorders the inner-ctor call so `maybe_discontinuity, initialize_save_discretes` come at the end after `saved_clock_partitions`, matching the positional ctor's signature (`callbacks.jl:281–306`) and the 3-arg form (`callbacks.jl:350–357`).
- Adds `test/callback_constructors.jl` with regression tests for both the 4-arg and 3-arg kwarg forms, wired into the Core group of `runtests.jl`.

## Reproduction (without this fix)

```julia
using SciMLBase
cond(out, u, t, integ) = (out[1] = u[1])
aff!(integ, idx) = nothing
VectorContinuousCallback(cond, aff!, nothing, 1; save_positions=(true, true))
# MethodError: no method matching ...
```

After this fix, the same call returns a `VectorContinuousCallback`.

## Downstream impact

Surfaced as a CI failure in OrdinaryDiffEq.jl PR #3604 — the `test/integrators/ode_event_tests.jl` "Issue #3222: chained velocity crossing in friction state machine" testset uses this constructor and breaks against SciMLBase v3.9.0. This patch should let an v3.9.1 release unblock that and any other downstream that constructs `VectorContinuousCallback` via the 4-arg kwarg form.

## Test plan

- [x] `Pkg.test()` on SciMLBase Core group passes locally on Julia 1.12 (including the new `Callback constructors` tests; 8/8 pass)
- [ ] CI green