### PR TITLE
Fix Zygote ensemble adjoints (RAT v4 cotangent iteration + mutable-problem over-counting) and remove __getindex

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -13,6 +13,33 @@ using SymbolicIndexingInterface: symbolic_type, NotSymbolic, variable_index, is_
 using RecursiveArrayTools
 import SciMLStructures
 
+# SciML problem types are mutable structs, so Zygote routes their field-access
+# cotangents through the per-`Context` mutable-struct accumulator (`grad_mut`),
+# keyed on the problem instance. That accumulator is shared across all pullback
+# invocations of one context, so when several independent pullbacks read fields
+# of the *same* problem (one per trajectory in the ensemble `tmap`/
+# `responsible_map` adjoints below) and their structural tangents are then
+# `accum`ed, each tangent carries a snapshot of the *running* accumulator and the
+# earlier trajectories' contributions are double-counted. (Zygote's Ref-identity
+# protocol that normally prevents this is broken as soon as the cotangent is
+# materialized at a ChainRules boundary, which the per-trajectory solve rrules
+# guarantee.) Treat problems as immutable for reverse-mode AD instead, mirroring
+# the `getproperty(::NonlinearProblem)` rrule in SciMLBaseChainRulesCoreExt.
+# Scoped to `AbstractDEProblem` so that `AbstractNonlinearProblem` keeps its
+# existing behavior — its nested-AD path already produces partial-`NamedTuple`
+# problem cotangents (the `getproperty` rrule in the ChainRulesCore ext), which
+# this full-`NamedTuple` pullback would collide with in `Zygote.accum`.
+@adjoint function Zygote.literal_getfield(
+        prob::SciMLBase.AbstractDEProblem, ::Val{f}
+    ) where {f}
+    val = getfield(prob, f)
+    function problem_literal_getfield_pullback(Δ)
+        Zygote.accum_param(__context__, val, Δ) === nothing && return (nothing, nothing)
+        ((; Zygote.nt_nothing(prob)..., Zygote.pair(Val(f), Δ, prob)...), nothing)
+    end
+    val, problem_literal_getfield_pullback
+end
+
 @adjoint function SciMLBase.remake(prob::ODEFunction; kw...)
     y = remake(prob; kw...)
     function odefunction_remake_back(Δ)
@@ -270,6 +297,20 @@ end
     sol.u, solu_adjoint
 end
 
+# Under RecursiveArrayTools v4, `AbstractVectorOfArray` (including
+# `EnsembleSolution` and `VectorOfArray`) is an `AbstractArray` whose iteration
+# yields scalars in column-major order. Cotangents for `tmap`/`responsible_map`
+# outputs can arrive wrapped in those containers (e.g. from the
+# `EnsembleSolution` constructor adjoint above), so they must be unwrapped to
+# the plain vector of per-element tangents before zipping them with the
+# pullbacks.
+function unwrap_map_cotangent(Δ)
+    while Δ isa RecursiveArrayTools.AbstractVectorOfArray
+        Δ = Δ.u
+    end
+    return Δ
+end
+
 function ∇tmap(cx, f, args...)
     ys_and_backs = SciMLBase.tmap((args...) -> Zygote._pullback(cx, f, args...), args...)
     return if isempty(ys_and_backs)
@@ -277,6 +318,7 @@ function ∇tmap(cx, f, args...)
     else
         ys, backs = Zygote.unzip(ys_and_backs)
         function ∇tmap_internal(Δ)
+            Δ = unwrap_map_cotangent(Δ)
             Δf_and_args_zipped = SciMLBase.tmap((f, δ) -> f(δ), backs, Δ)
             Δf_and_args = Zygote.unzip(Δf_and_args_zipped)
             Δf = reduce(Zygote.accum, Δf_and_args[1])
@@ -297,6 +339,7 @@ function ∇responsible_map(cx, f, args...)
         ys, backs = Zygote.unzip(ys_and_backs)
         ys,
             function ∇responsible_map_internal(Δ)
