### PR TITLE
Disambiguate *(::AbstractMatrix, ::AbstractNoTimeSolution) against LinearAlgebra/StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.15.0"
+version = "3.15.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -51,6 +51,7 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
@@ -69,6 +70,7 @@ SciMLBasePyCallExt = "PyCall"
 SciMLBasePythonCallExt = "PythonCall"
 SciMLBaseRCallExt = "RCall"
 SciMLBaseReverseDiffExt = "ReverseDiff"
+SciMLBaseStaticArraysExt = "StaticArrays"
 SciMLBaseTrackerExt = "Tracker"
 SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore"]
 

--- a/ext/SciMLBaseStaticArraysExt.jl
+++ b/ext/SciMLBaseStaticArraysExt.jl
@@ -3,8 +3,9 @@ module SciMLBaseStaticArraysExt
 using SciMLBase: AbstractNoTimeSolution
 using StaticArrays: StaticMatrix
 
-# Disambiguate against StaticArrays' `*(::StaticMatrix, ::AbstractVector)` and
-# SciMLBase's `*(::AbstractMatrix, ::AbstractNoTimeSolution)`.
-Base.:*(A::StaticMatrix, sol::AbstractNoTimeSolution{<:Any, 1}) = A * sol.u
+# Disambiguate `*(::StaticMatrix, ::AbstractVecOrMat)` against SciMLBase's
+# `*(::AbstractMatrix, ::AbstractNoTimeSolution)`. Forward to `A * sol.u` so the
+# StaticArrays fast path is preserved.
+Base.:*(A::StaticMatrix, sol::AbstractNoTimeSolution) = A * sol.u
 
 end

