### PR TITLE
test: fix brittle NonlinearSolution getindex AD test (under-resolved reference)

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -307,13 +307,23 @@ end
     p_ss = [2.0, -2.0, 1.0, -4.0]
     prob_ss = SteadyStateProblem(f_iip!, u0_ss, p_ss)
 
+    # Tight solve tolerances so every gradient below is resolved to the true
+    # analytic value rather than to the steady-state solver's default error.
+    # The loss is `u₁` at steady state, where `p₁ + p₂ u₁ = 0`, so `u₁ = -p₁/p₂`
+    # and the exact gradient is `[-1/p₂, p₁/p₂², 0, 0] = [0.5, 0.5, 0, 0]`. At the
+    # default `DynamicSS` tolerance the ForwardDiff reference is only accurate to
+    # ~1.2e-6 — larger than the `rtol = 1e-6` compared against below — so the test
+    # was brittle to AD-backend accuracy drift. `abstol = reltol = 1e-10` brings
+    # every solve to ~1e-9 of the true gradient, well inside the tolerance.
+    ss_tol = (; abstol = 1.0e-10, reltol = 1.0e-10)
+
     # Reference gradient: the same loss computed via a path that does not
     # touch the buggy dispatch (full solve + index into the resulting array).
     ref_loss = θ -> sum(
         Array(
             solve(
                 prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ,
-                sensealg = SteadyStateAdjoint(),
+                sensealg = SteadyStateAdjoint(), ss_tol...,
             )
         )[1]
     )
@@ -322,10 +332,10 @@ end
     # Scalar `save_idxs` + `[1]` — this is the dispatch that used to return zero.
     scalar_loss_ssa = θ -> solve(
         prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ,
-        save_idxs = 1, sensealg = SteadyStateAdjoint(),
+        save_idxs = 1, sensealg = SteadyStateAdjoint(), ss_tol...,
     )[1]
     scalar_loss_default = θ -> solve(
-        prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ, save_idxs = 1,
+        prob_ss, DynamicSS(Rodas5()); u0 = u0_ss, p = θ, save_idxs = 1, ss_tol...,
     )[1]
 
     for backend in MOONCAKE_BACKENDS


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Fixes the `observables_autodiff.jl` failure currently red on **master** (Downstream group, `tests / Downstream (julia 1)`): testset `NonlinearSolution scalar getindex under AD (SciMLSensitivity#1446)` → `AutoMooncake`, `7 passed / 2 failed / 2 broken`.

## Root cause — brittle, under-resolved reference (not a code bug)

The test compares a Mooncake gradient against a ForwardDiff reference at `rtol = 1e-6`, but **both** are computed through a `DynamicSS` solve at its *default* tolerance.

The loss is `u₁` at steady state, where `p₁ + p₂·u₁ = 0`, so `u₁ = -p₁/p₂` and the exact gradient is `[-1/p₂, p₁/p₂², 0, 0] = [0.5, 0.5, 0, 0]`.

Measured locally (Julia 1.11.9), reference error from that exact gradient vs. `DynamicSS` solve tolerance:

| solve tol | reference error |
|---|---|
| **default** | **1.23e-6** ← exceeds the `rtol = 1e-6` it is held to |
| 1e-8 | 1.34e-8 |
| 1e-10 | 6.18e-10 |
| 1e-12 | 5.70e-12 |

So at the default tolerance the reference itself is off by `1.23e-6` — larger than the `rtol` it enforces. The Mooncake value (`[0.5, 0.49999996, 0, 0]`, error ~3.6e-8) is actually **closer to the true gradient than the reference**. The test passed before only because the two methods' errors happened to align within `1e-6`; a recent Mooncake update shifted the Mooncake gradient (toward truth) just enough to break the alignment. Confirmed not a SciMLBase code regression: the only commit between the last green master and the failing one is a one-line whitespace change (#1385).

## Fix — resolve the reference, don't loosen the assertion

Set `abstol = reltol = 1e-10` on all three solves so every gradient resolves to ~1e-9 of the analytic value. The `rtol = 1e-6` assertion is unchanged.

## Verification (run locally with the real `AutoMooncake` backend, Julia 1.11.9)

| | reference error | `grad_ssa ≈ grad_ref` | `grad_def ≈ grad_ref` |
|---|---|---|---|
| current (default tol) | 1.23e-6 | ❌ fail | ❌ fail |
| this PR (1e-10) | 6.18e-10 | ✅ pass | ✅ pass |

Reproduces the exact CI failure on the current tolerance and confirms the fix passes. Runic clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)