### PR TITLE
Fix(ad): accesing per-trajectory fields

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -480,6 +480,7 @@ end
 
 __getindex(x, i) = x[i]
 __getindex(x::AbstractVectorOfArray, i) = x.u[i]
+__getindex(x::AbstractEnsembleSolution, i) = __getindex(x.u, i)
 
 function responsible_map(f, II...)
     batch_data = Vector{

--- a/test/downstream/ensemble_lossfn.jl
+++ b/test/downstream/ensemble_lossfn.jl
@@ -1,0 +1,130 @@
+using OrdinaryDiffEq, SciMLBase, SciMLSensitivity, Test
+using DifferentiationInterface
+using ADTypes
+using ForwardDiff: ForwardDiff
+using Zygote: Zygote
+
+# Regression test for differentiating an EnsembleProblem when the loss iterates
+# per-trajectory solution fields (`for s in sol.u`).
+#
+# The bug was in `__getindex(::AbstractEnsembleSolution, i)` returning a scalar
+# instead of the i-th trajectory's array cotangent during the reverse pass
+# through `responsible_map` / `tmap`. The fault lives in the Zygote extension
+# (`SciMLBaseZygoteExt`), so this test targets Zygote and cross-checks against a
+# ForwardDiff ground truth. See SciML/SciMLSensitivity.jl#1478.
+
+# Reverse-mode AD backends to validate. Typed abstractly so more can be appended.
+const REVERSE_BACKENDS = ADTypes.AbstractADType[AutoZygote()]
+# Ground-truth backend (independent of the reverse-mode ensemble adjoint path).
+const FORWARD_BACKEND = AutoForwardDiff()
+
+# Adjoint sensitivity algorithms to validate. The fix is sensealg-independent;
+# every entry should give the same gradient.
+const SENSEALGS = [
+    ("automatic", nothing),
+    ("GaussAdjoint", GaussAdjoint(autojacvec=ReverseDiffVJP())),
+    ("QuadratureAdjoint", QuadratureAdjoint(autojacvec=ReverseDiffVJP())),
+]
+
+const ENSEMBLE_ALGS = [
+    ("EnsembleSerial", EnsembleSerial()),
+    ("EnsembleThreads", EnsembleThreads()),
+]
+
+backend_name(b::ADTypes.AbstractADType) = string(typeof(b).name.name)
+
+@testset "Ensemble per-trajectory loss AD (#1478)" begin
+    A = [1.0 2.0; 3.0 4.0]
+    n_traj = 4
+    tspan = (0.0, 1.0)
+
+    prob_func(prob, ctx) = remake(prob, u0=(1.0 + ctx.sim_id / 10) .* prob.u0)
+
+    function build(p)
+        prob = ODEProblem((u, p, t) -> p[1] .* (A * u), [1.0, 1.0], tspan, p)
+        return EnsembleProblem(prob; prob_func=prob_func)
+    end
+
+    # `Array(sol)` is the always-worked path; the others iterate `sol.u` and read
+    # per-trajectory fields (the patterns that triggered the BoundsError).
+    function loss_array(p; ealg, sensealg)
+        sol = solve(build(p), Tsit5(), ealg; trajectories=n_traj,
+            saveat=0.25, sensealg=sensealg)
+        return sum(abs2, Array(sol))
+    end
+
+    function loss_sum_all(p; ealg, sensealg)
+        sol = solve(build(p), Tsit5(), ealg; trajectories=n_traj,
+            saveat=0.25, sensealg=sensealg)
+        return sum(sum(sum, s.u) for s in sol.u)
+    end
+
+    function loss_per_traj_end(p; ealg, sensealg)
+        sol = solve(build(p), Tsit5(), ealg; trajectories=n_traj,
+            saveat=0.25, sensealg=sensealg)
+        return sum(sum(abs2, s.u[end]) for s in sol.u)
+    end
+
+    p0 = [1.0]
+
+    losses = [
+        ("Array(sol)", loss_array),
+        ("sum over s.u", loss_sum_all),
+        ("per-trajectory s.u[end]", loss_per_traj_end),
+    ]
+
+    # ForwardDiff ground truth (uses a representative sensealg; value is
+    # sensealg-independent for these smooth losses).
+    ref_sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP())
+    refs = Dict(
+        name => DifferentiationInterface.gradient(
+            p -> lossf(p; ealg=EnsembleSerial(), sensealg=ref_sensealg),
+            FORWARD_BACKEND, p0)
+        for (name, lossf) in losses
+    )
+
+    @testset "$(backend_name(backend))" for backend in REVERSE_BACKENDS
+        @testset "$ealgname" for (ealgname, ealg) in ENSEMBLE_ALGS
+            @testset "$saname" for (saname, sa) in SENSEALGS
+                @testset "$lname" for (lname, lossf) in losses
+                    g = DifferentiationInterface.gradient(
+                        p -> lossf(p; ealg=ealg, sensealg=sa), backend, p0)
+                    @test g !== nothing
+                    @test g ≈ refs[lname] rtol = 1e-4
+                end
+            end
+        end
+    end
+
+    # Callback case (ragged trajectories via terminate!). `Array(sol)` is invalid
+    # here because trajectories end at different times, so only per-trajectory
+    # access patterns are tested.
+    @testset "with ContinuousCallback + terminate!" begin
+        condition(u, t, integrator) = u[1] - 3.0
+        cb = ContinuousCallback(condition, terminate!; save_positions=(false, true))
+
+        function loss_cb(p; ealg, sensealg)
+            sol = solve(build(p), Tsit5(), ealg; trajectories=n_traj,
+                sensealg=sensealg, callback=cb)
+            return sum(sum(abs2, s.u[end]) for s in sol.u)
+        end
+
+        @testset "$(backend_name(backend))" for backend in REVERSE_BACKENDS
+            @testset "$ealgname" for (ealgname, ealg) in ENSEMBLE_ALGS
+                @testset "$saname" for (saname, sa) in SENSEALGS
+                    # With a `terminate!` callback the gradient also flows through
+                    # the (near-zero here) event-time sensitivity, and different
+                    # adjoint methods resolve that with differing accuracy. The
+                    # point of this case is that the per-trajectory cotangent is
+                    # routed at all (the original bug threw a BoundsError), so we
+                    # only assert a finite gradient is produced rather than a
+                    # strict match against ForwardDiff.
+                    g = DifferentiationInterface.gradient(
+                        p -> loss_cb(p; ealg = ealg, sensealg = sa), backend, p0)
+                    @test g !== nothing
+                    @test all(isfinite, g)
+                end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,13 +7,13 @@ const is_APPVEYOR = (Sys.iswindows() && haskey(ENV, "APPVEYOR"))
 
 function activate_downstream_env()
     Pkg.activate("downstream")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 
 function activate_python_env()
     Pkg.activate("python")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
     return Pkg.instantiate()
 end
 
