### PR TITLE
docs: fix Ensembles `@example` blocks failing on Julia 1.12

### DIFF
--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -243,6 +243,7 @@ use the `@everywhere` macro. Instead, the same problem can be implemented simply
 
 ```@example ensemble1_2
 using OrdinaryDiffEq
+using SciMLBase
 prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 function prob_func(prob, ctx)
     remake(prob, u0 = rand() * prob.u0)
@@ -364,6 +365,7 @@ Our `prob_func` will simply randomize the initial condition:
 
 ```@example ensemble3
 using OrdinaryDiffEq
+using SciMLBase
 # Linear ODE which starts at 0.5 and solves from t=0.0 to t=1.0
 prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 


### PR DESCRIPTION
## Problem

The `Documentation` build on `master` has been red for several commits. It fails at the `:example_block` stage with:

```
failed to run `@example` block in docs/src/interfaces/Ensembles.md:244-254
UndefVarError: `EnsembleProblem` not defined in `Main.__atexample__named__ensemble1_2`
```

(and the same for the `ensemble3` blocks at `Ensembles.md:390-394` and `407-414`).

## Root cause

The `ensemble1_2` and `ensemble3` `@example` blocks only ran `using OrdinaryDiffEq` before referencing `EnsembleProblem` / `EnsembleThreads`. OrdinaryDiffEq does **not** export those names — only `StochasticDiffEq` does, which is exactly why the sibling `ensemble2` / `ensemble4` blocks (which `using StochasticDiffEq`) built fine.

Verified locally on Julia 1.12.6 in the docs environment:

```
OrdinaryDiffEq exports EnsembleProblem: false
StochasticDiffEq exports EnsembleProblem: true
SciMLBase exports EnsembleProblem: true
```

On Julia 1.12 an unexported-but-transitively-loaded name no longer silently resolves; it throws `UndefVarError` with the "loaded but not imported" hint, which terminates the Documenter build. (On older Julia it happened to resolve, so the docs built.)

## Fix

Add `using SciMLBase` to the two affected blocks so the ensemble interface types are unambiguously in scope. Minimal, doc-only, two added lines.

## Local verification

`julia +1.12 --project=docs docs/make.jl` now builds **past** the example-block stage (exit code 0); the prior `failed to run @example block ... UndefVarError: EnsembleProblem` errors are gone. The build only stops at deployment (no deploy credentials locally — CI supplies those). The remaining `Ensembles.md` `@docs`-block warnings (`timeseries_steps_*`) are pre-existing and already covered by `warnonly = [:docs_block, :missing_docs]`.

Please ignore until reviewed by @ChrisRackauckas.
