### PR TITLE
fix: specialize A*sol to use sol.u for AbstractNoTimeSolution

### DIFF
--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -12,6 +12,7 @@ Base.getindex(A::AbstractTimeseriesSolution, I::AbstractArray{Int}) = solution_s
 Base.setindex!(A::AbstractNoTimeSolution, v, i::Int) = (A.u[i] = v)
 Base.setindex!(A::AbstractNoTimeSolution, v, I::Vararg{Int, N}) where {N} = (A.u[I] = v)
 Base.size(A::AbstractNoTimeSolution) = size(A.u)
+Base.:*(A::AbstractMatrix, sol::AbstractNoTimeSolution) = A * sol.u
 
 function Base.show(io::IO, m::MIME"text/plain", A::AbstractNoTimeSolution)
     if hasfield(typeof(A), :retcode)


### PR DESCRIPTION
A*x where x is an AbstractNoTimeSolution was hitting a slow generic 
fallback. Added a Base.:* method that unwraps sol.u directly.