### PR TITLE
Add `AbstractOperatorSolution` for non-array operator-learning solutions

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -571,15 +571,31 @@ $(TYPEDEF)
 abstract type AbstractNoiseProcess{T, N, A, isinplace} <: AbstractDiffEqArray{T, N, A} end
 
 """
+$(TYPEDEF)
+
+Supertype for solutions whose primary content is a learned operator rather than
+a tabulated trajectory or array — e.g. physics-informed neural operator solvers
+(`PINOODE` in NeuralPDE.jl). Concrete subtypes are not `<: AbstractArray`; their
+call interface is solver-specific and is dispatched on the concrete type.
+
+Subtypes are still expected to expose `prob`, `alg`, `retcode`, and the
+`interp_summary`/`successful_retcode` interface used elsewhere in SciMLBase.
+"""
+abstract type AbstractOperatorSolution end
+
+"""
 Union of all base solution types.
 
-Uses a Union so that solution types can be `<: AbstractArray`
+Most branches of this union are `<: AbstractArray` (via `AbstractDiffEqArray` or
+`AbstractArray` directly); `AbstractOperatorSolution` is the exception — it
+covers operator-learning results that have no natural array shape.
 """
 const AbstractSciMLSolution = Union{
     AbstractTimeseriesSolution,
     AbstractNoTimeSolution,
     AbstractEnsembleSolution,
     AbstractNoiseProcess,
+    AbstractOperatorSolution,
 }
 
 """
@@ -1020,6 +1036,7 @@ export DynamicalDDEFunction, DynamicalDDEProblem,
     SecondOrderDDEProblem
 export SDDEProblem
 export PDEProblem, PDETimeSeriesSolution, PDENoTimeSolution
+export AbstractOperatorSolution
 export IncrementingODEProblem
 
 export BVProblem, TwoPointBVProblem, SecondOrderBVProblem, TwoPointSecondOrderBVProblem

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -110,6 +110,14 @@ end
     @test sol ≈ sol
 end
 
+@testset "AbstractOperatorSolution subtype joins AbstractSciMLSolution union" begin
+    struct OpSolTest <: SciMLBase.AbstractOperatorSolution end
+    sol = OpSolTest()
+    @test sol isa SciMLBase.AbstractSciMLSolution
+    @test isabstracttype(SciMLBase.AbstractOperatorSolution)
+    @test !(SciMLBase.AbstractOperatorSolution <: AbstractArray)
+end
+
 @testset "solution_new_original_retcode type inference" begin
     # Regression test: `solution_new_original_retcode` must not widen the
     # returned ODESolution's type parameters through the Accessors / setproperties


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

Foundational SciMLBase change for the PINOODE (NeuralPDE) refactor away from `ODESolution`. Companion NeuralPDE PR will follow on top of this.

## Why

`AbstractSciMLSolution` is currently a `Union{AbstractTimeseriesSolution, AbstractNoTimeSolution, AbstractEnsembleSolution, AbstractNoiseProcess}`. **Every** concrete solution type therefore inherits from `AbstractArray` (directly or via `AbstractDiffEqArray`).

Operator-learning solvers (PINOODE, DeepONet-style PINOs, etc.) produce a *learned mapping* from `(parameters, time) → state`, not a tabulated trajectory. Forcing them into `AbstractODESolution` is what produced SciML/OrdinaryDiffEq.jl#3613 / SciML/NeuralPDE.jl#1060: the v7 ecosystem bump assumed downstream solvers could ride the standard `(sol)(t::Number)` / `(sol)(t::Vector)` interface, but PINOODE's natural query is `(p, t)` with both as arrays — there's no array-shaped trajectory to interpolate.

## Change

Introduce `abstract type AbstractOperatorSolution end` and add it to the `AbstractSciMLSolution` union. Documented as the deliberate exception to the \"every solution is `<: AbstractArray`\" rule.

```julia
abstract type AbstractOperatorSolution end

const AbstractSciMLSolution = Union{
    AbstractTimeseriesSolution,
    AbstractNoTimeSolution,
    AbstractEnsembleSolution,
    AbstractNoiseProcess,
    AbstractOperatorSolution,
}
```

Exported. Concrete subtypes are responsible for their own call interface and `Base.show`; the existing dispatches on `AbstractSciMLSolution` (`successful_retcode`, `interp_summary`, `getindepsym`, `getsyms`, `strip_solution`) all go through field access (`.retcode`, `.interp`, `.prob`) and so work unchanged on any subtype that exposes those fields.

## Why a fresh top-level type and not a subtype of `AbstractPDETimeSeriesSolution`

That route works for MOL because MOL discretizes a PDE *into an ODE* and wraps the underlying `ODESolution` — `disc_data`, `original_sol`, `ivdomain`, `ivs`, `dvs` are all populated. PINOODE has no underlying `ODESolution` (just a trained network), so populating those fields would be fictional. The right abstraction is a non-array, non-trajectory supertype.

## Test plan

- [x] Added a test in `test/solution_interface.jl` that asserts a concrete subtype lands in `AbstractSciMLSolution` and that `AbstractOperatorSolution` is not `<: AbstractArray`.
- [x] `julia --project=. test/solution_interface.jl` — full file green.
- [ ] CI: full SciMLBase suite + downstream.

## Follow-up

NeuralPDE.jl PR will define `PINOODESolution <: AbstractOperatorSolution` and migrate `__solve` and the PINO ODE test suite. Once that lands, SciMLBase #1351 (the `(sol::AbstractODESolution)(t::AbstractArray{<:Number})` band-aid) can be closed — PINOODE will no longer be an `ODESolution`.