### PR TITLE
Fix dead docs link in OptimizationProblem docstring

### DIFF
--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -93,7 +93,7 @@ Note that these vectors must be sized to match the number of constraints, with o
 ## Data handling
 
 As described above the second argument of the objective definition can take a full batch or a [`DataLoader`](https://juliaml.github.io/MLUtils.jl/stable/api/#MLUtils.DataLoader) object for mini-batching which is useful for stochastic optimization solvers. Thus the data either as an Array or a `DataLoader` object should be passed as the third argument of the `OptimizationProblem` constructor.
-For an example of how to use this data handling, see the `Sophia` example in the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/dev/optimization_packages/optimization) or the [mini-batching tutorial](https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/).
+For an example of how to use this data handling, see the `Sophia` example in the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/) or the [mini-batching tutorial](https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/).
 """
 struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
     AbstractOptimizationProblem{iip}


### PR DESCRIPTION
## Summary

The `OptimizationProblem` docstring in `src/problems/optimization_problems.jl` linked to a docs path that no longer exists:

`https://docs.sciml.ai/Optimization/dev/optimization_packages/optimization` → **403 / dead** (there is no such page; the directory hosts per-package pages like `sophia/`).

This repoints the dead link to the page that actually hosts the `Sophia` data-handling example referenced in the surrounding text:

`https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/` → **HTTP 200**

The sibling mini-batching link (`tutorials/minibatch/` → **200**) was already correct and is left unchanged.

## Why this matters

Optimization.jl renders SciMLBase docstrings (`modules=[..., SciMLBase, ...]`), so this dead link surfaces in Optimization.jl's docs build. It is the **only remaining `:linkcheck` failure** in SciML/Optimization.jl#1232 after that PR's other docs fixes.

## Verification

Documenter linkcheck-style curl (`curl -sI --proto =http,https -g -A '<chrome UA>' --max-time 10`):

```
403  https://docs.sciml.ai/Optimization/dev/optimization_packages/optimization   (old, dead)
200  https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/         (new)
200  https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/                  (unchanged)
```

## Note on propagation

A SciMLBase release must be tagged and propagate (so Optimization.jl's docs pick up the new docstring) before Optimization.jl#1232's docs CI goes green. This PR is the necessary upstream prerequisite.

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)