### PR TITLE
fix(ad): EnsembleSolution cotangent shape + redundant remake reconstructions

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -217,24 +217,6 @@ function ChainRulesCore.rrule(
         ::Type{EnsembleSolution}, sim, time, converged, stats = nothing
     )
     out = EnsembleSolution(sim, time, converged, stats)
-    function EnsembleSolution_adjoint(p̄::AbstractArray{T, N}) where {T, N}
-        arrarr = [
-            [
-                    p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
-                    for j in 1:size(p̄)[end - 1]
-                ] for i in 1:size(p̄)[end]
-        ]
-        return (NoTangent(), arrarr, NoTangent(), NoTangent(), NoTangent())
-    end
-    function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1})
-        return (NoTangent(), p̄, NoTangent(), NoTangent(), NoTangent())
-    end
-    function EnsembleSolution_adjoint(p̄::AbstractVectorOfArray)
-        return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
-    end
-    function EnsembleSolution_adjoint(p̄::EnsembleSolution)
-        return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
-    end
     function EnsembleSolution_adjoint(p̄::NamedTuple)
         return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
     end

--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -1,11 +1,61 @@
 module SciMLBaseChainRulesCoreExt
 
 using SciMLBase
-using SciMLBase: getobserved
+using SciMLBase: getobserved, ODEProblem, _remake_ode_inner
 import ChainRulesCore
-import ChainRulesCore: NoTangent, @non_differentiable, zero_tangent, rrule_via_ad
+import ChainRulesCore: NoTangent, ZeroTangent, AbstractZero, Tangent,
+    @non_differentiable, zero_tangent, rrule_via_ad, backing
 using SymbolicIndexingInterface
 using RecursiveArrayTools: AbstractVectorOfArray
+
+@inline function _remake_ode_inner_split_cotangent(Δ, f, u0, tspan, p)
+    Δ_nt = if Δ isa Tangent
+        b = backing(Δ)
+        b isa NamedTuple ? b :
+            (b isa Tuple && length(b) == 1 && b[1] isa NamedTuple ? b[1] : NamedTuple())
+    elseif Δ isa NamedTuple
+        Δ
+    else
+        NamedTuple()
+    end
+    get_cot(field::Symbol) = (Δ_nt isa NamedTuple && haskey(Δ_nt, field)) ?
+        Δ_nt[field] : nothing
+    f_cot = (f === missing) ? NoTangent() : get_cot(:f)
+    u0_cot = (u0 === missing) ? NoTangent() : get_cot(:u0)
+    tspan_cot = (tspan === missing) ? NoTangent() : get_cot(:tspan)
+    p_cot = (p === missing) ? NoTangent() : get_cot(:p)
+    prob_cot = (
+        f = (f === missing) ? get_cot(:f) : nothing,
+        u0 = (u0 === missing) ? get_cot(:u0) : nothing,
+        tspan = (tspan === missing) ? get_cot(:tspan) : nothing,
+        p = (p === missing) ? get_cot(:p) : nothing,
+        kwargs = nothing,
+        problem_type = nothing,
+    )
+    return prob_cot, f_cot, u0_cot, tspan_cot, p_cot
+end
+
+function ChainRulesCore.rrule(
+        ::typeof(_remake_ode_inner),
+        prob::ODEProblem, f, u0, tspan, p, kwargs,
+        interpret_symbolicmap, build_initializeprob, use_defaults,
+        lazy_initialization, _kwargs
+    )
+    new_prob = _remake_ode_inner(
+        prob, f, u0, tspan, p, kwargs,
+        interpret_symbolicmap, build_initializeprob, use_defaults,
+        lazy_initialization, _kwargs
+    )
+    function _remake_ode_inner_pullback(Δ)
+        prob_cot, f_cot, u0_cot, tspan_cot, p_cot = _remake_ode_inner_split_cotangent(
+            Δ, f, u0, tspan, p
+        )
+        return (NoTangent(), prob_cot, f_cot, u0_cot, tspan_cot, p_cot,
+            NoTangent(), NoTangent(), NoTangent(), NoTangent(), NoTangent(),
+            NoTangent())
+    end
+    return new_prob, _remake_ode_inner_pullback
+end
 
 @non_differentiable SciMLBase.checkkwargs(kwargshandle)
 
