### PR TITLE
Enzyme: treat `remake(::AbstractSciMLFunction)` reconstruction as inactive

### DIFF
--- a/ext/SciMLBaseEnzymeExt.jl
+++ b/ext/SciMLBaseEnzymeExt.jl
@@ -1,6 +1,7 @@
 module SciMLBaseEnzymeExt
 
-using SciMLBase: AbstractSensitivityAlgorithm, AbstractSciMLProblem
+using SciMLBase: AbstractSensitivityAlgorithm, AbstractSciMLProblem,
+    AbstractSciMLFunction, remake
 import CommonSolve
 import Enzyme: EnzymeRules
 
@@ -38,5 +39,29 @@ EnzymeRules.inactive_kwarg(
 EnzymeRules.inactive_kwarg(
     ::typeof(CommonSolve.solve), ::AbstractSciMLProblem, args...; kwargs...,
 ) = nothing
+
+# Rebuilding an `AbstractSciMLFunction` via `remake` — e.g. the in-loss
+# `remake(prob; build_initializeprob = true)` rebuilds `prob.f` with fresh
+# `initialization_data` at `remake.jl`'s `remake(prob.f; f, initialization_data)` — is pure
+# structural reconstruction. It does not itself produce derivative-carrying output: the
+# active data flows through the problem's `u0`/`p` (and, at solve time, through the live
+# parameters via `update_initializeprob!`), not through the rebuilt function's stored
+# `initialization_data`.
+#
+# But `remake(::AbstractSciMLFunction; …)` is type-unstable (it infers `Any`, even when the
+# inputs are concrete and the runtime result type equals `typeof(prob.f)`), so Enzyme
+# differentiates the rebuild through its dynamic `runtime_generic_rev` path. There it
+# cannot statically prove the type of the deeply nested `OverrideInitData` /
+# `InitializationMetadata` the function carries (e.g. for MTK-built problems) and throws
+# `EnzymeNoTypeError`. Marking the reconstruction call inactive — so Enzyme runs it as a
+# primal-only call and does not differentiate / type-analyze its body — avoids this while
+# keeping the gradient correct. This is the Enzyme analog of the
+# `OverrideInitData`/`ODENLStepData` `NoTangent` declarations in the Mooncake extension.
+#
+# `remake(f; kwargs...)` lowers to `Core.kwcall((; kwargs...), remake, f)`, so the rule is
+# declared on `Core.kwcall`.
+EnzymeRules.inactive_noinl(
+    ::typeof(Core.kwcall), ::Any, ::typeof(remake), ::AbstractSciMLFunction, args...,
+) = true
 
 end


### PR DESCRIPTION

## What

Adds one `EnzymeRules.inactive_noinl` declaration to `ext/SciMLBaseEnzymeExt.jl` so that
rebuilding an `AbstractSciMLFunction` via `remake` is treated as a primal-only
(non-differentiated) call by Enzyme.

```julia
EnzymeRules.inactive_noinl(
    ::typeof(Core.kwcall), ::Any, ::typeof(remake), ::AbstractSciMLFunction, args...,
) = true
```

Fixes #1398.

## Why

Reverse-mode Enzyme through `remake(prob; build_initializeprob = true)` throws
`EnzymeNoTypeError` at the `remake(prob.f; f, initialization_data)` ODEFunction rebuild
(`src/remake.jl`) when `prob.f` carries `initialization_data` (e.g. any MTK-built problem
with an initialization system). `remake(::AbstractSciMLFunction; …)` is type-unstable (it
infers `Any`), so Enzyme handles the rebuild through its dynamic `runtime_generic_rev`
path, where it cannot statically prove the type of the deeply nested `OverrideInitData` /
`InitializationMetadata` the function carries.

Rebuilding the function is **pure structural reconstruction** — it does not produce
derivative-carrying output. The active data flows through the problem's `u0`/`p` (and, at
solve time, through the live parameters via `update_initializeprob!`), not through the
rebuilt function's stored `initialization_data`. Marking the reconstruction call inactive
lets Enzyme run it as a primal-only call (skipping the type-analysis of its body that
fails) while keeping the gradient correct.

This mirrors the existing Mooncake treatment in `ext/SciMLBaseMooncakeExt.jl`
(`Mooncake.tangent_type(::Type{<:OverrideInitData}) = NoTangent`, and the same for
`ODENLStepData`), whose comment already identifies the nested `InitializationMetadata` etc.
as the problematic infrastructure. The Enzyme extension simply lacked the analog.

`inactive_type` (the type-level analog) does **not** work here: it governs activity
tracking, not the type-analysis pass that fails. Marking the *call* inactive
(`inactive_noinl`) is what skips analyzing the reconstruction body. `remake(f; kwargs...)`
lowers to `Core.kwcall((; kwargs...), remake, f)`, so the rule is declared on `Core.kwcall`.

## Validation

Using the MWE from the issue (Julia 1.12.6, SciMLBase 3.22.0, Enzyme 0.13.166):

- **Before:** `EnzymeNoTypeError` at the `remake(prob.f; …)` kwcall.
- **After:** gradient computes; matches `ForwardDiff` (relerr ≈ 4e-7) and is stable across
  repeated calls. Also validated end-to-end with a `Vern9` solve + `GaussAdjoint`
  (SciMLSensitivity #1477's scenario): correct gradient, stable, no primal mutation.

## Notes / scope

- The rule is intentionally broad (any keyword `remake` of any `AbstractSciMLFunction`).
  That is consistent with the semantics — function reconstruction is infrastructure — but if
  a narrower scope is preferred we can restrict it (e.g. only when `initialization_data`
  is among the keywords).
- A complementary, deeper fix would make `remake(::AbstractSciMLFunction)` type-stable so
  the rebuild stays on Enzyme's static path; the type-instability (`infer_return_type` =>
  `Any`) is noted in the issue as a standalone item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
