### PR TITLE
Mooncake: handle scalar-u NonlinearSolution in getindex rrule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.13.0"
+version = "3.13.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -587,6 +587,19 @@ end
 # inner numeric function, which it handles in seconds.
 
 @is_primitive MinimalCtx Tuple{typeof(getindex), AbstractNonlinearSolution, Any}
+# Integer indexing on a NonlinearSolution returns `NS.u[i]`. For ordinary
+# vector-`u` solutions this is the i-th state. For 0-d / scalar-`u` solutions
+# (produced e.g. by `solve(prob; save_idxs = i::Integer)`, which yields a
+# `NonlinearSolution{T,0,T,...}` whose `u::T` is a scalar), `NS[i]` just
+# returns that scalar. Both cases need a dedicated, more-specific
+# `Integer`-tagged primitive so they bypass the symbolic-indexing rrule
+# below, which only writes the gradient into the `u` fdata when that fdata
+# is an `AbstractArray` and otherwise silently drops the cotangent
+# (SciMLSensitivity.jl#1446: `save_idxs = 1` returning a zero gradient
+# under Mooncake).
+@is_primitive MinimalCtx Tuple{
+    typeof(getindex), AbstractNonlinearSolution, Integer,
+}
 
 function _run_observable_pullback_no_t(getter, s, u, p, dy)
     # Resolve the inner observed function from the cache outside Mooncake's