--- a/ext/SciMLBaseStaticArraysExt.jl
+++ b/ext/SciMLBaseStaticArraysExt.jl
@@ -1,0 +1,10 @@
+module SciMLBaseStaticArraysExt
+
+using SciMLBase: AbstractNoTimeSolution
+using StaticArrays: StaticMatrix
+
+# Disambiguate against StaticArrays' `*(::StaticMatrix, ::AbstractVector)` and
+# SciMLBase's `*(::AbstractMatrix, ::AbstractNoTimeSolution)`.
+Base.:*(A::StaticMatrix, sol::AbstractNoTimeSolution{<:Any, 1}) = A * sol.u
+
+end

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -14,6 +14,41 @@ Base.setindex!(A::AbstractNoTimeSolution, v, I::Vararg{Int, N}) where {N} = (A.u
 Base.size(A::AbstractNoTimeSolution) = size(A.u)
 Base.:*(A::AbstractMatrix, sol::AbstractNoTimeSolution) = A * sol.u
 
+# Disambiguators for `*(A, sol::AbstractNoTimeSolution)` against LinearAlgebra's
+# structured-matrix and covector methods. Each forwards to `A * sol.u` so the
+# specialized fast path in LinearAlgebra is preserved.
+Base.:*(A::LinearAlgebra.Diagonal, sol::AbstractNoTimeSolution) = A * sol.u
+Base.:*(A::LinearAlgebra.AbstractTriangular, sol::AbstractNoTimeSolution) = A * sol.u
+
+# Covector A (Adjoint/Transpose of a vector) acting on a matrix-shape sol.
+Base.:*(
+    A::LinearAlgebra.Adjoint{<:Any, <:AbstractVector},
+    sol::AbstractNoTimeSolution{<:Any, 2}
+) = A * sol.u
+Base.:*(
+    A::LinearAlgebra.Transpose{<:Any, <:AbstractVector},
+    sol::AbstractNoTimeSolution{<:Any, 2}
+) = A * sol.u
+
+# Covector A acting on a vector-shape sol (dot product). One Union method handles
+# the general T case; tighter Number/Real variants disambiguate the LinearAlgebra
+# specializations for those element types.
+Base.:*(
+    A::Union{
+        LinearAlgebra.Adjoint{<:Any, <:AbstractVector},
+        LinearAlgebra.Transpose{<:Any, <:AbstractVector},
+    },
+    sol::AbstractNoTimeSolution{<:Any, 1}
+) = A * sol.u
+Base.:*(
+    A::LinearAlgebra.Adjoint{<:Number, <:AbstractVector},
+    sol::AbstractNoTimeSolution{<:Number, 1}
+) = A * sol.u
+Base.:*(
+    A::LinearAlgebra.Transpose{T, <:AbstractVector},
+    sol::AbstractNoTimeSolution{T, 1}
+) where {T <: Real} = A * sol.u
+
 function Base.show(io::IO, m::MIME"text/plain", A::AbstractNoTimeSolution)
     if hasfield(typeof(A), :retcode)
         println(io, string("retcode: ", A.retcode))

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -1,8 +1,27 @@
 using Test, SciMLBase
+using LinearAlgebra: norm
+using StaticArrays
 
 @testset "getindex" begin
     u = rand(1)
     @test SciMLBase.build_linear_solution(nothing, u, zeros(1), nothing)[] == u[]
+end
+
+@testset "A * sol for AbstractNoTimeSolution" begin
+    # Matrix * LinearSolution: forwards to A * sol.u
+    A = [1.0 2.0; 3.0 4.0]
+    u = [1.0, -1.0]
+    sol = SciMLBase.build_linear_solution(nothing, u, zero(u), nothing)
+    @test A * sol == A * u
+    @test norm(A * sol .- A * u) < 1e-12
+
+    # StaticMatrix * LinearSolution must not be ambiguous (regression: LinearSolve.jl
+    # static_arrays test was triggering MethodError between StaticArrays' and SciMLBase's
+    # *(::AbstractMatrix, ::AbstractNoTimeSolution)).
+    SA = @SMatrix [1.0 2.0; 3.0 4.0]
+    su = @SVector [1.0, -1.0]
+    ssol = SciMLBase.build_linear_solution(nothing, su, zero(su), nothing)
+    @test SA * ssol == SA * su
 end
 
 @testset "plot ODE solution" begin

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -1,5 +1,5 @@
 using Test, SciMLBase
-using LinearAlgebra: norm
+using LinearAlgebra
 using StaticArrays
 
 @testset "getindex" begin
@@ -8,12 +8,23 @@ using StaticArrays
 end
 
 @testset "A * sol for AbstractNoTimeSolution" begin
-    # Matrix * LinearSolution: forwards to A * sol.u
-    A = [1.0 2.0; 3.0 4.0]
     u = [1.0, -1.0]
     sol = SciMLBase.build_linear_solution(nothing, u, zero(u), nothing)
+
+    # Plain matrix * LinearSolution: forwards to A * sol.u
+    A = [1.0 2.0; 3.0 4.0]
     @test A * sol == A * u
-    @test norm(A * sol .- A * u) < 1e-12
+    @test norm(A * sol .- A * u) < 1.0e-12
+
+    # Each disambiguator: result must match A * sol.u and not throw ambiguity.
+    @test Diagonal([2.0, 3.0]) * sol == Diagonal([2.0, 3.0]) * u
+    @test LowerTriangular([1.0 0.0; 2.0 3.0]) * sol ==
+        LowerTriangular([1.0 0.0; 2.0 3.0]) * u
+    @test UpperTriangular([1.0 2.0; 0.0 3.0]) * sol ==
+        UpperTriangular([1.0 2.0; 0.0 3.0]) * u
+    v = [0.5, 0.25]
+    @test v' * sol == v' * u
+    @test transpose(v) * sol == transpose(v) * u
 
     # StaticMatrix * LinearSolution must not be ambiguous (regression: LinearSolve.jl
     # static_arrays test was triggering MethodError between StaticArrays' and SciMLBase's


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary
The broad

```julia
Base.:*(A::AbstractMatrix, sol::AbstractNoTimeSolution) = A * sol.u
```

method introduced in #1363 has ambiguities with LinearAlgebra's specialized `*` methods (Diagonal, AbstractTriangular, Adjoint/Transpose-of-vector) and with StaticArrays' `*(::StaticMatrix, ::AbstractVecOrMat)`. These surface as:

- Aqua `detect_ambiguities(SciMLBase)` failures on master (Tests / QA, both Julia 1.10 lts and 1.12)
- `MethodError: ... is ambiguous` in LinearSolve.jl's `test/nopre/static_arrays.jl`

Per discussion, we want to keep the broad overload (the AbstractArray fallback is slow because every `getindex` goes through the solution wrapper) and just disambiguate.

## Approach
In `src/solutions/solution_interface.jl`, add per-conflict disambiguators that all forward to `A * sol.u`, preserving the LinearAlgebra fast paths:

```julia
Base.:*(A::Diagonal, sol::AbstractNoTimeSolution) = A * sol.u
Base.:*(A::AbstractTriangular, sol::AbstractNoTimeSolution) = A * sol.u

# covector * matrix-shape sol
Base.:*(A::Adjoint{<:Any, <:AbstractVector},   sol::AbstractNoTimeSolution{<:Any, 2}) = A * sol.u
Base.:*(A::Transpose{<:Any, <:AbstractVector}, sol::AbstractNoTimeSolution{<:Any, 2}) = A * sol.u

# covector * vector-shape sol (dot product); Union form covers lib's Union method 9
Base.:*(A::Union{Adjoint{<:Any, <:AbstractVector}, Transpose{<:Any, <:AbstractVector}},
        sol::AbstractNoTimeSolution{<:Any, 1}) = A * sol.u

# tighter element-type variants for lib's Number / Real specializations
Base.:*(A::Adjoint{<:Number, <:AbstractVector},  sol::AbstractNoTimeSolution{<:Number, 1}) = A * sol.u
Base.:*(A::Transpose{T, <:AbstractVector},       sol::AbstractNoTimeSolution{T, 1}) where {T<:Real} = A * sol.u
```

And a new `SciMLBaseStaticArraysExt` extension that adds:

```julia
Base.:*(A::StaticMatrix, sol::AbstractNoTimeSolution) = A * sol.u
```

The extension only loads when `StaticArrays` is loaded, so users not using static arrays pay nothing.

## Verification

Local, both Julia 1.10 (LTS) and 1.12:

```
julia> using SciMLBase, Test
julia> Test.detect_ambiguities(SciMLBase)
0-element Vector{Tuple{Method, Method}}
```

Local `include("test/solution_interface.jl")` — all testsets pass, including the new 8-test "A * sol for AbstractNoTimeSolution" testset that exercises:
- dense `Matrix * sol`
- `Diagonal * sol`, `LowerTriangular * sol`, `UpperTriangular * sol`
- `v' * sol`, `transpose(v) * sol`
- `SMatrix * sol` (LinearSolve regression)

## Files changed
- `src/solutions/solution_interface.jl` — 7 LinearAlgebra disambiguators
- `ext/SciMLBaseStaticArraysExt.jl` (new) — 1-method StaticMatrix disambiguator
- `Project.toml` — `StaticArrays` weakdep + extension entry; version 3.15.0 → 3.15.1
- `test/solution_interface.jl` — regression testset

## Test plan
- [ ] Wait for CI
- [ ] Confirm LinearSolve.jl `test/nopre/static_arrays.jl` passes against this branch
