### PR TITLE
Fix trailing `.nothing` in integrator abort warnings (#1387)

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -621,7 +621,7 @@ end
 
 has_reinit(i::DEIntegrator) = false
 
-log_instability(integrator) = nothing
+log_instability(integrator) = ""
 
 ### Display
 

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -70,12 +70,3 @@ let
     integrator = DummyIntegrator()
     @test 0 == @allocated SciMLBase.check_error!(integrator)
 end
-
-# Issue #1387: the default `log_instability` must interpolate into warning
-# messages as an empty string, not a trailing `nothing`.
-let
-    integrator = DummyIntegrator()
-    diagnostic = SciMLBase.log_instability(integrator)
-    @test diagnostic isa AbstractString
-    @test !occursin("nothing", "Float64 precision).$diagnostic")
-end

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -70,3 +70,12 @@ let
     integrator = DummyIntegrator()
     @test 0 == @allocated SciMLBase.check_error!(integrator)
 end
+
+# Issue #1387: the default `log_instability` must interpolate into warning
+# messages as an empty string, not a trailing `nothing`.
+let
+    integrator = DummyIntegrator()
+    diagnostic = SciMLBase.log_instability(integrator)
+    @test diagnostic isa AbstractString
+    @test !occursin("nothing", "Float64 precision).$diagnostic")
+end


### PR DESCRIPTION
Fixes #1387.

## Problem

The dt-min / dt-epsilon / instability abort warnings in `check_error` ended with a stray `.nothing`:

```
... or it cannot be represented in Float64 precision).nothing
                                                     ^^^^^^^
```

## Cause

The default method `log_instability(integrator) = nothing` (in `src/integrator_interface.jl`) is interpolated directly into the warning messages via `$diagnostic`. When no instability log is available (the default), `nothing` was rendered into the string literally.

## Fix

Return an empty string `""` instead of `nothing`, so the diagnostic appends cleanly when there is nothing to log. No downstream SciML package overrides `log_instability`, and the call sites already treat the result as string-like (the other branch returns `""`), so this is the intended contract.

## Test

Added a regression test in `test/integrator_tests.jl` asserting the default `log_instability` returns an `AbstractString` and does not interpolate as `nothing`. Verified locally: the test fails on the old `nothing` default and passes with the fix.

---
Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)