### PR TITLE
Fix master runic red: format observables_autodiff.jl

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -213,7 +213,7 @@ sol_dae = solve(prob_dae, Rodas5())
                 nothing
             end
             du = [du_ref for _ in sol_dae.u]
-            @test _unwrap_grad(gs).u ≈ du broken=true
+            @test _unwrap_grad(gs).u ≈ du broken = true
         end
     end
 


### PR DESCRIPTION
## Summary

One-line formatter fix for the master runic red. `broken=true` on `test/downstream/observables_autodiff.jl:213` violated runic's space-around-`=` rule:

\`\`\`diff
-@test _unwrap_grad(gs).u ≈ du broken=true
+@test _unwrap_grad(gs).u ≈ du broken = true
\`\`\`

## Root cause

The line was pre-existing; the violation was masked because the `FormatCheck` workflow couldn't actually invoke `runic-action` until #1348 wired Julia setup into it. Once #1348 merged, every PR including this one was blocked by the same red — the formatter regression in master, not in any feature branch.

Pure formatter output; no semantics change.

**Ignore until reviewed by @ChrisRackauckas.**

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>