### PR TITLE
Fix RAT v4 Zygote getindex adjoints for ODESolution (Downstream/SII CI)

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -112,7 +112,7 @@ end
 # 2D `AbstractArray`, so `eachindex(sol)` yields `CartesianIndex`es and
 # `sol[CartesianIndex(state, step)]` returns the corresponding scalar. Without a
 # dedicated adjoint this falls through to `getindex(VA::ODESolution, sym)`,
-# which mis-treats the `CartesianIndex` as a state index and calls
+# which wrongly treats the `CartesianIndex` as a state index and calls
 # `view(VA, ::CartesianIndex, :)` — three indices into a 2D parent — failing
 # with "number of indices (3) must match the parent dimensionality (2)". The
 # cotangent is returned as a zeroed `ODESolution` (matching the input, as the

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -108,6 +108,30 @@ end
     return y, ODESolution_scalar_pullback
 end
 
+# `sol[I::CartesianIndex]`: under RecursiveArrayTools v4 an `ODESolution` is a
+# 2D `AbstractArray`, so `eachindex(sol)` yields `CartesianIndex`es and
+# `sol[CartesianIndex(state, step)]` returns the corresponding scalar. Without a
+# dedicated adjoint this falls through to `getindex(VA::ODESolution, sym)`,
+# which mis-treats the `CartesianIndex` as a state index and calls
+# `view(VA, ::CartesianIndex, :)` — three indices into a 2D parent — failing
+# with "number of indices (3) must match the parent dimensionality (2)". The
+# cotangent is returned as a zeroed `ODESolution` (matching the input, as the
+# `sym` adjoint below does) with the scalar `Δ` scattered into the indexed slot,
+# so it has the shape `DifferentiationInterface`/`Zygote` expect for `sol`.
+@adjoint function Base.getindex(VA::ODESolution, I::CartesianIndex)
+    inds = Tuple(I)
+    front_inds = Base.front(inds)
+    step_idx = last(inds)
+    y = VA.u[step_idx][front_inds...]
+    function ODESolution_cartesian_pullback(Δ)
+        dVA = recursivecopy(VA)
+        recursivefill!(dVA, zero(eltype(dVA)))
+        dVA.u[step_idx][front_inds...] = Δ
+        return (dVA, nothing)
+    end
+    return y, ODESolution_cartesian_pullback
+end
+
 @adjoint function Base.getindex(VA::ODESolution, sym)
     function ODESolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym
@@ -188,6 +212,23 @@ end
         (a, nothing)
     end
     VA[sym], ODESolution_getindex_pullback
+end
+
+# `sol[syms, :]` returns the same per-timestep values of the selected states as
+# `sol[syms]` (the trailing `:` selects all timesteps), so it reuses the
+# vector-symbol adjoint above. Without this method the call has no `@adjoint`
+# and falls through to ChainRules' generic array `getindex` rule, which tries to
+# `fill!` a `Matrix{Vector{Float64}}` zero array with the scalar `false` and
+# errors with "Cannot `convert` an object of type Bool to ...".
+@adjoint function Base.getindex(
+        VA::ODESolution{T}, sym::Union{Tuple, AbstractVector}, ::Colon
+    ) where {T}
+    y, pullback = Zygote.pullback(getindex, VA, sym)
+    function ODESolution_getindex_colon_pullback(Δ)
+        dVA, dsym = pullback(Δ)
+        return (dVA, dsym, nothing)
+    end
+    return y, ODESolution_getindex_colon_pullback
 end
 
 @adjoint function Base.getindex(VA::SciMLBase.AbstractNonlinearSolution, sym)

--- a/test/downstream/adjoints.jl
+++ b/test/downstream/adjoints.jl
@@ -75,7 +75,12 @@ sol = solve(prob, Rodas4())
             true_grad_sym = zeros(length(ModelingToolkit.unknowns(sys)))
             true_grad_sym[idx_sym] = 1.0
 
-            @test all(map(x -> x == true_grad_sym, gs_sym))
+            # `gs_sym` is the cotangent `ODESolution`; iterate its per-timestep
+            # state vectors (`.u`), matching the other gradient testsets below.
+            # Under RecursiveArrayTools v4 raw iteration of an `ODESolution`
+            # yields scalars (column-major over the state×time array), not the
+            # per-timestep vectors this assertion compares against.
+            @test all(map(x -> x == true_grad_sym, gs_sym.u))
         end
     end
     # Mooncake does not support SymbolicIndexingInterface AD yet
@@ -89,7 +94,7 @@ sol = solve(prob, Rodas4())
                 idx_sym = SymbolicIndexingInterface.variable_index(sys, lorenz1.x)
                 true_grad_sym = zeros(length(ModelingToolkit.unknowns(sys)))
                 true_grad_sym[idx_sym] = 1.0
-                all(map(x -> x == true_grad_sym, gs_sym))
+                all(map(x -> x == true_grad_sym, gs_sym.u))
             end
         end
     end

--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -262,19 +262,16 @@ end
         return sum(sol[simple_dae.s_dae])
     end
 
-    # Zygote DAE adjoints currently broken. The ChainRules `_solve_adjoint`
-    # path calls `get_concrete_problem` -> `get_updated_symbolic_problem`,
-    # which evaluates the initialization SCCNonlinearProblem's observable
-    # `TimeIndependentObservedFunction` with `u = nothing`, and the generated
-    # `RuntimeGeneratedFunction` then hits
-    # `MethodError: no method matching getindex(::Nothing, ::Int64)`.
-    # See https://github.com/SciML/SciMLBase.jl/issues/1233
+    # Previously the Zygote DAE adjoint was broken (#1233): the ChainRules
+    # `_solve_adjoint` path evaluated the initialization SCCNonlinearProblem's
+    # observable with `u = nothing` and hit
+    # `MethodError: no method matching getindex(::Nothing, ::Int64)`. That path
+    # now produces a gradient of the expected shape, so this is asserted with
+    # `@test` (leaving it `@test_broken` errors with an "Unexpected Pass").
     for backend in ZYGOTE_BACKENDS
         @testset "$(backend_name(backend))" begin