@@ -72,7 +72,7 @@ end
     end
 
     if !is_APPVEYOR &&
-            (GROUP == "Core" || GROUP == "All" || GROUP == "SymbolicIndexingInterface")
+       (GROUP == "Core" || GROUP == "All" || GROUP == "SymbolicIndexingInterface")
         @time @safetestset "Remake" begin
             include("remake_tests.jl")
         end
@@ -139,6 +139,9 @@ end
         end
         @time @safetestset "Scalar RODESolution calculate_solution_errors!" begin
             include("downstream/rode_calculate_solution_errors.jl")
+        end
+        @time @safetestset "Ensemble per-trajectory loss AD" begin
+            include("downstream/ensemble_lossfn.jl")
         end
     end
 


### PR DESCRIPTION
The issue arises when trying to iterate sol.u and read per-trajectory fields on a loss fn. Zygote reverse pass produces a cotangent for the ensemble that is an EnsembleSolution that wraps a 3D VectorOfArray, and when calling getindex it yields a scalar value. using Array(sol) bypasses this and works.

The error was

```julia
ERROR: LoadError: BoundsError: attempt to access Tuple{} at index [0]
Stacktrace:
  [1] getindex(t::Tuple, i::Int64)
    @ Base ./tuple.jl:31
  [2] (::SciMLSensitivity.var"#df_iip#338"{Float32, Colon})(_out::Vector{Float32}, u::Vector{Float32}, p::ComponentVector{Float32, Vector{Float32}, Tuple{Axis{(weight = ViewAxis(1:16, ShapedAxis((4, 4))), bias = ViewAxis(17:20, Shaped1DAxis((4,))))}}}, t::Float32, i::Int64)
    @ SciMLSensitivity ~/.julia/packages/SciMLSensitivity/9RPKK/src/concrete_solve.jl:839
  [3] ReverseLossCallback
    @ ~/.julia/packages/SciMLSensitivity/9RPKK/src/adjoint_common.jl:744 [inlined]
...
```

The cotangent Δ that arrives at ∇responsible_map_internal is:

```julia
Δ :: EnsembleSolution{Float32, 1, VectorOfArray{Float32, 3, Vector{DiffEqArray{...}}}}
Δ.u :: VectorOfArray{Float32, 3, Vector{DiffEqArray{...}}}
Δ.u.u :: Vector{DiffEqArray{...}}   # length = n_traj, one per trajectory
Δ.u.u[i] :: DiffEqArray{...}        # trajectory i's cotangent (state × time)
```

This PR adds a case for `__getIndex` that fixes this issue. It also provides downstream tests for it. All Core and Downstream (except `Autodiff Remake` which failed before the update) tests passing.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Closes https://github.com/SciML/SciMLSensitivity.jl/issues/1478

Probably related to https://github.com/SciML/SciMLBase.jl/pull/1347
