### PR TITLE
Fix getproperty(::NonlinearProblem) rrule to emit full-width cotangents

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -225,21 +225,24 @@ end
 # `back` explicitly while already in a reverse pass causing a nested gradient call. The mutable struct
 # causes accumulation anytime `getfield/property` is called, accumulating multiple times. This tries to treat
 # AbstractDEProblem as immutable for the purposes of reverse mode AD.
+#
+# The cotangent must be a `Tangent` (not a single-field `NamedTuple`): Zygote canonicalizes
+# `Tangent`s to full-width NamedTuples over all struct fields, whereas a partial NamedTuple
+# like `(p = dp,)` cannot be `Zygote.accum`ed with cotangents for the same problem coming
+# from other pullbacks (which are full-width), throwing
+# `ArgumentError: ... keys must be a subset of ... keys`.
 function ChainRulesCore.rrule(
         ::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
         ::typeof(Base.getproperty), x::NonlinearProblem, f::Symbol
     )
     val = getfield(x, f)
     function back(der)
-        dx = if der === nothing
-            ChainRulesCore.zero_tangent(x)
+        dx = if der === nothing || der isa ChainRulesCore.AbstractZero
+            ChainRulesCore.ZeroTangent()
         else
-            NamedTuple{(f,)}((der,))
+            ChainRulesCore.Tangent{typeof(x)}(; NamedTuple{(f,)}((der,))...)
         end
-        return (
-            ChainRulesCore.NoTangent(), ChainRulesCore.ProjectTo(x)(dx),
-            ChainRulesCore.NoTangent(),
-        )
+        return (ChainRulesCore.NoTangent(), dx, ChainRulesCore.NoTangent())
     end
     return val, back
 end

--- a/test/nonlinearproblem_zygote.jl
+++ b/test/nonlinearproblem_zygote.jl
@@ -1,0 +1,43 @@
+using SciMLBase, Test
+using Zygote
+
+# The `getproperty(::NonlinearProblem)` rrule must emit full-width cotangents.
+# Partial NamedTuples like `(p = dp,)` cannot be `Zygote.accum`ed with
+# cotangents for the same problem coming from other pullbacks, throwing
+# `ArgumentError: ... keys must be a subset of ... keys`.
+# https://github.com/SciML/SciMLBase.jl test/downstream/remake_autodiff.jl hit
+# this via `remake(::ODEProblem)` -> trivial initialization of the MTK
+# initialization `NonlinearProblem`.
+
+fnl(u, p) = u .^ 2 .- p
+
+@testset "getproperty(::NonlinearProblem) cotangent shape" begin
+    prob = NonlinearProblem{false}(NonlinearFunction{false}(fnl), [1.0, 2.0], [3.0, 4.0])
+    _, back = Zygote.pullback(p -> getproperty(p, :p), prob)
+    dprob = back(ones(2))[1]
+    @test dprob isa NamedTuple
+    @test keys(dprob) == fieldnames(NonlinearProblem)
+    @test dprob.p == ones(2)
+end
+
+@testset "accumulating cotangents from different fields" begin
+    prob = NonlinearProblem{false}(NonlinearFunction{false}(fnl), [1.0, 2.0], [3.0, 4.0])
+
+    # reads two different fields of the same problem (remake reads kwargs,
+    # problem_type, lb, ub; user code reads p)
+    function loss(p)
+        prob2 = NonlinearProblem{false}(NonlinearFunction{false}(fnl), [1.0, 2.0], p)
+        prob3 = SciMLBase.remake(prob2; u0 = [2.0, 3.0])
+        return sum(prob3.p) + sum(prob2.p)
+    end
+    @test Zygote.gradient(loss, [3.0, 4.0])[1] == [2.0, 2.0]
+
+    # two remakes of the same problem
+    function loss2(p)
+        prob2 = NonlinearProblem{false}(NonlinearFunction{false}(fnl), [1.0, 2.0], p)
+        prob3 = SciMLBase.remake(prob2; u0 = [2.0, 3.0])
+        prob4 = SciMLBase.remake(prob2; u0 = [4.0, 5.0])
+        return sum(prob3.p) + sum(prob4.p)
+    end
+    @test Zygote.gradient(loss2, [3.0, 4.0])[1] == [2.0, 2.0]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,6 +69,9 @@ end
         @time @safetestset "Callback constructors" begin
             include("callback_constructors.jl")
         end
