### PR TITLE
Fix Zygote symbolic-indexing solution adjoints (greens SII test lane on lts)

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -190,6 +190,19 @@ end
     VA[sym], ODESolution_getindex_pullback
 end
 
+# `sol[syms, :]` returns the same value as `sol[syms]` (the trailing `:`
+# selects all timesteps, which is already the default), but the 3-arg form
+# does not hit the rule above and would otherwise fall through to ChainRules'
+# generic `∇getindex`, which cannot build a zero cotangent for the
+# `AbstractVectorOfArray`-backed solution under RecursiveArrayTools v4. Reuse
+# the 2-arg rule and pass `nothing` for the trailing-index cotangent.
+@adjoint function Base.getindex(
+        VA::ODESolution, sym::Union{Tuple, AbstractVector}, ::Colon
+    )
+    y, back = Zygote.pullback(getindex, VA, sym)
+    return y, Δ -> (back(Δ)..., nothing)
+end
+
 @adjoint function Base.getindex(VA::SciMLBase.AbstractNonlinearSolution, sym)
     function NonlinearSolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym

--- a/test/downstream/adjoints.jl
+++ b/test/downstream/adjoints.jl
@@ -75,7 +75,7 @@ sol = solve(prob, Rodas4())
             true_grad_sym = zeros(length(ModelingToolkit.unknowns(sys)))
             true_grad_sym[idx_sym] = 1.0
 
-            @test all(map(x -> x == true_grad_sym, gs_sym))
+            @test all(map(x -> x == true_grad_sym, gs_sym.u))
         end
     end
     # Mooncake does not support SymbolicIndexingInterface AD yet


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The `tests / SymbolicIndexingInterface (julia lts, ubuntu-latest)` master lane is red. The CI log shows two failures in `test/downstream/adjoints.jl` (the Zygote symbolic-indexing gradient tests run only on Julia `< 1.12`, i.e. the `lts` lane):

```
AutoZygote: Test Failed at .../test/downstream/adjoints.jl:78
...
AutoZygote: Error During Test at .../test/downstream/adjoints.jl:166
  Got exception outside of a @test
  MethodError: Cannot `convert` an object of type Bool to an object of type Vector{Float64}
...
ERROR: LoadError: Some tests did not pass: 4 passed, 1 failed, 1 errored, 5 broken.
```

## Root cause

Two distinct bugs, both surfaced by RecursiveArrayTools v4 (under which `ODESolution <: AbstractVectorOfArray <: AbstractArray`):

1. **Line 78 (test bug).** The scalar symbolic-indexing gradient test compared the cotangent with `map(x -> x == true_grad_sym, gs_sym)`. Iterating the cotangent `ODESolution` *directly* yields its underlying flat column-major **scalars** (`length(states) * length(timesteps)` of them), so each scalar was compared against the length-`nstates` vector `true_grad_sym` and the test was always false. The per-timestep cotangent vectors live in `gs_sym.u` — the convention the vector/tuple/timeseries gradient tests in the same file already use. The gradient itself is correct (every `gs_sym.u[i]` is the expected one-hot vector); only the container access was wrong. Fix: `gs_sym` → `gs_sym.u`.

2. **Line 166/167 (real Zygote-ext gap).** `sol[[syms], :]` has no SciMLBase Zygote adjoint, so it fell through to ChainRules' generic `∇getindex`, whose `_setindex_zero` tries `fill!(::Matrix{Vector{Float64}}, false)` and throws on the `AbstractVectorOfArray`-backed solution. `sol[syms, :]` returns the same value as `sol[syms]` (the trailing `:` selects all timesteps, already the default), so the fix is a thin `@adjoint` for the 3-arg colon form that reuses the existing 2-arg rule and passes `nothing` for the trailing-index cotangent.

## Verification (local, Julia lts 1.10)

`adjoints.jl` before fix (reproduced): `1 failed, 1 errored`. After fix:

```
Test Summary:      | Pass  Broken  Total
adjoints.jl verify |    6       5     11
=== ADJOINTS VERIFY: fails=0 errors=0 ===
```

The other SII files (`comprehensive_indexing`, `integrator_indexing`, `problem_interface`, `modelingtoolkit_remake`, `remake_tests`) all pass on lts and on Julia 1.12 locally; `adjoints.jl` was the sole failing file on the `lts` lane.

## Note on the `julia 1` (1.12) SII lane

That lane is also red, but for a *different* reason: its "Run tests" step never finalizes (the process is killed mid-run; every SII test file passes individually on 1.12 locally). That looks like a runner resource/instability issue on Julia 1.12 and is out of scope for this PR — this PR fixes the confirmed `lts` test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)