@@ -163,8 +213,6 @@ function ChainRulesCore.rrule(
         RODESolutionAdjoint
 end
 
-# EnsembleSolution rrule with full support for various gradient types
-# Matches the Zygote extension implementation for consistency
 function ChainRulesCore.rrule(
         ::Type{EnsembleSolution}, sim, time, converged, stats = nothing
     )
@@ -176,37 +224,22 @@ function ChainRulesCore.rrule(
                     for j in 1:size(p̄)[end - 1]
                 ] for i in 1:size(p̄)[end]
         ]
-        return (
-            NoTangent(),
-            EnsembleSolution(arrarr, 0.0, true, stats),
-            NoTangent(),
-            NoTangent(),
-            NoTangent(),
-        )
+        return (NoTangent(), arrarr, NoTangent(), NoTangent(), NoTangent())
     end
     function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1})
-        return (
-            NoTangent(),
-            EnsembleSolution(p̄, 0.0, true, stats),
-            NoTangent(),
-            NoTangent(),
-            NoTangent(),
-        )
+        return (NoTangent(), p̄, NoTangent(), NoTangent(), NoTangent())
     end
     function EnsembleSolution_adjoint(p̄::AbstractVectorOfArray)
-        return (
-            NoTangent(),
-            EnsembleSolution(p̄, 0.0, true, stats),
-            NoTangent(),
-            NoTangent(),
-            NoTangent(),
-        )
+        return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
     end
     function EnsembleSolution_adjoint(p̄::EnsembleSolution)
-        return (NoTangent(), p̄, NoTangent(), NoTangent(), NoTangent())
+        return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
     end
     function EnsembleSolution_adjoint(p̄::NamedTuple)
         return (NoTangent(), p̄.u, NoTangent(), NoTangent(), NoTangent())
+    end
+    function EnsembleSolution_adjoint(p̄::Tangent)
+        return (NoTangent(), backing(p̄).u, NoTangent(), NoTangent(), NoTangent())
     end
     return out, EnsembleSolution_adjoint
 end

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -28,24 +28,6 @@ end
 
 @adjoint function EnsembleSolution(sim, time, converged, stats)
     out = EnsembleSolution(sim, time, converged, stats)
-    function EnsembleSolution_adjoint(p̄::AbstractArray{T, N}) where {T, N}
-        arrarr = [
-            [
-                    p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
-                    for j in 1:size(p̄)[end - 1]
-                ] for i in 1:size(p̄)[end]
-        ]
-        (arrarr, nothing, nothing, nothing)
-    end
-    function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1})
-        (p̄, nothing, nothing, nothing)
-    end
-    function EnsembleSolution_adjoint(p̄::RecursiveArrayTools.AbstractVectorOfArray)
-        (p̄.u, nothing, nothing, nothing)
-    end
-    function EnsembleSolution_adjoint(p̄::EnsembleSolution)
-        (p̄.u, nothing, nothing, nothing)
-    end
     function EnsembleSolution_adjoint(p̄::NamedTuple)
         (p̄.u, nothing, nothing, nothing)
     end

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -35,16 +35,16 @@ end
                     for j in 1:size(p̄)[end - 1]
                 ] for i in 1:size(p̄)[end]
         ]
-        (EnsembleSolution(arrarr, 0.0, true, stats), nothing, nothing, nothing)
+        (arrarr, nothing, nothing, nothing)
     end
     function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1})
-        (EnsembleSolution(p̄, 0.0, true, stats), nothing, nothing, nothing)
+        (p̄, nothing, nothing, nothing)
     end
     function EnsembleSolution_adjoint(p̄::RecursiveArrayTools.AbstractVectorOfArray)