+                Δ = unwrap_map_cotangent(Δ)
                 # Apply pullbacks in reverse order. Needed for correctness if `f` is stateful.
                 Δf_and_args_zipped = SciMLBase.responsible_map(
                     (f, δ) -> f(δ),

--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -478,20 +478,17 @@ function solve_batch(
     return tighten_container_eltype(batch_data)
 end
 
-__getindex(x, i) = x[i]
-__getindex(x::AbstractVectorOfArray, i) = x.u[i]
-
 function responsible_map(f, II...)
     batch_data = Vector{
         Core.Compiler.return_type(
-            f, Tuple{ntuple(i -> typeof(__getindex(II[i], 1)), Val(length(II)))...}
+            f, Tuple{ntuple(i -> typeof(II[i][1]), Val(length(II)))...}
         ),
     }(
         undef,
         length(II[1])
     )
     for i in 1:length(II[1])
-        batch_data[i] = f(ntuple(ii -> __getindex(II[ii], i), Val(length(II)))...)
+        batch_data[i] = f(ntuple(ii -> II[ii][i], Val(length(II)))...)
     end
     return batch_data
 end

--- a/test/downstream/ensemble_adjoints.jl
+++ b/test/downstream/ensemble_adjoints.jl
@@ -1,0 +1,86 @@
+using OrdinaryDiffEq, SciMLBase, SciMLSensitivity, Test
+using ForwardDiff: ForwardDiff
+
+# Zygote has compatibility issues on Julia 1.12+
+if VERSION >= v"1.12"
+    @info "Skipping ensemble adjoint tests on Julia 1.12+ due to AD compatibility issues"
+    @testset "Ensemble adjoints (skipped on Julia 1.12+)" begin
+        @test_skip false
+    end
+else
+    using Zygote
+
+    # Gradient correctness of AD through ensemble solves (SciML/SciMLSensitivity.jl#1478).
+    # Two historical failure modes are covered:
+    #   1. A `BoundsError` from `map`ing pullbacks over an `EnsembleSolution`/
+    #      `VectorOfArray`-wrapped cotangent, which iterates scalars under
+    #      RecursiveArrayTools v4.
+    #   2. Silent gradient over-counting from Zygote's shared mutable-struct
+    #      accumulator when the trajectory pullbacks read fields of the shared
+    #      `ODEProblem`. Loss-decrease checks cannot catch this (the gradient is
+    #      wrong only by trajectory-dependent positive factors), so these tests
+    #      compare against ForwardDiff on per-trajectory reference solves.
+    f_ens = (u, p, t) -> p .* u
+    condition = (u, t, integrator) -> 0.5 - u[2]
+    cb = ContinuousCallback(condition, terminate!)
+    u0 = [1.0, 0.1]
+    tspan = (0.0, 1.0)
+    p0 = [1.0, 2.0]
+    B = 3
+    u0s = [Float64(i) .* u0 for i in 1:B]
+
+    function ensemble_loss(p; ensalg, sensealg, callback = nothing, dense = false)
+        prob = ODEProblem{false}(f_ens, u0, tspan, p)
+        eprob = EnsembleProblem(
+            prob;
+            prob_func = (prob, ctx) -> remake(prob; u0 = u0s[ctx.sim_id]),
+            safetycopy = false
+        )
+        kw = dense ? (; saveat = 0.1) : (;)
+        sol = solve(
+            eprob, Tsit5(), ensalg; trajectories = B, callback,
+            abstol = 1.0e-10, reltol = 1.0e-10, sensealg, kw...
+        )
+        return if dense
+            sum(abs2, Array(sol))
+        else
+            sum(abs2, reduce(hcat, [s.u[end] for s in sol.u]))
+        end
+    end
+
+    function reference_loss(p; callback = nothing, dense = false)
+        tot = zero(eltype(p))
+        for i in 1:B
+            prob = ODEProblem{false}(f_ens, u0s[i], tspan, p)
+            kw = dense ? (; saveat = 0.1) : (;)
+            s = solve(prob, Tsit5(); callback, abstol = 1.0e-10, reltol = 1.0e-10, kw...)
+            tot += dense ? sum(abs2, Array(s)) : sum(abs2, s.u[end])
+        end
+        return tot
+    end
+
+    @testset "ensalg = $(nameof(typeof(ensalg))), sensealg = $(nameof(typeof(sensealg)))" for ensalg in (
+                EnsembleSerial(), EnsembleThreads(),
+            ),
+            sensealg in (
+                GaussAdjoint(autojacvec = ReverseDiffVJP()),
+                QuadratureAdjoint(autojacvec = ReverseDiffVJP()),
+                InterpolatingAdjoint(autojacvec = ReverseDiffVJP()),
+            )
+
+        # `dense = true` (a `saveat` grid + `Array(sol)`) is not combined with the
+        # `terminate!` callback: early termination leaves the trajectories short of
+        # the `saveat` grid, which is unsupported for discrete-cost adjoints
+        # (SciMLSensitivity warns "Endpoints do not match").
+        @testset "callback = $(callback !== nothing), dense = $dense" for (callback, dense) in (
+                (nothing, false), (cb, false), (nothing, true),
+            )
+
+            gfd = ForwardDiff.gradient(p -> reference_loss(p; callback, dense), p0)
+            g = Zygote.gradient(
+                p -> ensemble_loss(p; ensalg, sensealg, callback, dense), p0
+            )[1]
+            @test g ≈ gfd rtol = 1.0e-4
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,9 @@ end
         @time @safetestset "Ensemble RNG reproducibility" begin
             include("downstream/ensemble_rng.jl")
         end
+        @time @safetestset "Ensemble adjoint gradient correctness" begin
+            include("downstream/ensemble_adjoints.jl")
+        end
         @time @safetestset "Solution Indexing" begin
             include("downstream/solution_interface.jl")
         end


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Supersedes #1381 — contains all of #1381's changes plus the follow-up cleanup that #1381's approach makes possible. Open #1381 can be closed in favor of this.

## What this does

Fixes AD through `solve(::EnsembleProblem, ...)` when the loss reads per-trajectory solution fields (`for s in sol.u; s.u[end]; ...`), the root cause of SciML/SciMLSensitivity.jl#1478, and removes the now-redundant `__getindex` scaffolding in the forward ensemble utility.

### From #1381 (carried over unchanged)

1. **`BoundsError` crash — RAT v4 scalar cotangent iteration.** Under RecursiveArrayTools v4, `AbstractVectorOfArray` (incl. `EnsembleSolution`/`VectorOfArray`) subtypes `AbstractArray` and iterates scalars in column-major order. Cotangents for `tmap`/`responsible_map` outputs arrive wrapped in those containers, so zipping them with the per-trajectory pullbacks fed scalars where per-trajectory tangents were expected → `BoundsError: attempt to access Tuple{} at index [0]` in SciMLSensitivity. Fixed by `unwrap_map_cotangent`, which peels all `AbstractVectorOfArray` layers to the plain vector of per-element tangents in **both** `∇responsible_map` and `∇tmap`.

2. **Silent gradient over-counting — shared mutable problem.** `ODEProblem` is a `mutable struct`, so Zygote routes field-access cotangents through the per-`Context` `grad_mut` accumulator, shared across the per-trajectory pullbacks that all read the same problem. Once a cotangent is materialized at a ChainRules boundary (guaranteed by the per-trajectory solve rrules) Zygote's Ref-identity de-dup breaks, so trajectory tangents carry snapshots of the running accumulator → e.g. `3g₁ + 2g₂` instead of `g₁ + g₂`. Fixed by giving `AbstractDEProblem` a structural (immutable-style) `literal_getfield` pullback, mirroring the existing `getproperty(::NonlinearProblem)` precedent. Scoped to `AbstractDEProblem` so `AbstractNonlinearProblem`'s nested-AD path is untouched.

### New in this PR

3. **Remove `__getindex`.** That helper existed only to special-case `AbstractVectorOfArray` cotangents inside `responsible_map`'s reverse pass — a cotangent-shape concern living in the forward ensemble utility (the wrong layer). With `unwrap_map_cotangent` normalizing the cotangent at its source, `responsible_map` only ever sees plain index ranges (forward) or a plain vector (reverse), so the `__getindex` overloads are dead. Dropped them and index directly. (This is the cleaner alternative to #1380, which instead *added* another `__getindex` overload and only covered the serial path.)

## Why not #1380

#1380 patches `__getindex(::AbstractEnsembleSolution)` in the forward utility, fixes only `EnsembleSerial`, and leaves `EnsembleThreads` broken (`tmap` uses plain `getindex`, not `__getindex`). #1380's threaded tests pass only because single-threaded CI falls back to `EnsembleSerial`. This PR fixes both paths at the correct layer and removes the scaffolding entirely.

## Verification (run locally, Julia 1.11.9, `-t 8`)

Per-trajectory loss `sum(sum(sum, s.u) for s in sol.u)`, `GaussAdjoint(autojacvec=ReverseDiffVJP())`, compared against a ForwardDiff reference:

| branch | `EnsembleSerial` | `EnsembleThreads` |
|---|---|---|
| master | BoundsError | BoundsError |
| #1380 | ✓ | BoundsError |
| this PR | ✓ matches ForwardDiff | ✓ matches ForwardDiff |

Also confirmed: removing `__getindex` on top of the unwrap leaves both paths passing (the overloads were dead). Runic clean on the changed file.

I ran the targeted repro and Runic locally; I did **not** run the full `Pkg.test()` suite. The carried-over downstream testset `test/downstream/ensemble_adjoints.jl` exercises this exact path (skipped on Julia 1.12+ due to known Zygote/1.12 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)