### PR TITLE
Add missing trailing comma in src/errors.jl for Runic

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -95,7 +95,7 @@ const allowedkeywords = (
     # Parameter estimation with BVP
     :tune_parameters,
     # Optimizer kwargs passed via BVP solvers
-    :optimize_kwargs
+    :optimize_kwargs,
 )
 
 


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary
Master's `runic` CI check has been failing since #1361 added `:optimize_kwargs` to `allowedkeywords` without a trailing comma. This is a one-character fix to make Runic happy.

I noticed this while looking at CI for #1365 — extracting it as its own tiny PR per the small-focused-PR guideline.

## Test plan
- [ ] Wait for the `runic` check to go green