### PR TITLE
Preserve `lb`/`ub` when remaking Nonlinear(LeastSquares)Problem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.17.0"
+version = "3.18.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -910,6 +910,8 @@ function remake(
         u0 = missing,
         p = missing,
         problem_type = missing,
+        lb = missing,
+        ub = missing,
         kwargs = missing,
         interpret_symbolicmap = true,
         use_defaults = false,
@@ -939,17 +941,23 @@ function remake(
     if problem_type === missing
         problem_type = prob.problem_type
     end
+    if lb === missing
+        lb = prob.lb
+    end
+    if ub === missing
+        ub = prob.ub
+    end
 
     prob = if kwargs === missing
         NonlinearProblem{isinplace(prob)}(
             f = f, u0 = newu0, p = newp,
-            problem_type = problem_type; prob.kwargs...,
+            problem_type = problem_type, lb = lb, ub = ub; prob.kwargs...,
             _kwargs...
         )
     else
         NonlinearProblem{isinplace(prob)}(
             f = f, u0 = newu0, p = newp,
-            problem_type = problem_type; kwargs...
+            problem_type = problem_type, lb = lb, ub = ub; kwargs...
         )
     end
 
@@ -1015,6 +1023,7 @@ Remake the given `NonlinearLeastSquaresProblem`.
 """
 function remake(
         prob::NonlinearLeastSquaresProblem; f = missing, u0 = missing, p = missing,
+        lb = missing, ub = missing,
         interpret_symbolicmap = true, use_defaults = false, kwargs = missing,
         lazy_initialization = nothing, build_initializeprob = Val{true}, _kwargs...
     )
@@ -1037,14 +1046,21 @@ function remake(
     f = coalesce(f, prob.f)
     f = remake(prob.f; f, initialization_data)
 
+    if lb === missing
+        lb = prob.lb
+    end
+    if ub === missing
+        ub = prob.ub
+    end
+
     prob = if kwargs === missing
         prob = NonlinearLeastSquaresProblem{isinplace(prob)}(;
-            f, u0 = newu0, p = newp, prob.kwargs...,
+            f, u0 = newu0, p = newp, lb = lb, ub = ub, prob.kwargs...,
             _kwargs...
         )
     else
         prob = NonlinearLeastSquaresProblem{isinplace(prob)}(;
-            f, u0 = newu0, p = newp, kwargs...
+            f, u0 = newu0, p = newp, lb = lb, ub = ub, kwargs...
         )
     end
 

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -494,3 +494,27 @@ end
     sol = DiffEqArray(vals, ts)
     @test SciMLBase.anyeltypedual(sol, Val{0}) == Any
 end
+
+@testset "`remake` preserves `lb`/`ub` on bounded nonlinear problems" begin
+    nlf(u, p) = u .^ 2 .- p
+    for P in (NonlinearProblem, NonlinearLeastSquaresProblem)
+        prob = P(nlf, [1.0, 1.0], [2.0, 3.0]; lb = [0.0, 0.0], ub = [5.0, 5.0])
+        @test prob.lb == [0.0, 0.0]
+        @test prob.ub == [5.0, 5.0]
+
+        # `remake` with no bounds override keeps the existing bounds
+        prob2 = remake(prob; u0 = [2.0, 2.0])
+        @test prob2.lb == [0.0, 0.0]
+        @test prob2.ub == [5.0, 5.0]
+
+        # explicit bounds override
+        prob3 = remake(prob; lb = [-1.0, -1.0], ub = [1.0, 1.0])
+        @test prob3.lb == [-1.0, -1.0]
+        @test prob3.ub == [1.0, 1.0]
+
+        # bounds can be cleared
+        prob4 = remake(prob; lb = nothing, ub = nothing)
+        @test prob4.lb === nothing
+        @test prob4.ub === nothing
+    end
+end


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

## Problem

`remake(::NonlinearProblem)` and `remake(::NonlinearLeastSquaresProblem)` reconstruct the problem without forwarding the `lb`/`ub` fields, so any bounds on the problem are **silently dropped on every `remake`**. Because problem construction in ModelingToolkit (and the trivial-initialization `remake` path generally) routes through `remake`, bounds set at construction never survive to the solver.

`remake(::OptimizationProblem)` already preserves `lb`/`ub` (and `int`, `lcons`, …); the nonlinear `remake` methods simply never got the same treatment.

## Fix

Add `lb`/`ub` keyword arguments to both nonlinear `remake` methods, defaulting to the problem's current values and forwarding them to the constructor — exactly mirroring `remake(::OptimizationProblem)`. Bounds can be overridden or cleared (`lb = nothing`).

## Reproduction (before this PR)

```julia
using NonlinearSolve, SciMLBase
prob = NonlinearProblem((u,p)->u.^2 .- 4 .*u .+ 3, [1.5], nothing; lb=[0.0], ub=[2.0])
remake(prob).lb   # => nothing   (bounds dropped!)
```

## Tests

Added a testset to `test/remake_tests.jl` covering preservation, override, and clearing of `lb`/`ub` for both `NonlinearProblem` and `NonlinearLeastSquaresProblem`. Verified locally against this branch.

## Context

This is a prerequisite for SciML/ModelingToolkit.jl#4308 (forwarding `bounds` metadata to nonlinear problems). It also pairs with a NonlinearSolveBase fix so that bounded problems carrying initialization data solve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)