### PR TITLE
Declare public API (unlock downstream ExplicitImports allow-lists)

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1066,10 +1066,6 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 @public has_init, has_step, successful_retcode
 
-# Public API not exported to avoid namespace clashes with downstream packages.
-# Declaring these public lets downstream packages access them as
-# `SciMLBase.name` without ExplicitImports flagging them as non-public.
-
 # Abstract interface types
 @public AbstractSciMLProblem, AbstractSciMLSolution, AbstractDEAlgorithm,
     AbstractODEProblem, AbstractODEAlgorithm, AbstractNonlinearProblem,

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1066,4 +1066,25 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 @public has_init, has_step, successful_retcode
 
+# Public API not exported to avoid namespace clashes with downstream packages.
+# Declaring these public lets downstream packages access them as
+# `SciMLBase.name` without ExplicitImports flagging them as non-public.
+
+# Abstract interface types
+@public AbstractSciMLProblem, AbstractSciMLSolution, AbstractDEAlgorithm,
+    AbstractODEProblem, AbstractODEAlgorithm, AbstractNonlinearProblem,
+    AbstractDynamicalODEProblem, AbstractIntegralAlgorithm
+
+# Solution / problem support types
+@public NLStats, NullParameters, AutoSpecialize
+
+# Core functions
+@public build_solution, numargs
+
+# SciMLFunction derivative traits
+@public has_jac, has_jvp, has_vjp
+
+# Function-argument validation errors
+@public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError
+
 end


### PR DESCRIPTION
## What

Marks a focused set of non-exported, **SciMLBase-owned** names as `public` using this repo's existing `@public` (SciMLPublic) convention. This lets the ~92 downstream SciML/JuliaSymbolics repos that carry ExplicitImports allow-lists drop the matching `ei_kwargs` ignores (`check_all_qualified_accesses_are_public` / `check_all_explicit_imports_are_public`) for these names, since they will no longer be flagged as non-public when accessed as `SciMLBase.name`.

`@public` is a no-op on Julia <1.11 (the 1.10 floor), so this is safe across supported versions. None of these names are exported, so there is no exported+public double-declaration (which would error on 1.11+).

## madePublic (19)

Abstract interface types (docstring + re-exported by DiffEqBase):
- `AbstractSciMLProblem`
- `AbstractSciMLSolution`
- `AbstractDEAlgorithm`
- `AbstractODEProblem`
- `AbstractODEAlgorithm`
- `AbstractNonlinearProblem`
- `AbstractDynamicalODEProblem`
- `AbstractIntegralAlgorithm`

Solution / problem support types:
- `NLStats` (docstring)
- `NullParameters` (documented in `docs/src/interfaces/Problems.md`, re-exported by DiffEqBase)
- `AutoSpecialize` (docstring; specialization API type)

Core functions:
- `build_solution` (core solution-builder extension point, re-exported by DiffEqBase)
- `numargs` (docstring; function-introspection utility, re-exported by DiffEqBase)

SciMLFunction derivative traits (same family as the already-public `has_init`/`has_step`, re-exported by DiffEqBase):
- `has_jac`
- `has_jvp`
- `has_vjp`

Function-argument validation error types (caught and re-wrapped downstream, e.g. DiffEqPhysics imports and `e isa TooManyArgumentsError` etc., reading `.fname`/`.f`):
- `FunctionArgumentsError`
- `TooFewArgumentsError`
- `TooManyArgumentsError`

## skipped (with reason)

- `NonlinearLeastSquaresProblem` — already **exported** (already public; adding `public` would error on 1.11+).
- `reinit!` — already **exported** (already public).
- `init` — CommonSolve verb, **owned by CommonSolve** (`binding_module == CommonSolve`), not SciMLBase.
- `solve!` — CommonSolve verb, **owned by CommonSolve**, not SciMLBase.
- `Success` — this is `ReturnCode.Success`, an EnumX value in the `SciMLBase.ReturnCode` submodule; it is **already public** in its owning module (`Base.ispublic(SciMLBase.ReturnCode, :Success) == true`). There is no top-level `SciMLBase.Success` binding to declare.
- `_unwrap_val` — underscore-prefixed **internal** implementation detail.
- `plot_indices` — **internal plotting-recipe helper** (no docstring, not in docs, used only inside plot recipes); also name-collides with RecursiveArrayTools' own `plot_indices`, and SciML/SciMLBase.jl#1305 is delegating plotting helpers to RecursiveArrayTools. False-publicizing an internal here would be worse than a leftover downstream ignore.

## Verification

Loads and verified on Julia 1.10 (floor, `@public` no-op) and Julia 1.12. On 1.12, `Base.ispublic(SciMLBase, :name) == true` and `Base.isexported(SciMLBase, :name) == false` for all 19 newly-public names. Runic reports no changes.

## Overlap with #1397

PR #1397 ("Add ExplicitImports.jl QA checks via SciMLTesting run_qa") edits the *imports* section of `src/SciMLBase.jl` (making `using` statements explicit and adding the `using SciMLPublic: @public` machinery) but does **not** add any of these public *declarations*. This PR is the natural complement and is kept separate and focused, branched off `master`. The two changes touch non-overlapping regions of the file.

---

This lets downstream packages drop the matching `ei_kwargs` ignores for these SciMLBase names.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)