### PR TITLE
Remove `affect_neg!` from `VectorContinuousCallback` constructor

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -145,7 +145,7 @@ struct ContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
             initialize::F4, finalize::F5, idxs::I, rootfind,
             interp_points, save_positions, dtrelax::R, abstol::T,
             reltol::T2, repeat_nudge::T3, initializealg::T4 = nothing,
-            saved_clock_partitions::SCP = (), maybe_discontinuity::Bool = true, 
+            saved_clock_partitions::SCP = (), maybe_discontinuity::Bool = true,
             initialize_save_discretes::Bool = true
         ) where {
             F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP,
@@ -158,7 +158,7 @@ struct ContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
             interp_points,
             BitArray(collect(save_positions)),
             dtrelax, abstol, reltol, repeat_nudge, initializealg, saved_clock_partitions,
-            maybe_discontinuity, initialize_save_discretes 
+            maybe_discontinuity, initialize_save_discretes
         )
     end
 end
@@ -200,7 +200,7 @@ function ContinuousCallback(
         interp_points = 10,
         dtrelax = 1,
         abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-        initializealg = nothing, saved_clock_partitions = (), 
+        initializealg = nothing, saved_clock_partitions = (),
         maybe_discontinuity = true,
         initialize_save_discretes = true,
     )
