### PR TITLE
Add `HomotopyProblem`: a homotopy/continuation problem type

### DIFF
--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -197,3 +197,9 @@ SciMLBase.AbstractSDDEProblem
 SciMLBase.AbstractConstantLagSDDEProblem
 SciMLBase.AbstractPDEProblem
 ```
+
+## Concrete Nonlinear Problems
+
+```@docs
+SciMLBase.HomotopyProblem
+```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1002,7 +1002,7 @@ export LinearProblem, LinearSolution, IntervalNonlinearProblem,
     OptimizationProblem, OptimizationSolution
 
 export NonlinearProblem, NonlinearSolution,
-    SCCNonlinearProblem, NonlinearLeastSquaresProblem
+    SCCNonlinearProblem, NonlinearLeastSquaresProblem, HomotopyProblem
 
 export DiscreteProblem, ImplicitDiscreteProblem
 export SteadyStateProblem, SteadyStateSolution

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -50,6 +50,7 @@ struct OverrideInitData{
             Union{
             SCCNonlinearProblem, ImmutableNonlinearProblem,
             NonlinearProblem, NonlinearLeastSquaresProblem,
+            HomotopyProblem,
         }
         return new{I, J, K, L, M, O}(
             initprob, update_initprob!, initprobmap, initprobpmap, metadata, is_update_oop

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -795,3 +795,15 @@ end
 function HomotopyProblem(f, u0, p = NullParameters(); kwargs...)
     return HomotopyProblem(NonlinearFunction(f), u0, p; kwargs...)
 end
+
+function ConstructionBase.constructorof(::Type{P}) where {P <: HomotopyProblem}
+    return function ctor(f, u0, p, homotopy_parameter, λspan, kw)
+        if f isa AbstractNonlinearFunction
+            iip = isinplace(f)
+        else
+            iip = isinplace(f, 4)
+        end
+        return HomotopyProblem{iip}(
+            f, u0, p; homotopy_parameter = homotopy_parameter, λspan = λspan, kw...)
+    end
+end

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -722,3 +722,68 @@ function Base.convert(
         prob.f, prob.u0, prob.p, prob.problem_type; prob.kwargs...
     )
 end
+
+@doc doc"""
+
+Defines a one-parameter homotopy nonlinear problem.
+
+## Mathematical Specification of a Homotopy Problem
+
+To define a Homotopy Problem, you give the residual function ``H``
+
+```math
+0 = H(u, p, \lambda)
+```
+
+where ``\lambda \in \texttt{λspan}`` is the continuation parameter embedded inside `p`.
+The solver sweeps ``\lambda`` from `λspan[1]` to `λspan[2]`, warm-starting each step
+from the previous solution, performing natural-parameter continuation.
+
+## Problem Type
+
+### Constructors
+
+```julia
+HomotopyProblem(f::NonlinearFunction, u0, p = NullParameters(); homotopy_parameter, λspan = (0.0, 1.0), kwargs...)
+HomotopyProblem{isinplace}(f, u0, p = NullParameters(); homotopy_parameter, λspan = (0.0, 1.0), kwargs...)
+```
+
+`isinplace` optionally sets whether the function is in-place or not. This is
+determined automatically, but not inferred.
+
+### Fields
+
+* `f`: The residual `H` as a `NonlinearFunction`.
+* `u0`: The initial guess.
+* `p`: The parameters; one entry, located by `homotopy_parameter`, is ``\lambda``.
+* `homotopy_parameter`: locator (symbol or index) of ``\lambda`` within `p`.
+* `λspan`: the `(start, stop)` continuation interval; the target system is at `stop`.
+* `kwargs`: The keyword arguments passed on to the solvers.
+"""
+mutable struct HomotopyProblem{uType, isinplace, P, F, K, Λ, S} <:
+               AbstractNonlinearProblem{uType, isinplace}
+    f::F
+    u0::uType
+    p::P
+    homotopy_parameter::Λ
+    λspan::S
+    kwargs::K
+
+    @add_kwonly function HomotopyProblem{iip}(
+            f::AbstractNonlinearFunction{iip}, u0, p = NullParameters();
+            homotopy_parameter = nothing, λspan = (0.0, 1.0), kwargs...) where {iip}
+        if haskey(kwargs, :p)
+            error("`p` specified as a keyword argument `p = $(kwargs[:p])` to " *
+                  "`HomotopyProblem`. This is not supported. Pass `p` as the third " *
+                  "positional argument instead.")
+        end
+        warn_paramtype(p)
+        new{typeof(u0), iip, typeof(p), typeof(f), typeof(kwargs),
+            typeof(homotopy_parameter), typeof(λspan)}(
+            f, u0, p, homotopy_parameter, λspan, kwargs)
+    end
+
+    function HomotopyProblem{iip}(f, u0, p = NullParameters(); kwargs...) where {iip}
+        return HomotopyProblem{iip}(NonlinearFunction{iip}(f), u0, p; kwargs...)
+    end
+end

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -726,61 +726,73 @@ end
 @doc doc"""
 
 Defines a one-parameter homotopy nonlinear problem.
+This is the embedding / natural-parameter continuation problem type. It is unrelated to
+`HomotopyNonlinearFunction`, which supports polynomial homotopy continuation
+(e.g. via HomotopyContinuation.jl).
 
 ## Mathematical Specification of a Homotopy Problem
 
-To define a Homotopy Problem, you give the residual function ``H``
+To define a Homotopy Problem, you give the residual function ``f``
 
 ```math
