### PR TITLE
Remove affect_neg! field from VectorContinuousCallback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.10.0"
+version = "3.11.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -245,11 +245,10 @@ Rest of the arguments have the same meaning as in [`ContinuousCallback`](@ref).
 
 - `saved_clock_partitions`: An iterable of `len` elements, where the `i`th element is an iterable of clock partition indices to save when the `i`th event triggers. MTK-only API.
 """
-struct VectorContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
+struct VectorContinuousCallback{F1, F2, F4, F5, T, T2, T3, T4, I, R, SCP} <:
     AbstractContinuousCallback
     condition::F1
     affect!::F2
-    affect_neg!::F3
     len::Int
     initialize::F4
     finalize::F5
@@ -266,7 +265,7 @@ struct VectorContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
     maybe_discontinuity::Bool
     initialize_save_discretes::Bool
     function VectorContinuousCallback(
-            condition::F1, affect!::F2, affect_neg!::F3, len::Int,
+            condition::F1, affect!::F2, len::Int,
             initialize::F4, finalize::F5, idxs::I, rootfind,
             interp_points, save_positions, dtrelax::R,
             abstol::T, reltol::T2, repeat_nudge::T3,
@@ -275,13 +274,13 @@ struct VectorContinuousCallback{F1, F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP} <:
             maybe_discontinuity::Bool = true,
             initialize_save_discretes = true
         ) where {
-            F1, F2, F3, F4, F5, T, T2,
+            F1, F2, F4, F5, T, T2,
             T3, T4, I, R, SCP,
         }
         _condition = prepare_function(condition)
-        return new{typeof(_condition), F2, F3, F4, F5, T, T2, T3, T4, I, R, SCP}(
+        return new{typeof(_condition), F2, F4, F5, T, T2, T3, T4, I, R, SCP}(
             _condition,
-            affect!, affect_neg!, len,
+            affect!, len,
             initialize, finalize, idxs, rootfind,
             interp_points,
             BitArray(collect(save_positions)),
@@ -308,7 +307,7 @@ function VectorContinuousCallback(
         initialize_save_discretes = true
     )
     return VectorContinuousCallback(
-        condition, affect!, affect!, len, initialize, finalize,
+        condition, affect!, len, initialize, finalize,
         idxs,
         rootfind, interp_points,
         collect(save_positions),


### PR DESCRIPTION
## Summary

Drops the `affect_neg!` field (and `F3` type parameter) from `VectorContinuousCallback`. VCC's `apply_callback!` only ever calls `affect!` — the field has been a no-op since the v6→v7 cleanup. The v6 4-arg positional constructor and the `affect_neg!` keyword were already removed in `ba118ad`, but the field itself was kept as a compat shim aliased to `affect!`. That's a footgun: code that reads `cb.affect_neg!` on a VCC silently gets `affect!` back instead of an error, masking porting bugs from the v6 API.

After this PR:
- `fieldnames(VectorContinuousCallback)` no longer includes `:affect_neg!`.
- `cb.affect_neg!` throws `FieldError` for VCC.
- The 4-arg positional constructor and `affect_neg!` kwarg continue to throw `MethodError` (covered by `test/callback_constructors.jl::@testset "VectorContinuousCallback rejects affect_neg!"`).

Version bumped to `3.11.0` (struct layout change; semver-pre-1 minor).

## Downstream

DiffEqBase still has two `callback.affect_neg!` reads on the VCC path (`findall_events!` call site + the field-pass inside it). Coordinated PR: SciML/OrdinaryDiffEq.jl#TBD bumps `DiffEqBase` compat to `SciMLBase = "3.11"` and removes those reads. Without it, anyone updating SciMLBase past 3.11 with an old DiffEqBase will hit `FieldError` the moment a VCC sees a sign change.

## Test plan
- [x] Full `Pkg.test()` green locally (Core group, all Remake/Callback/Integrator/Display/etc — 4400+ pass).
- [x] `cb.affect_neg!` field access throws `FieldError`.
- [ ] CI green.

**Ignore until reviewed by @ChrisRackauckas.**

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>