### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -16,8 +16,8 @@ jobs:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
+      julia-version: "lts"
       # DifferentiationInterface is skipped: DI 0.6-0.7 requires ADTypes >= ~1.6,
       # but julia-downgrade-compat would pin ADTypes to 1.0.0 (minimum of compat "1"),
-      skip: "Pkg,TOML,DifferentiationInterface"
+      skip: "DifferentiationInterface"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot@v1` workflow (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`. Not a monorepo (no `lib/`), so single-package form only.
- **Downgrade**: removed the stdlib entries `Pkg,TOML` from the `skip:` input (the centralized workflow now auto-populates stdlibs + in-repo sublibs + caller package); kept the genuine extra `DifferentiationInterface`. Changed `julia-version: "1.10"` to `"lts"`.

Ignore until reviewed by @ChrisRackauckas.
