### PR TITLE
Forward `sol(t::AbstractArray{<:Number})` to `sol.interp`

### DIFF
--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -249,6 +249,20 @@ function (sol::AbstractODESolution)(
     return augment(sol.interp(t, idxs, deriv, sol.prob.p, continuity), sol; discretes)
 end
 
+# Higher-dimensional array inputs (e.g. `Matrix`, 3-D arrays) are not the
+# standard `t::Number` / `t::AbstractVector{<:Number}` shape supported by
+# the `augment`-wrapping path, but downstream solvers (notably PINOODE in
+# NeuralPDE) build solutions whose `interp` is queried with an array of
+# parameter-and-time samples. Forward straight to `sol.interp`; if the
+# concrete interpolation does not handle the input shape it will error
+# there with a clearer message than `MethodError` on `sol`.
+function (sol::AbstractODESolution)(
+        t::AbstractArray{<:Number}, ::Type{deriv},
+        idxs::Nothing, continuity
+    ) where {deriv}
+    return sol.interp(t, idxs, deriv, sol.prob.p, continuity)
+end
+
 function (sol::AbstractODESolution)(
         t::Number, ::Type{deriv}, idxs::Integer,
         continuity

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -78,6 +78,36 @@ end
     @test_throws ErrorException sol([0, -0.5, 0])
 end
 
+# Higher-dimensional `t` (e.g. `Matrix`, 3-D array) used to `MethodError` on
+# `sol(t, ...)`. PINOODE in NeuralPDE queries its solution with a
+# parameter-and-time array; SciMLBase now forwards array `t` straight to
+# `sol.interp` so these solvers can use the standard call interface.
+# See SciML/NeuralPDE.jl#1060.
+@testset "ODESolution call with AbstractArray t forwards to sol.interp" begin
+    struct ArrayInterp end
+    function (::ArrayInterp)(t, idxs, deriv, p, continuity)
+        # Marker payload: just echo back the shape, so we can assert reach.
+        return (t = t, idxs = idxs, deriv = deriv, p = p, continuity = continuity)
+    end
+
+    f = (u, p, t) -> -u
+    ode = ODEProblem(f, 1.0, (0.0, 1.0), 7.0)
+    sol = SciMLBase.build_solution(
+        ode, :NoAlgorithm, [0.0, 1.0], [1.0, exp(-1)]; interp = ArrayInterp()
+    )
+
+    t_mat = rand(2, 3)
+    out = sol(t_mat)
+    @test out.t === t_mat
+    @test out.idxs === nothing
+    @test out.deriv === Val{0}
+    @test out.p === 7.0
+
+    t_3d = rand(2, 3, 4)
+    out3 = sol(t_3d)
+    @test out3.t === t_3d
+end
+
 @testset "interpolate with empty idxs" begin
     f = (u, p, t) -> u
     sol1 = SciMLBase.build_solution(


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

`AbstractODESolution`'s call interface only defines inner-stage methods for `t::Number` and `t::AbstractVector{<:Number}` (`src/solutions/ode_solutions.jl:237` / `:244`). Calling a solution with any higher-dimensional `t` (a `Matrix` or 3-D array) hits a bare `MethodError`.

Downstream solvers — notably `NeuralPDE.PINOODE`, whose `prob.p` is a 3-D parameter-and-time sample tensor — query their solutions with array `t`. PINOODE used to ship per-solver overrides, but those were removed in the OrdinaryDiffEq v7 / StochasticDiffEq v7 compat bump (NeuralPDE commit 553e7293) under the assumption that SciMLBase covered the array case. It didn't, and the PINOODE test suite has been red on `Tests (1.11, PINOODE)` and `Tests (lts, PINOODE)` since.

This PR puts the fix where it belongs (SciMLBase, generically) instead of having every alg-specific solution patch the call interface. Closes the SciMLBase-side gap that motivated the (now-closed) NeuralPDE PR https://github.com/SciML/NeuralPDE.jl/pull/1060.

## Change

Add one method to `src/solutions/ode_solutions.jl`:

```julia
function (sol::AbstractODESolution)(
        t::AbstractArray{<:Number}, ::Type{deriv},
        idxs::Nothing, continuity
    ) where {deriv}
    return sol.interp(t, idxs, deriv, sol.prob.p, continuity)
end
```

- The existing `AbstractVector{<:Number}` method is **more specific** and still wins for vector input — the `augment`-wrapping path is preserved for the standard call site, so no behavior change for normal solutions.
- `Test.detect_ambiguities(SciMLBase; recursive=false)` reports zero ODE-related ambiguities after the change.
- If a concrete interpolation does not handle the array shape it errors at the interp call site (more informative than the prior top-level `MethodError`).

## Test

Added a focused unit test in `test/solution_interface.jl` that builds an `ODESolution` with a custom `interp` and verifies the call dispatches reach `sol.interp` for both `t::Matrix` and `t::Array{Float64,3}`. Asserts shape, `idxs === nothing`, `deriv === Val{0}`, and that `sol.prob.p` is forwarded.

Full smoke run of `solution_interface.jl` is green locally; the new test set passes 5/5.

## Test plan

- [x] `julia --project=. test/solution_interface.jl` green.
- [x] `Test.detect_ambiguities(SciMLBase; recursive=false)` shows no new ambiguities.
- [ ] CI: full SciMLBase suite + downstream.
- [ ] Verify NeuralPDE PINOODE tests go green against this branch (separate follow-up).