### PR TITLE
Convert now-passing Zygote DAE-adjoint `@test_broken` to `@test`

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -262,19 +262,16 @@ end
         return sum(sol[simple_dae.s_dae])
     end
 
-    # Zygote DAE adjoints currently broken. The ChainRules `_solve_adjoint`
-    # path calls `get_concrete_problem` -> `get_updated_symbolic_problem`,
-    # which evaluates the initialization SCCNonlinearProblem's observable
-    # `TimeIndependentObservedFunction` with `u = nothing`, and the generated
-    # `RuntimeGeneratedFunction` then hits
-    # `MethodError: no method matching getindex(::Nothing, ::Int64)`.
-    # See https://github.com/SciML/SciMLBase.jl/issues/1233
+    # Zygote DAE adjoints (previously broken via the ChainRules `_solve_adjoint`
+    # path evaluating the initialization SCCNonlinearProblem's observable
+    # `TimeIndependentObservedFunction` with `u = nothing`; see
+    # https://github.com/SciML/SciMLBase.jl/issues/1233) now return a gradient
+    # of the expected length.
     for backend in ZYGOTE_BACKENDS
         @testset "$(backend_name(backend))" begin
-            @test_broken begin
-                gs = DifferentiationInterface.gradient(loss_dae, backend, tunables_dae)
-                !isnothing(gs) && length(gs) == length(tunables_dae)
-            end
+            gs = DifferentiationInterface.gradient(loss_dae, backend, tunables_dae)
+            @test !isnothing(gs)
+            @test length(gs) == length(tunables_dae)
         end
     end
     # Mooncake handles this adjoint through its own `build_rrule` /


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

The Zygote DAE observable-adjoint test in `test/downstream/observables_autodiff.jl` now passes, so its `@test_broken` reports an **"Unexpected Pass"** that fails CI (e.g. seen on the `Downstream (julia lts)` job of #1399). This converts it to real `@test` assertions, matching the Mooncake block immediately below it.

```
AutoZygote: Error During Test at .../observables_autodiff.jl:274
 Unexpected Pass
 Got correct result, please change to @test if no longer broken.
```

## Why

`@test_broken` errors when the wrapped expression unexpectedly succeeds. The Zygote DAE adjoint (issue #1233) now returns a gradient of the expected length, so the block must be a normal passing test. The stale "currently broken" comment is updated accordingly.

## Scope / note

This is an independent test-only change against `master` — not the Enzyme fix in #1399 — but it clears the unexpected-pass blocker that shows up in that PR's downstream CI. Note that the same `Downstream (julia lts)` job has a *separate*, genuine failure (`ArgumentError: number of indices (3) must match the parent dimensionality (2)` in `SciMLBaseZygoteExt.jl:129`, the "Integer time-step indexing under AD" / issue #1325 testset) which is a real code bug and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)