### PR TITLE
test: fix stale ndims assertion in scalar NoiseGrid downstream test

### DIFF
--- a/test/downstream/rode_calculate_solution_errors.jl
+++ b/test/downstream/rode_calculate_solution_errors.jl
@@ -10,9 +10,9 @@ additive_analytic(u0, p, t, W) = @. u0 / sqrt(1 + t) + p[2] * (t + p[1] * W) / s
 ff_additive = SDEFunction(f_additive, σ_additive, analytic = additive_analytic)
 p = (0.1, 0.05)
 
-@testset "Scalar RODESolution calculate_solution_errors! with NoiseGrid (N=0)" begin
-    # NoiseGrid built from a Vector{Float64} has N=0 — this is the path that
-    # used to hit `ntuple(Val(-1))`.
+@testset "Scalar RODESolution calculate_solution_errors! with scalar NoiseGrid" begin
+    # Exercises the `sol.W.u[i]` branch of calculate_solution_errors! on a
+    # scalar-valued NoiseGrid (the formerly-broken `ntuple(Val(-1))` path).
     dt = 1.0e-2
     n = round(Int, 1 / dt)
     Random.seed!(12345)
@@ -21,7 +21,7 @@ p = (0.1, 0.05)
     ts = collect(0:dt:(1 + dt))
 
     Wgrid = NoiseGrid(ts, Wvals, Zvals)
-    @test ndims(Wgrid) == 0  # scalar-valued NoiseGrid carries N=0
+    @test ndims(Wgrid) == 1
 
     prob = SDEProblem(ff_additive, σ_additive, 1.0, (0.0, 1.0), p; noise = Wgrid)
 
@@ -47,10 +47,9 @@ p = (0.1, 0.05)
     @test isfinite(sol.errors[:L2])
 end
 
-@testset "Scalar RODESolution calculate_solution_errors! with default NoiseProcess (N=1)" begin
-    # The default WienerProcess-based path lands in the same `else` branch
-    # of calculate_solution_errors! but with N=1. Ensure the fix doesn't
-    # regress it.
+@testset "Scalar RODESolution calculate_solution_errors! with default NoiseProcess" begin
+    # The default WienerProcess-based path lands in the `AbstractDiffEqArray{T,N,nothing}`
+    # branch of calculate_solution_errors!. Ensure the fix doesn't regress it.
     prob = SDEProblem(ff_additive, σ_additive, 1.0, (0.0, 1.0), p)
     sol = solve(prob, SRA(), dt = 0.01, adaptive = false)
     @test SciMLBase.successful_retcode(sol)


### PR DESCRIPTION
## Summary
Fixes the failing Downstream test on master (e.g. https://github.com/SciML/SciMLBase.jl/actions/runs/25858729040/job/75983618731 and the preceding run on master ${SHA_BEFORE}):

```
Scalar RODESolution calculate_solution_errors! with NoiseGrid (N=0):
  Test Failed at .../test/downstream/rode_calculate_solution_errors.jl:24
  Expression: ndims(Wgrid) == 0
   Evaluated: 1 == 0
```

The assertion was correct when the test was added (PR #1322), but **DiffEqNoiseProcess 5.31** (commit [`aceaa7c`](https://github.com/SciML/DiffEqNoiseProcess.jl/commit/aceaa7c) — *"Fix T/N parameterization in NoiseGrid/Function/Approximation/VBT"*) corrected the
`AbstractNoiseProcess{T, N, A, iip} <: AbstractDiffEqArray{T, N, A}` parameterization so that `N = ndims(inner) + 1`, matching RAT's own DiffEqArray. A scalar-valued NoiseGrid built from a `Vector{Float64}` now carries `N == 1`, not `N == 0`.

`SciMLBase.calculate_solution_errors!(::AbstractRODESolution)` is unaffected — NoiseGrid (storage `Vector{T2}`, not `nothing`) is still routed through the `else`-branch using `sol.W.u[i]`, which works for any inner ndims and never consults `size(sol.W)`. The original regression fix from #1322 is still exercised by the rest of the testset.

Changes:
- Update the stale `ndims(Wgrid) == 0` assertion to `ndims(Wgrid) == 1`.
- Rename the testset and update the inline comment so the description matches the new DiffEqNoiseProcess parameterization. `(N=0)` → `scalar NoiseGrid`; `(N=1)` was the only thing distinguishing the second testset (which now also has N=1), so its parenthetical is dropped — the second testset now describes itself by the actual branch it exercises (`AbstractDiffEqArray{T,N,nothing}`).

This PR is a test-only patch — no source changes, no version bump needed.

## Test plan
- [x] Reproduced the failure locally on Julia 1.12.6 with DiffEqNoiseProcess 5.31.1: 12/13 pass, 1 fails (only the stale `ndims` assertion).
- [x] After the fix, ran `test/downstream/rode_calculate_solution_errors.jl` locally → 17/17 pass.
- [ ] Downstream CI on this PR.

**Please ignore until reviewed by @ChrisRackauckas.**

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>