-0 = H(u, p, \lambda)
+0 = f(u, p, \lambda)
 ```
 
-where ``\lambda \in \texttt{λspan}`` is the continuation parameter embedded inside `p`.
-The solver sweeps ``\lambda`` from `λspan[1]` to `λspan[2]`, warm-starting each step
-from the previous solution, performing natural-parameter continuation.
+where ``\lambda \in \texttt{λspan}`` is the scalar continuation parameter, passed to
+`f` as a separate trailing argument after the parameters `p`. A continuation solver
+sweeps ``\lambda`` from `λspan[1]` to `λspan[2]`, warm-starting each step from the
+previous solution; the target system is the one at `λspan[2]`.
 
 ## Problem Type
 
 ### Constructors
 
 ```julia
-HomotopyProblem(f::NonlinearFunction, u0, p = NullParameters(); homotopy_parameter, λspan = (0.0, 1.0), kwargs...)
-HomotopyProblem{isinplace}(f, u0, p = NullParameters(); homotopy_parameter, λspan = (0.0, 1.0), kwargs...)
+HomotopyProblem(f::NonlinearFunction, u0, p = NullParameters(); λspan = (0.0, 1.0), kwargs...)
+HomotopyProblem{isinplace}(f, u0, p = NullParameters(); λspan = (0.0, 1.0), kwargs...)
 ```
 
 `isinplace` optionally sets whether the function is in-place or not. This is
-determined automatically, but not inferred.
+determined automatically, but not inferred. The residual follows the time-dependent
+argument convention with ``\lambda`` in place of `t`:
+
+- out-of-place: `f(u, p, λ)`
+- in-place: `f(du, u, p, λ)`
 
 ### Fields
 
-* `f`: The residual `H` as a `NonlinearFunction`.
-* `u0`: The initial guess.
-* `p`: The parameters; one entry, located by `homotopy_parameter`, is ``\lambda``.
-* `homotopy_parameter`: locator (symbol or index) of ``\lambda`` within `p`.
+* `f`: The residual function, called as `f(u, p, λ)` (or `f(du, u, p, λ)` in-place).
+  Optional derivative fields of the wrapped `NonlinearFunction` (e.g. `jac`), if
+  provided, must follow the same λ-extended argument convention; continuation solvers
+  do not consume them yet.
+* `u0`: The initial guess (a solution of the simplified system at `λspan[1]`).
+* `p`: The parameters, passed through to `f` unchanged; ``\lambda`` is not part of `p`.
 * `λspan`: the `(start, stop)` continuation interval; the target system is at `stop`.
 * `kwargs`: The keyword arguments passed on to the solvers.
 """
-mutable struct HomotopyProblem{uType, isinplace, P, F, K, Λ, S} <:
-               AbstractNonlinearProblem{uType, isinplace}
+struct HomotopyProblem{uType, isinplace, P, F, K, S} <:
+    AbstractNonlinearProblem{uType, isinplace}
     f::F
     u0::uType
     p::P
-    homotopy_parameter::Λ
     λspan::S
     kwargs::K
 
     @add_kwonly function HomotopyProblem{iip}(
             f::AbstractNonlinearFunction{iip}, u0, p = NullParameters();
-            homotopy_parameter = nothing, λspan = (0.0, 1.0), kwargs...) where {iip}
+            λspan = (0.0, 1.0), kwargs...
+        ) where {iip}
         if haskey(kwargs, :p)
-            error("`p` specified as a keyword argument `p = $(kwargs[:p])` to " *
-                  "`HomotopyProblem`. This is not supported. Pass `p` as the third " *
-                  "positional argument instead.")
+            error(
+                "`p` specified as a keyword argument `p = $(kwargs[:p])` to " *
+                    "`HomotopyProblem`. This is not supported. Pass `p` as the third " *
+                    "positional argument instead."
+            )
         end
         warn_paramtype(p)
-        new{typeof(u0), iip, typeof(p), typeof(f), typeof(kwargs),
-            typeof(homotopy_parameter), typeof(λspan)}(
-            f, u0, p, homotopy_parameter, λspan, kwargs)
+        new{typeof(u0), iip, typeof(p), typeof(f), typeof(kwargs), typeof(λspan)}(
+            f, u0, p, λspan, kwargs
+        )
     end
 
     function HomotopyProblem{iip}(f, u0, p = NullParameters(); kwargs...) where {iip}
@@ -793,17 +805,19 @@ function HomotopyProblem(f::AbstractNonlinearFunction, u0, p = NullParameters();
 end
 
 function HomotopyProblem(f, u0, p = NullParameters(); kwargs...)
-    return HomotopyProblem(NonlinearFunction(f), u0, p; kwargs...)
+    # The residual takes λ as a trailing argument (like `t` for ODEs), so in-place
+    # detection follows the 4-argument convention: f(du, u, p, λ) is in-place.
+    iip = isinplace(f, 4)
+    return HomotopyProblem(NonlinearFunction{iip}(f), u0, p; kwargs...)
 end
 
 function ConstructionBase.constructorof(::Type{P}) where {P <: HomotopyProblem}
-    return function ctor(f, u0, p, homotopy_parameter, λspan, kw)
+    return function ctor(f, u0, p, λspan, kw)
         if f isa AbstractNonlinearFunction
             iip = isinplace(f)
         else
             iip = isinplace(f, 4)
         end
-        return HomotopyProblem{iip}(
-            f, u0, p; homotopy_parameter = homotopy_parameter, λspan = λspan, kw...)
+        return HomotopyProblem{iip}(f, u0, p; λspan = λspan, kw...)
     end
 end

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -787,3 +787,11 @@ mutable struct HomotopyProblem{uType, isinplace, P, F, K, Λ, S} <:
         return HomotopyProblem{iip}(NonlinearFunction{iip}(f), u0, p; kwargs...)
     end
 end
+
+function HomotopyProblem(f::AbstractNonlinearFunction, u0, p = NullParameters(); kwargs...)
+    return HomotopyProblem{isinplace(f)}(f, u0, p; kwargs...)
+end
+
+function HomotopyProblem(f, u0, p = NullParameters(); kwargs...)
+    return HomotopyProblem(NonlinearFunction(f), u0, p; kwargs...)
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -47,3 +47,14 @@ using Accessors: @reset
     @test newprob.homotopy_parameter == 2
     @test newprob.λspan == (0.0, 1.0)
 end
+
+import SymbolicIndexingInterface as SII
+
+@testset "HomotopyProblem export + inherited SII traits" begin
+    @test isdefined(SciMLBase, :HomotopyProblem)
+    @test :HomotopyProblem in names(SciMLBase)
+
+    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)   # bare name now works
+    @test SII.parameter_values(prob) == p
+    @test SII.state_values(prob) == u0
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -74,3 +74,19 @@ end
     @test rp2.homotopy_parameter == 1
     @test rp2.u0 == u0                        # unchanged
 end
+
+@testset "HomotopyProblem @reset to a raw f exercises constructorof else-branch" begin
+    # f_ode_oop is a plain (non-AbstractNonlinearFunction) 3-arg function.
+    # isinplace(f, 4) treats 3-arg as out-of-place, 4-arg as in-place.
+    # Passing it through @reset forces the else-branch of constructorof.
+    f_ode_oop(u, p, t) = [u[1] - p[1] * p[2]]
+    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    # @reset prob.f to a RAW function (not an AbstractNonlinearFunction) so the
+    # `else` branch of constructorof (isinplace(f, 4)) runs and re-wraps it.
+    newprob = @reset prob.f = f_ode_oop
+    @test newprob isa HomotopyProblem
+    @test newprob.f isa SciMLBase.NonlinearFunction       # raw f got re-wrapped
+    @test SciMLBase.isinplace(newprob) == false           # 3-arg oop ⇒ not in-place
+    @test newprob.homotopy_parameter == 2                 # preserved
+    @test newprob.λspan == (0.0, 1.0)                     # preserved
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -36,3 +36,14 @@ f_iip(du, u, p) = (du[1] = u[1] - p[1] * p[2]; nothing)
     prob2 = SciMLBase.HomotopyProblem(nf, u0, p; homotopy_parameter = 2, λspan = (0.0, 2.0))
     @test prob2.λspan == (0.0, 2.0)
 end
+
+using Accessors: @reset
+
+@testset "HomotopyProblem ConstructionBase / @reset preserves type" begin
+    prob = SciMLBase.HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    newprob = @reset prob.u0 = u0 .+ 1
+    @test typeof(newprob) == typeof(prob)
+    @test newprob.u0 == u0 .+ 1
+    @test newprob.homotopy_parameter == 2
+    @test newprob.λspan == (0.0, 1.0)
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -1,50 +1,55 @@
 using SciMLBase
 using Test
 
-# out-of-place residual H(u, p): p = [a, λ]; here a trivial linear family.
-f_oop(u, p) = [u[1] - p[1] * p[2]]
-u0 = [0.0]
-p = [2.0, 1.0]          # p[2] is λ
+# out-of-place residual f(u, p, λ): λ is a separate scalar argument, p is untouched.
+# Linear-to-quadratic family: λ=0 root u=p[1], λ=1 root u=√p[1].
+f_oop(u, p, λ) = [(1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1])]
+u0 = [2.0]
+p = [2.0]
 
 @testset "HomotopyProblem construction (explicit NonlinearFunction, oop)" begin
     nf = NonlinearFunction{false}(f_oop)
-    prob = SciMLBase.HomotopyProblem{false}(nf, u0, p; homotopy_parameter = 2)
+    prob = SciMLBase.HomotopyProblem{false}(nf, u0, p)
     @test prob isa SciMLBase.HomotopyProblem
     @test prob isa SciMLBase.AbstractNonlinearProblem
     @test prob.f === nf
     @test prob.u0 == u0
     @test prob.p == p
-    @test prob.homotopy_parameter == 2
     @test prob.λspan == (0.0, 1.0)
     @test SciMLBase.isinplace(prob) == false
 end
 
-f_iip(du, u, p) = (du[1] = u[1] - p[1] * p[2]; nothing)
+f_iip(du, u, p, λ) = (du[1] = (1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1]); nothing)
 
 @testset "HomotopyProblem outer constructors (raw function, oop + iip autodetect)" begin
-    # raw out-of-place function: isinplace must autodetect false
-    prob_oop = SciMLBase.HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    # raw out-of-place f(u, p, λ): 3 args ⇒ isinplace(f, 4) detects false
+    prob_oop = SciMLBase.HomotopyProblem(f_oop, u0, p)
     @test SciMLBase.isinplace(prob_oop) == false
     @test prob_oop.f isa SciMLBase.NonlinearFunction
 
-    # raw in-place function: isinplace must autodetect true
-    prob_iip = SciMLBase.HomotopyProblem(f_iip, u0, p; homotopy_parameter = 2)
+    # raw in-place f(du, u, p, λ): 4 args ⇒ isinplace(f, 4) detects true
+    prob_iip = SciMLBase.HomotopyProblem(f_iip, u0, p)
     @test SciMLBase.isinplace(prob_iip) == true
+
+    # p needs no particular structure anymore: NamedTuple works
+    prob_nt = SciMLBase.HomotopyProblem(
+        (u, p, λ) -> [(1 - λ) * (u[1] - p.c) + λ * (u[1]^2 - p.c)], u0, (c = 2.0,)
+    )
+    @test prob_nt.p == (c = 2.0,)
 
     # explicit AbstractNonlinearFunction, no {iip} given
     nf = NonlinearFunction{false}(f_oop)
-    prob2 = SciMLBase.HomotopyProblem(nf, u0, p; homotopy_parameter = 2, λspan = (0.0, 2.0))
+    prob2 = SciMLBase.HomotopyProblem(nf, u0, p; λspan = (0.0, 2.0))
     @test prob2.λspan == (0.0, 2.0)
 end
 
 using Accessors: @reset
 
 @testset "HomotopyProblem ConstructionBase / @reset preserves type" begin
-    prob = SciMLBase.HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    prob = SciMLBase.HomotopyProblem(f_oop, u0, p)
     newprob = @reset prob.u0 = u0 .+ 1
     @test typeof(newprob) == typeof(prob)
     @test newprob.u0 == u0 .+ 1
-    @test newprob.homotopy_parameter == 2
     @test newprob.λspan == (0.0, 1.0)
 end
 
@@ -54,39 +59,33 @@ import SymbolicIndexingInterface as SII
     @test isdefined(SciMLBase, :HomotopyProblem)
     @test :HomotopyProblem in names(SciMLBase)
 
-    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)   # bare name now works
+    prob = HomotopyProblem(f_oop, u0, p)
     @test SII.parameter_values(prob) == p
     @test SII.state_values(prob) == u0
 end
 
 @testset "HomotopyProblem remake" begin
-    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
-    rp = SciMLBase.remake(prob; u0 = [5.0], p = [3.0, 0.5])
+    prob = HomotopyProblem(f_oop, u0, p)
+    rp = SciMLBase.remake(prob; u0 = [5.0], p = [3.0])
     @test rp isa HomotopyProblem
     @test rp.u0 == [5.0]
-    @test rp.p == [3.0, 0.5]
-    @test rp.homotopy_parameter == 2          # preserved
+    @test rp.p == [3.0]
     @test rp.λspan == (0.0, 1.0)              # preserved
     @test SciMLBase.isinplace(rp) == false
 
-    rp2 = SciMLBase.remake(prob; λspan = (0.0, 2.0), homotopy_parameter = 1)
+    rp2 = SciMLBase.remake(prob; λspan = (0.0, 2.0))
     @test rp2.λspan == (0.0, 2.0)
-    @test rp2.homotopy_parameter == 1
     @test rp2.u0 == u0                        # unchanged
 end
 
 @testset "HomotopyProblem @reset to a raw f exercises constructorof else-branch" begin
-    # f_ode_oop is a plain (non-AbstractNonlinearFunction) 3-arg function.
-    # isinplace(f, 4) treats 3-arg as out-of-place, 4-arg as in-place.
-    # Passing it through @reset forces the else-branch of constructorof.
-    f_ode_oop(u, p, t) = [u[1] - p[1] * p[2]]
-    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
-    # @reset prob.f to a RAW function (not an AbstractNonlinearFunction) so the
-    # `else` branch of constructorof (isinplace(f, 4)) runs and re-wraps it.
-    newprob = @reset prob.f = f_ode_oop
+    # a plain 3-arg function f(u, p, λ) — not an AbstractNonlinearFunction —
+    # forces the else-branch of constructorof: isinplace(f, 4) ⇒ out-of-place.
+    f_raw(u, p, λ) = [(1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1])]
+    prob = HomotopyProblem(f_oop, u0, p)
+    newprob = @reset prob.f = f_raw
     @test newprob isa HomotopyProblem
     @test newprob.f isa SciMLBase.NonlinearFunction       # raw f got re-wrapped
-    @test SciMLBase.isinplace(newprob) == false           # 3-arg oop ⇒ not in-place
-    @test newprob.homotopy_parameter == 2                 # preserved
+    @test SciMLBase.isinplace(newprob) == false
     @test newprob.λspan == (0.0, 1.0)                     # preserved
 end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -18,3 +18,21 @@ p = [2.0, 1.0]          # p[2] is λ
     @test prob.λspan == (0.0, 1.0)
     @test SciMLBase.isinplace(prob) == false
 end
+
+f_iip(du, u, p) = (du[1] = u[1] - p[1] * p[2]; nothing)
+
+@testset "HomotopyProblem outer constructors (raw function, oop + iip autodetect)" begin
+    # raw out-of-place function: isinplace must autodetect false
+    prob_oop = SciMLBase.HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    @test SciMLBase.isinplace(prob_oop) == false
+    @test prob_oop.f isa SciMLBase.NonlinearFunction
+
+    # raw in-place function: isinplace must autodetect true
+    prob_iip = SciMLBase.HomotopyProblem(f_iip, u0, p; homotopy_parameter = 2)
+    @test SciMLBase.isinplace(prob_iip) == true
+
+    # explicit AbstractNonlinearFunction, no {iip} given
+    nf = NonlinearFunction{false}(f_oop)
+    prob2 = SciMLBase.HomotopyProblem(nf, u0, p; homotopy_parameter = 2, λspan = (0.0, 2.0))
+    @test prob2.λspan == (0.0, 2.0)
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -58,3 +58,19 @@ import SymbolicIndexingInterface as SII
     @test SII.parameter_values(prob) == p
     @test SII.state_values(prob) == u0
 end
+
+@testset "HomotopyProblem remake" begin
+    prob = HomotopyProblem(f_oop, u0, p; homotopy_parameter = 2)
+    rp = SciMLBase.remake(prob; u0 = [5.0], p = [3.0, 0.5])
+    @test rp isa HomotopyProblem
+    @test rp.u0 == [5.0]
+    @test rp.p == [3.0, 0.5]
+    @test rp.homotopy_parameter == 2          # preserved
+    @test rp.λspan == (0.0, 1.0)              # preserved
+    @test SciMLBase.isinplace(rp) == false
+
+    rp2 = SciMLBase.remake(prob; λspan = (0.0, 2.0), homotopy_parameter = 1)
+    @test rp2.λspan == (0.0, 2.0)
+    @test rp2.homotopy_parameter == 1
+    @test rp2.u0 == u0                        # unchanged
+end

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -1,0 +1,20 @@
+using SciMLBase
+using Test
+
+# out-of-place residual H(u, p): p = [a, λ]; here a trivial linear family.
+f_oop(u, p) = [u[1] - p[1] * p[2]]
+u0 = [0.0]
+p = [2.0, 1.0]          # p[2] is λ
+
+@testset "HomotopyProblem construction (explicit NonlinearFunction, oop)" begin
+    nf = NonlinearFunction{false}(f_oop)
+    prob = SciMLBase.HomotopyProblem{false}(nf, u0, p; homotopy_parameter = 2)
+    @test prob isa SciMLBase.HomotopyProblem
+    @test prob isa SciMLBase.AbstractNonlinearProblem
+    @test prob.f === nf
+    @test prob.u0 == u0
+    @test prob.p == p
+    @test prob.homotopy_parameter == 2
+    @test prob.λspan == (0.0, 1.0)
+    @test SciMLBase.isinplace(prob) == false
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,9 @@ end
         @time @safetestset "Problem building tests" begin
             include("problem_building_test.jl")
         end
+        @time @safetestset "HomotopyProblem tests" begin
+            include("homotopy_problem_tests.jl")
+        end
         @time @safetestset "Serialization tests" begin
             include("serialization_tests.jl")
         end


### PR DESCRIPTION
## Summary

Adds `HomotopyProblem <: AbstractNonlinearProblem`, a problem type describing a one-parameter homotopy / continuation family

```
0 = H(u, p, λ)
```

in which one parameter inside `p` is a continuation knob `λ`. It is the natural-parameter-continuation analogue of `NonlinearProblem`: a solver sweeps `λ` across `λspan` (default `0 → 1`), deforming an easy-to-solve system into the target. This is the interface type targeted by a continuation solver (`HomotopySweep`, NonlinearSolve.jl) and by symbolic frontends (the Modelica `homotopy()` operator in ModelingToolkit.jl).

It does **not** describe a polynomial system — that is the existing `HomotopyNonlinearFunction` / `HomotopyContinuationJL`, which this PR leaves untouched.

## API

```julia
HomotopyProblem(f, u0, p = NullParameters(); homotopy_parameter, λspan = (0.0, 1.0), kwargs...)
```

- `f` — the residual `H` as a `NonlinearFunction` (`f(u, p)` out-of-place or `f(du, u, p)` in-place); `λ` lives inside `p`.
- `homotopy_parameter` — which parameter is `λ`: a symbolic parameter (resolved through SymbolicIndexingInterface) or an integer index into `p`.
- `λspan` — the continuation interval; the target system is at `stop`.

It mirrors `NonlinearProblem` exactly: `@add_kwonly` inner constructor, raw-function wrapping with `isinplace` autodetection, and `ConstructionBase.constructorof` so `@reset` / `remake` preserve the parametrized type. The SymbolicIndexingInterface surface is inherited from `AbstractNonlinearProblem` with no overrides.

`HomotopyProblem` is also added to the accepted-type set of `OverrideInitData`, so it can serve as an initialization problem.

## Tests

`test/homotopy_problem_tests.jl` (Core group): construction (explicit `NonlinearFunction` and raw function with iip autodetection), `@reset` type preservation, export visibility, inherited `parameter_values`/`state_values`, and `remake` field preservation. The full `Core` group passes.

## Part of a series

First of three coordinated PRs implementing Modelica's `homotopy(actual, simplified)` operator (spec 3.7.4) for initialization across the SciML stack:

1. **(this PR) SciMLBase** — the `HomotopyProblem` interface type.
2. **NonlinearSolve** — `HomotopySweep`, an MTK-independent natural-parameter continuation solver dispatching on `HomotopyProblem`.
3. **ModelingToolkit** — lower `homotopy(actual, simplified)` into a `HomotopyProblem` and target `HomotopySweep`.

Each is independently reviewable; (2) and (3) depend on this one being released first.