+        @time @safetestset "NonlinearProblem Zygote cotangents" begin
+            include("nonlinearproblem_zygote.jl")
+        end
     end
 
     if !is_APPVEYOR &&


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Fixes the `test/downstream/remake_autodiff.jl` ("`split = false`") failure currently on master (also visible as the red Downstream CI on master):

```
ArgumentError: @NamedTuple{f::Nothing, u0::Nothing, p::Vector{Float64}, problem_type::Nothing, lb::Nothing, ub::Nothing, kwargs::Nothing} keys must be a subset of @NamedTuple{p::Vector{Float64}} keys
```

## Root cause

The `getproperty(::NonlinearProblem)` rrule in `SciMLBaseChainRulesCoreExt` returned a single-field NamedTuple like `(p = dp,)` as the problem cotangent. `Zygote.accum` cannot combine such partial NamedTuples with full-width cotangents for the same problem produced by other pullbacks (or with a partial for a *different* field) — it requires one side's keys to be a subset of the other's and throws the `ArgumentError` above otherwise.

This was latent until ModelingToolkitBase 1.42.0 changed `initializeprobmap` (SciML/ModelingToolkit.jl commit 5236ce3d7), after which the trivial-initialization `NonlinearProblem` receives cotangents from two pullback paths in `SciMLBase.get_initial_values` during Zygote differentiation of `remake`d MTK `ODEProblem`s — i.e. the failure is exposed by a dependency update, not by a SciMLBase commit (the same SciMLBase v3.17.0 source fails with current deps, verified).

## Fix

Return a `Tangent{typeof(x)}` instead: Zygote canonicalizes `Tangent`s to full-width NamedTuples over all struct fields, which accumulate cleanly in any order. A `der === nothing` / `AbstractZero` cotangent now returns `ZeroTangent()` instead of `zero_tangent(x)`, since a `MutableTangent` also cannot be accumulated with NamedTuple cotangents.

## How this was pinned down

- The partial-NamedTuple rrule was introduced in `aced3e87b` (Jul 2025, v2.103.1) but stayed latent.
- CI archaeology: the LTS Downstream "Autodiff Remake" job was 6-pass/1-broken through the May 31 run and first failed June 1 (v3.17.0); the only dependency delta was ModelingToolkitBase 1.41.0 → 1.42.0. The SciMLBase code delta in that window was unrelated (ForwardDiff ext only) — in particular this is **not** caused by the v3.18.0 `lb`/`ub` remake changes (v3.17.0 source + current Manifest fails identically).
- Direct trigger confirmation: unfixed master + ModelingToolkitBase pinned to 1.41.0 **passes** with gradients identical to the fixed run; unfixed master + 1.42.x fails.
- Why CI didn't flag it loudly: the Downstream group runs with `continue_on_error = true`, and the Julia "1"/"pre" jobs skip this testset (`VERSION < v"1.12"` gate — only the LTS job runs it).

## Verification

- Minimal repro (MTK lotka-volterra + `remake` + `BacksolveAdjoint(autojacvec=ZygoteVJP())` via DI `AutoZygote`, extracted from the failing testset): fails on unmodified master, succeeds with this fix.
- New unit tests (`test/nonlinearproblem_zygote.jl`) covering cotangent shape and multi-field/multi-remake accumulation: pass on Julia 1.10, 1.11, and 1.12.
- Full `remake_autodiff.jl` "`split = false`" downstream testset passes with the fix (see CI / verification log).

Related: #1381 (ensemble Zygote adjoint fixes) documents encountering this same failure on master while validating that PR; the two PRs are independent.

Side note for maintainers: the same partial-cotangent hazard would apply to `NonlinearLeastSquaresProblem` if it ever gains a similar `getproperty` rrule (it currently has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