-            @test_broken begin
-                gs = DifferentiationInterface.gradient(loss_dae, backend, tunables_dae)
-                !isnothing(gs) && length(gs) == length(tunables_dae)
-            end
+            gs = DifferentiationInterface.gradient(loss_dae, backend, tunables_dae)
+            @test !isnothing(gs) && length(gs) == length(tunables_dae)
         end
     end
     # Mooncake handles this adjoint through its own `build_rrule` /


### PR DESCRIPTION
## What this fixes

The `Downstream` and `SymbolicIndexingInterface` test groups are red on master. On Julia **LTS (1.10)**, where the Zygote backend is active in these tests, the failures are SciMLBase Zygote `getindex` adjoint gaps/bugs exposed by RecursiveArrayTools v4 (an `ODESolution` is now a 2-D `AbstractArray`). All four are reproduced and fixed:

1. **`test/downstream/observables_autodiff.jl:383`** (`eachindex` loss) — `ArgumentError: number of indices (3) must match the parent dimensionality (2)`. `eachindex(sol)` now yields `CartesianIndex`es; `sol[I]` had no adjoint and fell through to the symbolic `getindex(::ODESolution, sym)` rule, which calls `view(VA, ::CartesianIndex, :)` (3 indices into a 2-D parent).
   - Fix: add a `getindex(::ODESolution, ::CartesianIndex)` adjoint returning a zeroed cotangent `ODESolution` with `Δ` scattered into the indexed slot.

2. **`test/downstream/adjoints.jl:166`** (`sol[[syms], :]`) — `MethodError: Cannot convert an object of type Bool to Vector{Float64}` (ChainRules' generic array `getindex` rule `fill!`-ing a `Matrix{Vector{Float64}}` with `false`).
   - Fix: add a `getindex(::ODESolution, ::Union{Tuple,AbstractVector}, ::Colon)` adjoint that delegates to the existing vector-symbol adjoint (the trailing `:` selects all timesteps, giving the same value as `sol[syms]`).

3. **`test/downstream/adjoints.jl:78`** (`sol[lorenz1.x]`) — "Test Failed". The gradient is actually **correct** (verified: `gs.u[t] == [0,0,0,0,0,1]` for all `t`, both raw Zygote and via DifferentiationInterface); the assertion iterated `gs_sym` directly, but RAT v4 raw iteration of an `ODESolution` yields scalars. Fixed by iterating `gs_sym.u`, matching the other three gradient testsets in the same file.

4. **`test/downstream/observables_autodiff.jl:274`** — "Unexpected Pass". The Zygote DAE adjoint (#1233) now produces a gradient of the expected shape, so it is asserted with `@test` instead of `@test_broken`.

## Spell-check fix (commit 2)

The first revision tripped the repo's `Spell Check with Typos` job: `typos` read "mis" inside the word "mis-treats" in the new `getindex(::ODESolution, ::CartesianIndex)` comment as the standalone misspelling "mis". Reworded to "wrongly treats". Verified locally that `typos` exits 0 on the changed file and on the whole repository; this is a comment-only wording change (Runic clean, no behavior change).

## Verification

Reproduced and verified locally on Julia 1.10 (lts) with CI-matching dependency versions (RecursiveArrayTools 4.3.1, ChainRules 1.73.0, Zygote 0.7.11, SciMLBase 3.21.0, ModelingToolkit 11.28). After the change:
- single / vector / tuple / time-series symbolic gradients in `adjoints.jl` pass;
- the `eachindex` Lotka–Volterra Zygote gradient matches the ForwardDiff reference (`rtol=1e-4`);
- the DAE Zygote adjoint returns a gradient of the expected length;
- the full `observables_autodiff.jl` file passes (274 + 383).

Changed `.jl` files are Runic-formatted.

## Scope note (the remaining julia 1 / pre reds)

The `Downstream (julia 1)`, `Downstream (julia pre)`, and `SymbolicIndexingInterface (julia 1)` legs are **not** addressed by the code change here, and do not reproduce as SciMLBase bugs: the Zygote backend list `ZYGOTE_BACKENDS` is empty on Julia ≥ 1.12 (`VERSION < v"1.12" ? [AutoZygote()] : []`), so the adjoint code touched here never runs on those legs. The master CI logs confirm that the `Adjoints`/`SII_Downstream` testsets run clean on the **pre** channel (1.13) — `Adjoints | 5 Broken / 5 Total`, "SciMLBase tests passed" — i.e. only the Mooncake `@test_broken` cases execute and the files pass. The four real failures in the master logs are all on the **LTS** legs (`adjoints.jl` under SII-lts, `observables_autodiff.jl` under Downstream-lts), which are exactly what this PR fixes. The julia-1/pre Downstream/SII reds look like CI infrastructure (heavy-dependency precompile timeout / transient) on the self-hosted runner rather than a SciMLBase code bug, and are left for separate investigation.

The various `... / Downstream Tests - X` reds (ModelingToolkit, OrdinaryDiffEq, Catalyst, LinearSolve, BoundaryValueDiffEq, ModelingToolkitStandardLibrary) are downstream-package CI: they are not caused by this repo's changes or dependencies and resolve when those packages are fixed in their own repos.

Please ignore until reviewed by @ChrisRackauckas.