### PR TITLE
Fix Plots.plot(::AbstractEnsembleSolution) recipe under v3

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -226,7 +226,7 @@ end
         sim::AbstractEnsembleSolution;
         zcolors = sim.u isa AbstractArray ? fill(nothing, length(sim.u)) :
             nothing,
-        trajectories = eachindex(sim)
+        trajectories = eachindex(sim.u)
     )
     for i in trajectories
         size(sim.u[i].u, 1) == 0 && continue


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes #1354.

## Summary

`Plots.plot(::AbstractEnsembleSolution)` errors out-of-the-box with `BoundsError ... at index [1, 2, 1]` under SciMLBase v3. The recipe in `src/ensemble/ensemble_solutions.jl` sets

```julia
trajectories = eachindex(sim)
```

but under the v3 flattened-array layout, `eachindex(::EnsembleSolution)` now returns 3-D `CartesianIndices((nstate, ntime, ntraj))`. The loop body then does `sim.u[i]` with that 3-D index against the underlying `Vector{ODESolution}` and raises.

Change the default to `eachindex(sim.u)` — `sim.u` is the `Vector{ODESolution}` the loop body already indexes, so this aligns the default with the actual access pattern (and matches the pre-v3 behaviour). One-character change.

## Repro / verification

```julia
import OrdinaryDiffEq as ODE
import SciMLBase
import Plots

prob = ODE.ODEProblem((du, u, p, t) -> (du .= u), [1.0, 2.0, 3.0, 4.0], (0.0, 0.1))
eprob = SciMLBase.EnsembleProblem(prob;
    prob_func = (p, ctx) -> ODE.remake(p, u0 = ctx.sim_id * [1.0, 2.0, 3.0, 4.0]))
esol = ODE.solve(eprob, ODE.Tsit5(), SciMLBase.EnsembleThreads(); trajectories = 3)

Plots.plot(esol)                                     # before: BoundsError; after: OK
Plots.plot(esol, trajectories = 1:length(esol.u))    # OK both before and after
```

Sanity-checked by dev'ing this branch into a fresh DifferentialEquations v8 / OrdinaryDiffEq v7 / SciMLBase v3 env — `Plots.plot(esol)` with the recipe default returned `BoundsError` before the patch and plots cleanly after.

## Test plan

- [ ] SciMLBase CI is green (the change is isolated to the recipe's kwarg default; nothing else touched).
- [ ] Downstream `SciML/SciMLDocs` PR #338 currently ships a `trajectories = 1:length(ensemblesol.u)` workaround in four showcase plots; once this lands in a tagged release, that workaround can be reverted.