### PR TITLE
Downgrade CI: switch to allow_reresolve=false (genuine test-at-floor)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,7 +19,6 @@ jobs:
       julia-version: "1.10"
       # DifferentiationInterface is skipped: DI 0.6-0.7 requires ADTypes >= ~1.6,
       # but julia-downgrade-compat would pin ADTypes to 1.0.0 (minimum of compat "1"),
-      # making resolution impossible. See https://github.com/SciML/SciMLBase.jl/issues/1232
       skip: "Pkg,TOML,DifferentiationInterface"
-      allow-reresolve: true
+      allow-reresolve: false
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -75,8 +75,8 @@ SciMLBaseTrackerExt = "Tracker"
 SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore"]
 
 [compat]
-ADTypes = "1"
-Accessors = "0.1.36"
+ADTypes = "1.9.0"
+Accessors = "0.1.39"
 Adapt = "4.3"
 ArrayInterface = "7.19"
 ChainRules = "1.58.0"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft. Follow-up to #1368.

#1368 re-enabled the Downgrade workflow with `allow_reresolve: true` (tests re-resolve away from the floor). This switches to `allow_reresolve: false` so the suite genuinely runs at the **minimal (downgraded) dependency versions**, and raises the two declared-dep floors that the floor set needs:

- `ADTypes 1 -> 1.9.0` — DifferentiationInterface 0.6-0.7 (pinned by Zygote 0.7) requires ADTypes >= 1.9.0; ADTypes 1.0.0 left DI no versions.
- `Accessors 0.1.36 -> 0.1.39` — RecursiveArrayTools 4 forces StructArrays >= 0.7 via its weakdep-ext, but Accessors 0.1.36's StructArrays-ext caps it <= 0.6; 0.1.39 widens that ext to 0.6-0.7.

Verified locally on Julia 1.10 (CI matrix) in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with **0 re-resolve events**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)