@@ -215,25 +215,12 @@ end
 
 """
 ```julia
-VectorContinuousCallback(condition, affect!, affect_neg!, len;
-    initialize = INITIALIZE_DEFAULT,
-    finalize = FINALIZE_DEFAULT,
-    idxs = nothing,
-    rootfind = LeftRootFind,
-    save_positions = (true, true),
-    interp_points = 10,
-    abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-    initializealg = nothing, maybe_discontinuity = true)
-```
-
-```julia
 VectorContinuousCallback(condition, affect!, len;
     initialize = INITIALIZE_DEFAULT,
     finalize = FINALIZE_DEFAULT,
     idxs = nothing,
     rootfind = LeftRootFind,
     save_positions = (true, true),
-    affect_neg! = affect!,
     interp_points = 10,
     abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
     initializealg = nothing, maybe_discontinuity = true)
@@ -307,38 +294,12 @@ struct VectorContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
 end
 
 function VectorContinuousCallback(
-        condition, affect!, affect_neg!, len;
-        initialize = INITIALIZE_DEFAULT,
-        finalize = FINALIZE_DEFAULT,
-        idxs = nothing,
-        rootfind = LeftRootFind,
-        save_positions = (true, true),
-        interp_points = 10,
-        dtrelax = 1,
-        abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-        initializealg = nothing, saved_clock_partitions = (), 
-        maybe_discontinuity = true,
-        initialize_save_discretes = true
-    )
-    return VectorContinuousCallback(
-        condition, affect!, affect_neg!, len,
-        initialize, finalize,
-        idxs,
-        rootfind, interp_points,
-        save_positions, dtrelax,
-        abstol, reltol, repeat_nudge, initializealg, saved_clock_partitions,
-        maybe_discontinuity, initialize_save_discretes
-    )
-end
-
-function VectorContinuousCallback(
         condition, affect!, len;
         initialize = INITIALIZE_DEFAULT,
         finalize = FINALIZE_DEFAULT,
         idxs = nothing,
         rootfind = LeftRootFind,
         save_positions = (true, true),
-        affect_neg! = affect!,
         interp_points = 10,
         dtrelax = 1,
         abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
@@ -347,7 +308,7 @@ function VectorContinuousCallback(
         initialize_save_discretes = true
     )
     return VectorContinuousCallback(
-        condition, affect!, affect_neg!, len, initialize, finalize,
+        condition, affect!, affect!, len, initialize, finalize,
         idxs,
         rootfind, interp_points,
         collect(save_positions),

--- a/test/callback_constructors.jl
+++ b/test/callback_constructors.jl
@@ -1,36 +1,42 @@
 using SciMLBase
 using Test
 
-# Regression: the 4-arg `VectorContinuousCallback` keyword constructor used to
-# forward arguments to the inner positional constructor in the wrong order,
-# placing `maybe_discontinuity` in the slot expected for `abstol`.
-@testset "VectorContinuousCallback 4-arg kwarg constructor" begin
-    cond(out, u, t, integ) = (out[1] = u[1]; out[2] = u[2])
+@testset "VectorContinuousCallback 3-arg kwarg constructor" begin
+    cond(out, u, t, integ) = (out[1] = u[1])
     aff!(integ, idx) = nothing
 
-    cb = VectorContinuousCallback(cond, aff!, nothing, 2)
-    @test cb isa VectorContinuousCallback
+    cb = VectorContinuousCallback(cond, aff!, 1; abstol = 1.0e-12)
+    @test cb.abstol == 1.0e-12
+    @test cb.maybe_discontinuity == true
 
-    cb_kw = VectorContinuousCallback(cond, aff!, nothing, 2;
+    cb_kw = VectorContinuousCallback(
+        cond, aff!, 2;
         save_positions = (true, false),
         rootfind = SciMLBase.LeftRootFind,
-        abstol = 1e-9, reltol = 0.0,
+        abstol = 1.0e-9, reltol = 0.0,
         saved_clock_partitions = (),
         maybe_discontinuity = false,
-        initialize_save_discretes = false)
+        initialize_save_discretes = false
+    )
     @test cb_kw.save_positions == BitVector([true, false])
-    @test cb_kw.abstol == 1e-9
+    @test cb_kw.abstol == 1.0e-9
     @test cb_kw.maybe_discontinuity == false
     @test cb_kw.initialize_save_discretes == false
     @test cb_kw.saved_clock_partitions == ()
 end
 
-# Sanity check: the 3-arg form (which already had the right order) still works.
-@testset "VectorContinuousCallback 3-arg kwarg constructor" begin
+# `VectorContinuousCallback` should not accept `affect_neg!`. The
+# 4-arg positional form was a leftover from the v6 `ContinuousCallback`
+# API that was supposed to be removed in the v7 update; downstream
+# code that passed `affect_neg!` had it silently ignored, so the
+# constructor itself is now removed (and so is the kwarg).
+@testset "VectorContinuousCallback rejects affect_neg!" begin
     cond(out, u, t, integ) = (out[1] = u[1])
     aff!(integ, idx) = nothing
+    aff_neg!(integ, idx) = nothing
 
-    cb = VectorContinuousCallback(cond, aff!, 1; abstol = 1e-12)
-    @test cb.abstol == 1e-12
-    @test cb.maybe_discontinuity == true
+    @test_throws MethodError VectorContinuousCallback(cond, aff!, aff_neg!, 1)
+    @test_throws MethodError VectorContinuousCallback(
+        cond, aff!, 1; affect_neg! = aff_neg!
+    )
 end


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

`VectorContinuousCallback`'s `apply_callback!` dispatch in DiffEqBase has never invoked `affect_neg!` — it calls `affect!(integrator, sims)` and discards the field. The v6 ergonomic constructor

```julia
VectorContinuousCallback(condition, affect!, affect_neg!, len; ...)
```

and the matching `affect_neg! = affect!` keyword on the 3-arg form were therefore silent footguns: users who copied the documented v6 idiom (e.g. `VectorContinuousCallback(condition, nothing, affect_neg!, len)`) got it accepted by the constructor and then dropped at dispatch time. See SciML/OrdinaryDiffEq.jl#3613 for the bouncing-ball reproducer.

This is being treated as removing a **mistake**, not a breaking change — the v7 update should have removed these constructors and didn't.

## Changes

- Drop the 4-arg outer constructor `VectorContinuousCallback(condition, affect!, affect_neg!, len; ...)`.
- Drop the `affect_neg! = affect!` keyword from the 3-arg outer constructor.
- Update the docstring to no longer advertise the 4-arg form.
- Replace the previous regression test for the 4-arg kwarg-order bug with:
  - a 3-arg kwarg-coverage test (same kwarg surface, valid form), and
  - a `@test_throws MethodError` that the 4-arg positional form and the `affect_neg!` keyword are both rejected.

The struct field `affect_neg!` is **kept** so that downstream code reading `cb.affect_neg!` (e.g. DiffEqBase's `findall_events!`) still works; it is now always set to `affect!`.

## Notes

- Inner constructor and struct layout are unchanged.
- `ContinuousCallback` is untouched — it still respects `affect_neg!` correctly.
- Runic-formatted.

## Test plan

- [x] `julia --project=. test/callback_constructors.jl` — 9/9 pass.
- [ ] CI: full test suite + downstream.