-        (EnsembleSolution(p̄, 0.0, true, stats), nothing, nothing, nothing)
+        (p̄.u, nothing, nothing, nothing)
     end
     function EnsembleSolution_adjoint(p̄::EnsembleSolution)
-        (p̄, nothing, nothing, nothing)
+        (p̄.u, nothing, nothing, nothing)
     end
     function EnsembleSolution_adjoint(p̄::NamedTuple)
         (p̄.u, nothing, nothing, nothing)
@@ -190,24 +190,6 @@ end
     VA[sym], NonlinearSolution_getindex_pullback
 end
 
-@adjoint function ODESolution{
-        T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15,
-    }(
-        u,
-        args...
-    ) where {
-        T1, T2, T3, T4, T5, T6, T7, T8,
-        T9, T10, T11, T12, T13, T14, T15,
-    }
-    function ODESolutionAdjoint(ȳ)
-        (ȳ, ntuple(_ -> nothing, length(args))...)
-    end
-
-    ODESolution{T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15}(
-            u, args...
-        ),
-        ODESolutionAdjoint
-end
 
 @adjoint function SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND}(
         u,

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -335,6 +335,18 @@ function remake(
         lazy_initialization = nothing,
         _kwargs...
     )
+    return _remake_ode_inner(
+        prob, f, u0, tspan, p, kwargs,
+        interpret_symbolicmap, build_initializeprob, use_defaults,
+        lazy_initialization, values(_kwargs)
+    )
+end
+
+function _remake_ode_inner(
+        prob::ODEProblem, f, u0, tspan, p, kwargs,
+        interpret_symbolicmap, build_initializeprob, use_defaults,
+        lazy_initialization, _kwargs
+    )
     if tspan === missing
         tspan = prob.tspan
     end
@@ -382,9 +394,11 @@ function remake(
         ODEProblem{iip}(f, newu0, tspan, newp, prob.problem_type; kwargs...)
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -600,9 +614,11 @@ function remake(
         SDEProblem{iip}(f, newu0, tspan, newp; noise, noise_rate_prototype, seed, kwargs...)
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -667,9 +683,11 @@ function remake(
         )
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -764,9 +782,11 @@ function remake(
         )
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -826,9 +846,11 @@ function remake(
         DAEProblem{iip}(f, du0, newu0, tspan, newp; differential_vars, kwargs...)
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -953,9 +975,11 @@ function remake(
         )
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -1000,9 +1024,11 @@ function remake(
         SteadyStateProblem{isinplace(prob)}(f = f, u0 = newu0, p = newp; kwargs...)
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end
@@ -1048,9 +1074,11 @@ function remake(
         )
     end
 
-    u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
-    @reset prob.u0 = u0
-    @reset prob.p = p
+    if initialization_data !== nothing
+        u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
+        @reset prob.u0 = u0
+        @reset prob.p = p
+    end
 
     return prob
 end

--- a/test/downstream/ensemble_remake_reverse_mode_adjoints.jl
+++ b/test/downstream/ensemble_remake_reverse_mode_adjoints.jl
@@ -1,0 +1,93 @@
+using SciMLBase, OrdinaryDiffEq, Test
+using SciMLBase: EnsembleProblem, EnsembleSerial, EnsembleSolution
+using Zygote, ForwardDiff
+import ChainRulesCore
+
+@testset "EnsembleSolution constructor cotangent shape" begin
+    f(u, p, t) = -u
+    prob = ODEProblem(f, [1.0], (0.0, 1.0))
+    sols = [solve(prob, Tsit5(); saveat = 0.5) for _ in 1:3]
+    es = EnsembleSolution(sols, 0.0, true, nothing)
+    arr = Array(es)
+    @test ndims(arr) == 3
+
+    _, back = Zygote.pullback(EnsembleSolution, sols, 0.0, true, nothing)
+    sim_cot, = back(ones(eltype(arr), size(arr)))
+
+    @test !(sim_cot isa EnsembleSolution)
+    @test length(sim_cot) == length(sols)
+    @test all(eltype(c) <: AbstractArray for c in sim_cot)
+end
+
+@testset "EnsembleSolution rrule cotangent shape" begin
+    f(u, p, t) = -u
+    prob = ODEProblem(f, [1.0], (0.0, 1.0))
+    sols = [solve(prob, Tsit5(); saveat = 0.5) for _ in 1:3]
+    es = EnsembleSolution(sols, 0.0, true, nothing)
+    arr = Array(es)
+
+    _, pb = ChainRulesCore.rrule(EnsembleSolution, sols, 0.0, true, nothing)
+    sim_cot = pb(ones(eltype(arr), size(arr)))[2]
+    @test !(sim_cot isa EnsembleSolution)
+    @test length(sim_cot) == length(sols)
+end
+
+@testset "remake(::ODEProblem; u0) gradient parity" begin
+    f(u, p, t) = u
+    base_prob = ODEProblem(f, [0.0, 0.0], (0.0, 1.0), [1.0])
+    loss(p) = (q = remake(base_prob, u0 = [p[1] * 2, p[1] + 5]); sum(abs2, q.u0))
+    p0 = [3.0]
+    @test Zygote.gradient(loss, p0)[1] ≈ ForwardDiff.gradient(loss, p0) rtol=1e-6
+end
+
+@testset "remake(::ODEProblem; p) gradient parity" begin
+    f(u, p, t) = p[1] * u
+    base_prob = ODEProblem(f, [1.0], (0.0, 1.0), [0.5])
+    loss(p) = (q = remake(base_prob, p = [p[1] * 3]); sum(abs2, q.p))
+    p0 = [2.0]
+    @test Zygote.gradient(loss, p0)[1] ≈ ForwardDiff.gradient(loss, p0) rtol=1e-6
+end
+
+@testset "remake field-pass-through gradient parity" begin
+    f(u, p, t) = u
+    base_prob = ODEProblem(f, [1.0], (0.0, 1.0), [1.0])
+    loss(p) = (q = remake(base_prob, u0 = [p[1]]); sum(abs2, q.u0))
+    p0 = [2.5]
+    @test Zygote.gradient(loss, p0)[1] ≈ ForwardDiff.gradient(loss, p0) rtol=1e-6
+end
+
+@testset "_remake_ode_inner rrule cotangent distribution" begin
+    base_prob = ODEProblem((u, p, t) -> u, [1.0, 2.0], (0.0, 1.0), [3.0])
+    Δ_u0 = [10.0, 20.0]
+    Δ = ChainRulesCore.Tangent{Any}(;
+        f = ChainRulesCore.NoTangent(),
+        u0 = Δ_u0,
+        tspan = ChainRulesCore.NoTangent(),
+        p = ChainRulesCore.NoTangent(),
+        kwargs = ChainRulesCore.NoTangent(),
+        problem_type = ChainRulesCore.NoTangent(),
+    )
+
+    # u0 supplied → cotangent flows to the u0 positional.
+    _, pb = ChainRulesCore.rrule(
+        SciMLBase._remake_ode_inner,
+        base_prob, missing, [9.9, 8.8], missing, missing, missing,
+        true, Val{true}, false, nothing, NamedTuple()
+    )
+    cot = pb(Δ)
+    @test length(cot) == 12
+    @test cot[1] === ChainRulesCore.NoTangent()
+    @test cot[4] == Δ_u0
+    @test cot[2].u0 === nothing
+    @test all(cot[i] === ChainRulesCore.NoTangent() for i in 7:12)
+
+    # u0 not supplied → cotangent accumulates onto prob.u0.
+    _, pb2 = ChainRulesCore.rrule(
+        SciMLBase._remake_ode_inner,
+        base_prob, missing, missing, missing, [99.0], missing,
+        true, Val{true}, false, nothing, NamedTuple()
+    )
+    cot2 = pb2(Δ)
+    @test cot2[4] === ChainRulesCore.NoTangent()
+    @test cot2[2].u0 == Δ_u0
+end

--- a/test/downstream/ensemble_remake_reverse_mode_adjoints.jl
+++ b/test/downstream/ensemble_remake_reverse_mode_adjoints.jl
@@ -3,33 +3,25 @@ using SciMLBase: EnsembleProblem, EnsembleSerial, EnsembleSolution
 using Zygote, ForwardDiff
 import ChainRulesCore
 
-@testset "EnsembleSolution constructor cotangent shape" begin
+@testset "EnsembleSolution constructor pulls NamedTuple cotangent" begin
     f(u, p, t) = -u
     prob = ODEProblem(f, [1.0], (0.0, 1.0))
     sols = [solve(prob, Tsit5(); saveat = 0.5) for _ in 1:3]
-    es = EnsembleSolution(sols, 0.0, true, nothing)
-    arr = Array(es)
-    @test ndims(arr) == 3
+    arrarr = [[copy(s.u[j]) for j in eachindex(s.u)] for s in sols]
 
     _, back = Zygote.pullback(EnsembleSolution, sols, 0.0, true, nothing)
-    sim_cot, = back(ones(eltype(arr), size(arr)))
-
-    @test !(sim_cot isa EnsembleSolution)
-    @test length(sim_cot) == length(sols)
-    @test all(eltype(c) <: AbstractArray for c in sim_cot)
-end
-
-@testset "EnsembleSolution rrule cotangent shape" begin
-    f(u, p, t) = -u
-    prob = ODEProblem(f, [1.0], (0.0, 1.0))
-    sols = [solve(prob, Tsit5(); saveat = 0.5) for _ in 1:3]
-    es = EnsembleSolution(sols, 0.0, true, nothing)
-    arr = Array(es)
+    sim_cot, t_cot, c_cot, s_cot = back((u = arrarr,))
+    @test sim_cot == arrarr
+    @test t_cot === nothing && c_cot === nothing && s_cot === nothing
 
     _, pb = ChainRulesCore.rrule(EnsembleSolution, sols, 0.0, true, nothing)
-    sim_cot = pb(ones(eltype(arr), size(arr)))[2]
-    @test !(sim_cot isa EnsembleSolution)
-    @test length(sim_cot) == length(sols)
+    cot = pb((u = arrarr,))
+    @test cot[2] == arrarr
+    @test cot[1] === ChainRulesCore.NoTangent()
+    @test all(cot[i] === ChainRulesCore.NoTangent() for i in 3:5)
+
+    cot_t = pb(ChainRulesCore.Tangent{Any}(; u = arrarr))
+    @test cot_t[2] == arrarr
 end
 
 @testset "remake(::ODEProblem; u0) gradient parity" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,9 @@ end
         @time @safetestset "Autodiff Remake" begin
             include("downstream/remake_autodiff.jl")
         end
+        @time @safetestset "Ensemble + remake reverse-mode adjoints" begin
+            include("downstream/ensemble_remake_reverse_mode_adjoints.jl")
+        end
         @time @safetestset "Partial Functions" begin
             include("downstream/partial_functions.jl")
         end


### PR DESCRIPTION
## Summary

Reverse-mode-AD correctness fixes that surfaced while debugging `Zygote.gradient` through `solve(::EnsembleProblem, alg, EnsembleGPUArray)` (where the gradient was coming back exactly **2x** the correct value vs. ForwardDiff and finite differences, when it didn't error out earlier).

The full chain now matches ForwardDiff numerically with no Zygote internals patched and no piracy. Verified end-to-end on JLArrays:

```
Forward: 20.2634
Zygote:      Float32[37.526844, 150.10738]
ForwardDiff: Float32[37.52689, 150.10756]
Ratio Zg/FD: Float32[0.9999988, 0.9999988]   # 1.0 within Float32 eps
```

### 1. EnsembleSolution constructor cotangent shape

Both `@adjoint EnsembleSolution(...)` and `ChainRulesCore.rrule(::Type{EnsembleSolution}, ...)` returned the cotangent for `sim` re-wrapped as another `EnsembleSolution`. Since `EnsembleSolution <: AbstractVectorOfArray`, its `getindex(es, i)` is **flat scalar indexing**. Downstream pullbacks that walked the cotangent by row index received scalars where they expected per-row tangents, surfacing as `DimensionMismatch` deeper in the trace.

Fix: return a plain `Vector` for the `sim` cotangent. Also handle `Tangent` input explicitly (struct-tangent from upstream `Array(::AbstractVectorOfArray)` adjoint).

### 2. Stale `@adjoint ODESolution{T1...T15}`

The signature in `SciMLBaseZygoteExt.jl:199` lists 15 type params, but the current `ODESolution` constructor has 16. Dead code. Delete.

### 3. `remake(::ODEProblem; ...)` redundant reconstructions

The remake body's `@reset prob.u0/p` lines run unconditionally even in the no-init-data path. Each `@reset` reconstructs the (mutable) ODEProblem; on a mutable struct, Zygote's `Jnew` re-accumulates gradient via the `grad_mut` cache — exact 2x doubling per remake.

Fix: guard on `initialization_data !== nothing`. Applied to all 8 affected remake overloads.

### 4. Positional `_remake_ode_inner` helper + rrule (the architectural piece)

`Zygote.chain_rrule_kw` drops kwarg cotangents at `(nothing, nothing, dxs...)`, so an rrule on `remake(prob::ODEProblem; kwargs...)` cannot propagate gradients to kwargs like `u0=expr(p)`. Lower the kwarg `remake(prob::ODEProblem; ...)` into a positional `_remake_ode_inner(prob, f, u0, tspan, p, kwargs, ...)` and define the rrule on the positional helper. If a kwarg was passed (not `missing`), its cotangent goes to that positional; otherwise it accumulates onto `prob.field`. Control flags get `NoTangent`. The kwarg gradients now flow naturally because the rrule operates on a non-kwarg signature.

This is the piece that closes the full chain. Once it's in, no Zygote internals need patching for `EnsembleGPUArray` reverse-mode AD to match ForwardDiff.

## Tests

`test/downstream/ensemble_remake_reverse_mode_adjoints.jl` (no SciMLSensitivity dep — exercises SciMLBase-side cotangent flow directly):

- EnsembleSolution constructor cotangent shape (4 tests)
- EnsembleSolution rrule cotangent shape (2 tests)
- `remake(::ODEProblem; u0)` / `; p` / field-pass-through gradient parity vs ForwardDiff (3 tests)
- `_remake_ode_inner` rrule cotangent distribution (7 tests)

All 16 pass.

## Companion PR

Pairs with [SciML/RecursiveArrayTools.jl#587](https://github.com/SciML/RecursiveArrayTools.jl/pull/587) (Array adjoint cotangent shape). Together they make `Zygote.gradient` through `solve(::EnsembleProblem, alg, EnsembleGPUArray)` match ForwardDiff/finite differences exactly.

## Future work (out of scope)

The positional-helper pattern (#4) should be applied to SDEProblem / DDEProblem / SDDEProblem / DAEProblem / NonlinearProblem / SteadyStateProblem / BVProblem `remake` overloads too. ODEProblem ships here as the proof of concept; happy to scale up in a follow-up if the architecture is approved.

Please ignore until reviewed by @ChrisRackauckas.

## Test plan

- [ ] Existing `test/downstream/adjoints.jl` continues to pass
- [ ] New testsets pass (16 tests)
- [ ] No regressions in remake-related suites
