### PR TITLE
Add sol.prob / get_prob to recover the OptimizationProblem from a solution (Optimization.jl#1191)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.16.0"
+version = "3.17.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/solutions/optimization_solutions.jl
+++ b/src/solutions/optimization_solutions.jl
@@ -65,6 +65,12 @@ Representation of the solution to a non-linear optimization defined by an Optimi
 
   - `cache::AbstractOptimizationCache`: the optimization cache that was solved.
 
+## Accessing the original problem
+
+  - `sol.prob` (equivalently `SciMLBase.get_prob(sol)`) returns the original
+    `OptimizationProblem` the solution was produced from, when the cache retains
+    it. Use `SciMLBase.has_prob(sol)` to check availability.
+
 ## Interface
 
 `OptimizationSolution` is a `SciMLBase.AbstractNoTimeSolution`. For more information on the SciML
@@ -191,6 +197,31 @@ has_observed(sol::OptimizationSolution) = get_observed(sol) !== nothing
 has_syms(sol::OptimizationSolution) = !isempty(variable_symbols(sol.cache.f))
 has_paramsyms(sol::OptimizationSolution) = !isempty(parameter_symbols(sol.cache.f))
 
+has_prob(sol::OptimizationSolution) = hasfield(typeof(getfield(sol, :cache)), :prob)
+
+"""
+    get_prob(sol::OptimizationSolution)
+
+Return the original `OptimizationProblem` that `sol` was solved from, as retained
+by the optimization cache (`sol.cache.prob`). This is the untouched problem the
+user constructed, so its objective, constraints, parameters, and bounds are the
+originals rather than the instantiated, `p`-baked versions held in `sol.cache.f`.
+
+Throws an `ArgumentError` if the solution's cache does not store the original
+problem (`has_prob(sol) == false`), as is the case for caches such as
+`DefaultOptimizationCache` that do not retain it.
+"""
+function get_prob(sol::OptimizationSolution)
+    cache = getfield(sol, :cache)
+    has_prob(sol) && return getfield(cache, :prob)
+    throw(
+        ArgumentError(
+            "The optimization cache of type `$(nameof(typeof(cache)))` does not store the " *
+                "original `OptimizationProblem`, so it cannot be recovered from the solution."
+        )
+    )
+end
+
 function Base.show(io::IO, A::AbstractOptimizationSolution)
     println(io, string("retcode: ", A.retcode))
     print(io, "u: ")
@@ -211,6 +242,8 @@ Base.@propagate_inbounds function Base.getproperty(
     )
     if s === :ps
         return ParameterIndexingProxy(x)
+    elseif s === :prob
+        return get_prob(x)
     end
     return getfield(x, s)
 end

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -183,3 +183,37 @@ end
     # must produce a fully concrete ODESolution type.
     @inferred bvde_like(odesol, nlsol)
 end
+
+# Mock cache that retains the original problem (mirrors OptimizationBase's
+# OptimizationCache.prob field). Defined at top level so it can be used below.
+struct ProbRetainingCache{P} <: SciMLBase.AbstractOptimizationCache
+    prob::P
+end
+
+@testset "OptimizationSolution: sol.prob / get_prob (issue #1191)" begin
+    prob = SciMLBase.OptimizationProblem(
+        SciMLBase.OptimizationFunction((x, p) -> sum(x), SciMLBase.NoAD()),
+        [1.0, 2.0]
+    )
+    cache = ProbRetainingCache(prob)
+    sol = SciMLBase.build_solution(
+        cache, nothing, [1.0, 2.0], 0.0; retcode = SciMLBase.ReturnCode.Success
+    )
+
+    @test SciMLBase.has_prob(sol)
+    @test SciMLBase.get_prob(sol) === prob
+    @test sol.prob === prob
+    @test sol.prob !== sol.cache
+
+    # A cache that does not retain the problem must error clearly, not silently
+    # hand back the cache.
+    nocache = SciMLBase.DefaultOptimizationCache(
+        SciMLBase.OptimizationFunction((x, p) -> sum(x), SciMLBase.NoAD()), nothing
+    )
+    nosol = SciMLBase.build_solution(
+        nocache, nothing, [1.0, 2.0], 0.0; retcode = SciMLBase.ReturnCode.Success
+    )
+    @test !SciMLBase.has_prob(nosol)
+    @test_throws ArgumentError SciMLBase.get_prob(nosol)
+    @test_throws ArgumentError nosol.prob
+end


### PR DESCRIPTION
## Summary

Adds a way to recover the original `OptimizationProblem` from an `OptimizationSolution`, addressing SciML/Optimization.jl#1191 (`sol.prob` returns the cache, not the problem).

`OptimizationSolution` stores the solved cache in `sol.cache`. Historically `sol.prob` was deprecated to return the cache (2.x) and then removed (3.x), so there is currently no supported way to get the original problem back from a solution.

## What changed

- Add `SciMLBase.get_prob(sol)` and `SciMLBase.has_prob(sol)`, mirroring the existing `get_p`/`get_syms` accessors. `get_prob` returns the original problem retained by the cache (`sol.cache.prob`).
- Re-add `sol.prob` as sugar for `get_prob(sol)` via the solution `getproperty`, alongside the existing `:ps` accessor.
- Caches that don't retain the problem (e.g. `DefaultOptimizationCache`) raise a clear `ArgumentError` instead of silently returning the cache.
- `propertynames`/`hasproperty` are intentionally left unchanged (matching `:ps`), so `wrap_sol`'s `hasproperty(sol, :prob)` guard — and every other `hasproperty`-gated path — is unaffected.
- Version `3.16.0 → 3.17.0`.

## Pairs with

OptimizationBase storing the original problem on `OptimizationCache` (Optimization.jl PR). The two are complementary but independent: this PR works for any `AbstractOptimizationCache` that exposes a `prob` field and errors otherwise.

## Note for review

This re-introduces `sol.prob` (previously deprecated to return the cache, then removed). Here it returns the **problem**. If you'd rather keep `sol.prob` retired and expose only `get_prob(sol)`, the `getproperty` branch can be dropped — happy to do so.

## Tests (run locally)

Added a self-contained testset in `solution_interface.jl` using a mock prob-retaining `AbstractOptimizationCache` and `DefaultOptimizationCache` (negative path). Verified the full `solution_interface.jl` passes (existing + new 7-assertion set), and an end-to-end OptimizationBase+LBFGSB run where `sol.prob === prob`, `get_prob(sol) === prob`, `has_prob(sol)`. Runic-formatted.

🚧 Draft — please ignore until reviewed by @ChrisRackauckas.