@@ -669,6 +682,56 @@ function rrule!!(
     end
 
     return zero_fcodual(y), _scatter_pullback_ns
+end
+
+# Dedicated `Integer` rrule for `getindex(::AbstractNonlinearSolution, ::Int)`.
+# Two cases:
+#   (1) `NS.u` is an `AbstractArray` (the usual `NonlinearSolution{T,N>0,...}`):
+#       scatter the scalar cotangent `dy` into `sol_fdata.data.u[i]`.
+#   (2) `NS.u` is itself scalar (`NonlinearSolution{T,0,T,...}` from
+#       `save_idxs = i::Integer`): the `u` field has no fdata
+#       (`fdata_type(Float64) = NoFData`), so its gradient must travel back
+#       through the rdata channel. Build a structured `RData` with `u = dy`
+#       and return it in the pullback tuple.
+# Without this method the more-general `(AbstractNonlinearSolution, Any)`
+# primitive above catches integer indices, takes the `i !== nothing` branch
+# unconditionally, and only writes through fdata; the scalar-u case
+# silently drops the gradient (SciMLSensitivity.jl#1446).
+function rrule!!(
+        ::CoDual{typeof(getindex)},
+        sol::CoDual{<:AbstractNonlinearSolution},
+        i::CoDual{<:Integer},
+    )
+    NS = sol.x
+    ip = i.x
+    y = NS[ip]
+    sol_fdata = sol.dx
+    u_dest = sol_fdata isa NoFData ? nothing : sol_fdata.data.u
+    lzr_sol = lazy_zero_rdata(NS)
+
+    function _ns_int_pullback(dy)
+        if u_dest isa AbstractArray
+            u_dest[ip] += dy
+            return (NoRData(), instantiate(lzr_sol), NoRData())
+        else
+            # Scalar-u case: route the cotangent through rdata on the `u`
+            # field. `instantiate(lzr_sol)` returns a zero `RData` whose
+            # `data` is a NamedTuple of per-field rdata; replace the `u`
+            # entry with `dy` (the scalar cotangent) and reconstruct.
+            zr = instantiate(lzr_sol)
+            if zr isa Mooncake.RData && hasproperty(zr.data, :u)
+                new_data = merge(zr.data, (; u = dy))
+                return (NoRData(), typeof(zr)(new_data), NoRData())
+            else
+                # Unexpected rdata shape — return zero to stay sound rather
+                # than guess at the layout. This branch is not expected to
+                # be reached for the standard NonlinearSolution layout.
+                return (NoRData(), zr, NoRData())
+            end
+        end
+    end
+
+    return zero_fcodual(y), _ns_int_pullback
 end
 
 # NOTE: The ChainRules extension also defines rrules for constructors

--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -288,6 +288,56 @@ end
     end
 end
 
+@testset "NonlinearSolution scalar getindex under AD (SciMLSensitivity#1446)" begin
+    using SteadyStateDiffEq
+    using OrdinaryDiffEqRosenbrock: Rodas5
+
+    # `save_idxs = i::Integer` makes `solve` return a NonlinearSolution{T,0,T,...}
+    # whose `u::Float64` is a scalar (vs `save_idxs = i:i` which keeps a 1-d
+    # Vector{T}). Indexing the scalar solution as `sol[1]` returns that scalar.
+    # Before the dedicated `Integer` rrule on `AbstractNonlinearSolution`, the
+    # generic symbolic-indexing rrule silently dropped the cotangent because
+    # `sol.u`'s fdata for a scalar field is `NoFData`, not a `Vector{<:Real}`.
+    function f_iip!(du, u, p, t)
+        du[1] = p[1] + p[2] * u[1]
+        du[2] = p[3] * u[1] + p[4] * u[2]
+        return nothing
+    end
+    u0_ss = zeros(2)
+    p_ss = [2.0, -2.0, 1.0, -4.0]
+    prob_ss = SteadyStateProblem(f_iip!, u0_ss, p_ss)
+
+    # Reference gradient: the same loss computed via a path that does not
+    # touch the buggy dispatch (full solve + index into the resulting array).
+    ref_loss = θ -> sum(
+        Array(
+            solve(
+                prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ,
+                sensealg = SteadyStateAdjoint(),
+            )
+        )[1]
+    )
+    grad_ref = DifferentiationInterface.gradient(ref_loss, AutoForwardDiff(), p_ss)
+
+    # Scalar `save_idxs` + `[1]` — this is the dispatch that used to return zero.
+    scalar_loss_ssa = θ -> solve(
+        prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ,
+        save_idxs = 1, sensealg = SteadyStateAdjoint(),
+    )[1]
+    scalar_loss_default = θ -> solve(
+        prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ, save_idxs = 1,
+    )[1]
+
+    for backend in MOONCAKE_BACKENDS
+        @testset "$(backend_name(backend))" begin
+            grad_ssa = DifferentiationInterface.gradient(scalar_loss_ssa, backend, p_ss)
+            @test grad_ssa ≈ grad_ref rtol = 1.0e-6
+            grad_def = DifferentiationInterface.gradient(scalar_loss_default, backend, p_ss)
+            @test grad_def ≈ grad_ref rtol = 1.0e-6
+        end
+    end
+end
+
 @testset "Integer time-step indexing under AD (issue #1325)" begin
     function lotka_volterra!(du, u, p, t)
         x, y = u


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

Fixes a silent zero-gradient bug in the Mooncake extension for
`getindex(::AbstractNonlinearSolution, ::Integer)` when the solution has
a scalar `u` (`NonlinearSolution{T,0,T,...}`), as produced by
`solve(prob; save_idxs = i::Integer)` on a SteadyStateProblem /
NonlinearProblem.

The existing `@is_primitive ... AbstractNonlinearSolution, Any` catches
integer indices and falls into the symbolic-indexing `rrule!!`, whose
`i !== nothing` branch only writes the cotangent into `sol_fdata.data.u`
when that fdata is a `Vector{<:Real}`. For scalar-`u` solutions, the
`u` field's fdata is `NoFData()` (scalars carry rdata), so the gradient
was silently dropped.

Adds a dedicated, more-specific `rrule!!` for
`(getindex, AbstractNonlinearSolution, Integer)` that:
- For vector `u`: scatters `dy` into `sol_fdata.data.u[i]` (the
  pre-existing semantics, just made unambiguous via dispatch).
- For scalar `u`: builds a structured `RData` with `u = dy` and returns
  it through the rdata channel.

Mirrors the existing dedicated `Integer` rrule for `ODESolution`
(introduced in #1325).

## How this was found

Failing CI on SciML/SciMLSensitivity.jl `test (Core6, 1)` Julia 1.12:
`test/steady_state.jl` lines 492 and 494 (the `iip` testset of
\"concrete_solve derivatives steady state solver\"), where
`dp2` and `dp2d` returned `0.0` against a reference of `0.5`. Isolating
the failure to `solve(prob; save_idxs = 1)[1]` under Mooncake.

Verified locally on Julia 1.12.6 with this fix applied: the four
previously-failing tests at lines 491–494 now pass and produce
`[0.5, 0.5, 0.0, 0.0]` for all four loss formulations, matching the FD
reference.

## Test plan

- [ ] CI green on SciMLBase.jl
- [ ] Re-run `SciML/SciMLSensitivity.jl` `test (Core6, 1)` on Julia 1.12
      to confirm the steady_state.jl regressions are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)