### PR TITLE
EnzymeExt: declare `init` / `solve!` / `solve` kwargs inactive on `AbstractSciMLProblem`

### DIFF
--- a/ext/SciMLBaseEnzymeExt.jl
+++ b/ext/SciMLBaseEnzymeExt.jl
@@ -1,6 +1,7 @@
 module SciMLBaseEnzymeExt
 
-using SciMLBase: AbstractSensitivityAlgorithm
+using SciMLBase: AbstractSensitivityAlgorithm, AbstractSciMLProblem
+import CommonSolve
 import Enzyme: EnzymeRules
 
 # Enzyme rules for SciMLBase abstract types
@@ -14,5 +15,28 @@ import Enzyme: EnzymeRules
 
 # All sensitivity algorithm types should be inactive for Enzyme differentiation
 EnzymeRules.inactive_type(::Type{<:AbstractSensitivityAlgorithm}) = true
+
+# Solver-configuration keyword arguments to `solve`, `init`, and `solve!` on
+# SciML problems are never derivative-carrying — they are scalar tolerances,
+# booleans, or non-numeric configuration (`abstol`, `reltol`, `verbose`,
+# `alias`, `assumptions`, `Pl`, `Pr`, `weight`, …). Without an
+# `inactive_kwarg` declaration, custom Enzyme rules that downstream solver
+# packages register on `CommonSolve.init` / `solve!` / `solve` trip
+# `Enzyme.Compiler.NonConstantKeywordArgException` when callers reach them
+# through `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), …)`.
+#
+# Scoping to `::AbstractSciMLProblem` as the first positional argument keeps
+# the declaration narrow — it applies to SciML solver calls and not to
+# non-SciML CommonSolve callers, who may legitimately want differentiable
+# kwargs.
+EnzymeRules.inactive_kwarg(
+    ::typeof(CommonSolve.init), ::AbstractSciMLProblem, args...; kwargs...,
+) = nothing
+EnzymeRules.inactive_kwarg(
+    ::typeof(CommonSolve.solve!), ::AbstractSciMLProblem, args...; kwargs...,
+) = nothing
+EnzymeRules.inactive_kwarg(
+    ::typeof(CommonSolve.solve), ::AbstractSciMLProblem, args...; kwargs...,
+) = nothing
 
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

Adds three `EnzymeRules.inactive_kwarg` declarations to the existing `SciMLBaseEnzymeExt`, scoped to `::AbstractSciMLProblem` as the first positional argument:

```julia
EnzymeRules.inactive_kwarg(
    ::typeof(CommonSolve.init), ::AbstractSciMLProblem, args...; kwargs...,
) = nothing
EnzymeRules.inactive_kwarg(
    ::typeof(CommonSolve.solve!), ::AbstractSciMLProblem, args...; kwargs...,
) = nothing
EnzymeRules.inactive_kwarg(
    ::typeof(CommonSolve.solve), ::AbstractSciMLProblem, args...; kwargs...,
) = nothing
```

Solver-configuration kwargs on SciML problems — `abstol`, `reltol`, `verbose`, `alias`, `assumptions`, `Pl`, `Pr`, `weight`, etc. — are scalar tolerances, booleans, or non-numeric configuration. Without `inactive_kwarg`, custom Enzyme rules that downstream solver packages register trip `Enzyme.Compiler.NonConstantKeywordArgException` when callers reach them through `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), …)`.

## Why on SciMLBase instead of CommonSolve

This supersedes [SciML/CommonSolve.jl#69](https://github.com/SciML/CommonSolve.jl/pull/69) (already merged + released as 0.2.7) which declared the same kwargs inactive generically on every `CommonSolve.init` / `solve!` / `solve` call. Generic was too broad — non-SciML CommonSolve users may legitimately want differentiable kwargs. Scoping the declaration to `AbstractSciMLProblem` keeps it targeted.

A follow-up PR will revert the over-broad declarations in CommonSolve in favor of these scoped ones.

## Refs

- SciML/SciMLSensitivity.jl#1359 — umbrella tracker
- @wsmoses guidance on JuliaDiff/DifferentiationInterface.jl#1020 ([comment](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1020#issuecomment-4513384472))
- SciML/CommonSolve.jl#69 — the now-superseded broader version

## Test plan
- [x] Locally verified `methods(EnzymeRules.inactive_kwarg, Tuple{typeof(CommonSolve.init), AbstractSciMLProblem})` returns 1 hit from `SciMLBaseEnzymeExt`
- [ ] CI green