### PR TITLE
Format: apply Runic to fix format check

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -630,7 +630,7 @@ function Base.summary(io::IO, I::DEIntegrator)
     return print(
         io,
         type_color, nameof(typeof(I)),
-        no_color, " with uType ", 
+        no_color, " with uType ",
         type_color, typeof(I.u),
         no_color, " and tType ",
         type_color, typeof(I.t),


### PR DESCRIPTION
Formatting-only PR to fix the failing Runic format check.

The repo's `format-check` CI runs Runic (`fredrikekre/runic-action@v1` / `SciML/.github/.github/workflows/runic.yml@v1`) with default settings (extensions `jl`, no docstring formatting). The check is currently failing.

This applies Runic v1.7.0 (the version `version: '1'` resolves to) in place over all git-tracked `.jl` files, matching exactly how CI selects and formats files. No semantic/code changes — verified that diffs are whitespace/formatting only (`git diff --ignore-all-space` is empty for the larger reindent). Re-running Runic in `--check` mode after formatting passes with exit code 0.

Ignore until reviewed by @ChrisRackauckas.