### PR TITLE
Zygote: add `getindex(::ODESolution, ::CartesianIndex)` adjoint (#1325)

### DIFF
--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -79,17 +79,18 @@ end
     out, EnsembleSolution_adjoint
 end
 
-# `sol[i::Integer]`: under RecursiveArrayTools v4 `AbstractVectorOfArray`
-# subtypes `AbstractArray`, so linear integer indexing returns the i-th
-# scalar element in column-major order over the underlying state-by-time
-# layout (i.e. `VA[CartesianIndices(size(VA))[i]]`), NOT the i-th timestep
-# vector. A dedicated adjoint is still needed here to keep dispatch from
-# falling through to the broader `Base.getindex(VA::ODESolution, sym)`
-# rule below (which would misinterpret `i` as a state-variable index;
-# #1325). The pullback scatters the scalar cotangent into the matching
-# slot of `VA.u`.
-@adjoint function Base.getindex(VA::ODESolution, i::Integer)
-    inds = Tuple(CartesianIndices(size(VA))[i])
+# `sol[i::Integer]` / `sol[I::CartesianIndex]`: under RecursiveArrayTools v4
+# `AbstractVectorOfArray` subtypes `AbstractArray`, so scalar indexing returns
+# the corresponding scalar element over the underlying state-by-time layout,
+# NOT the i-th timestep vector. Linear `i` maps through
+# `CartesianIndices(size(VA))[i]`; a `CartesianIndex` already is that tuple
+# (e.g. from `eachindex(VA)`, which is `IndexCartesian`). A dedicated adjoint is
+# needed in both cases to keep dispatch from falling through to the broader
+# `Base.getindex(VA::ODESolution, sym)` rule below (which would misinterpret the
+# index as a state-variable symbol; #1325). The pullback scatters the scalar
+# cotangent into the matching slot of `VA.u`.
+@adjoint function Base.getindex(VA::ODESolution, i::Union{Integer, CartesianIndex})
+    inds = i isa CartesianIndex ? Tuple(i) : Tuple(CartesianIndices(size(VA))[i])
     front_inds = Base.front(inds)
     step_idx = last(inds)
     y = VA.u[step_idx][front_inds...]


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

Adds a Zygote `@adjoint` for `getindex(::ODESolution, ::CartesianIndex)` by broadening the existing scalar `Integer` adjoint in `ext/SciMLBaseZygoteExt.jl` to `Union{Integer, CartesianIndex}`.

## Why

Under RecursiveArrayTools v4 an `ODESolution` is a 2-D state-by-time `AbstractArray`, so `eachindex(sol)` is `IndexCartesian` and yields `CartesianIndex{2}`. A loop like

```julia
for i in eachindex(predicted)
    lp += sum(predicted[i])
end
```

indexes the solution with a `CartesianIndex`. Only an `Integer` scalar adjoint existed, so the `CartesianIndex` call fell through to the generic `getindex(VA, sym)` rule, whose pullback built `view(VA, I, ntuple(_ -> :, ndims(VA)-1)...)` = `view(VA, CartesianIndex(a,b), :)` — **3 indices into a 2-D parent** — and threw:

```
ArgumentError: number of indices (3) must match the parent dimensionality (2)
@ SciMLBaseZygoteExt.jl:129  (ODESolution_getindex_pullback, CartesianIndex{2})
```

This is the failure in the `test/downstream/observables_autodiff.jl` "Integer time-step indexing under AD (issue #1325)" testset on the `Downstream (julia lts)` job (Zygote backend; Mooncake already passed). Fixes #1325.

## Fix

A `CartesianIndex` already *is* the index tuple; an `Integer` maps through `CartesianIndices(size(VA))`. The `Integer` path is byte-for-byte unchanged (`i isa CartesianIndex` is `false` for integers). The pullback (scatter the scalar cotangent into the matching `VA.u` slot) is shared.

## Validation

Reproduced the exact `lv_logp` from issue #1325 (sum over `eachindex(predicted)`, differentiated **through `solve` w.r.t. parameters** via SciMLSensitivity + Zygote on Julia 1.10):

- **Before:** `ArgumentError: number of indices (3) must match the parent dimensionality (2)`.
- **After:** gradient computes and matches `ForwardDiff` to ~1e-13:
  ```
  ForwardDiff: [8.304244, -159.484020,  75.203162, -339.195163]
  Zygote:      [8.304244, -159.484020,  75.203162, -339.195163]   (rtol 1e-4 ✓, actually ~1e-13)
  ```

Runic-formatted. The existing issue-#1325 testset in `observables_autodiff.jl` already exercises this path, so no test change is needed here.

## Relationship to other PRs

Independent of #1400 (which converts a now-passing DAE-adjoint `@test_broken` to `@test`). Together, #1400 + this clear both failures in the `Downstream (julia lts)` job seen on #1399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)