### PR TITLE
Mark AbstractDEAlgorithm as Enzyme-inactive (fixes SciMLSensitivity#1499)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.24.0"
+version = "3.24.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -132,6 +132,7 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 PartialFunctions = "570af359-4316-4cb7-8c74-252c00c2016b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -147,4 +148,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "DifferentiationInterface", "ForwardDiff", "PartialFunctions", "Pkg", "SafeTestsets", "SciMLTesting", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]
+test = ["Aqua", "DifferentiationInterface", "Enzyme", "ForwardDiff", "PartialFunctions", "Pkg", "SafeTestsets", "SciMLTesting", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]

--- a/ext/SciMLBaseEnzymeExt.jl
+++ b/ext/SciMLBaseEnzymeExt.jl
@@ -1,6 +1,6 @@
 module SciMLBaseEnzymeExt
 
-using SciMLBase: AbstractSensitivityAlgorithm, AbstractSciMLProblem,
+using SciMLBase: AbstractSensitivityAlgorithm, AbstractDEAlgorithm, AbstractSciMLProblem,
     AbstractSciMLFunction, remake
 import CommonSolve
 import Enzyme: EnzymeRules
@@ -16,6 +16,28 @@ import Enzyme: EnzymeRules
 
 # All sensitivity algorithm types should be inactive for Enzyme differentiation
 EnzymeRules.inactive_type(::Type{<:AbstractSensitivityAlgorithm}) = true
+
+# Solver algorithms (`Tsit5`, `Rodas5P`, the `CompositeAlgorithm` behind
+# `DefaultODEAlgorithm`, …) are pure configuration: they describe HOW to solve,
+# carry no derivative-carrying data, and are never differentiated with respect
+# to. Marking the whole hierarchy inactive keeps Enzyme from ever assigning them
+# an active activity.
+#
+# This is required for correctness on Julia 1.12+, whose "inline-roots" split
+# calling convention (JuliaLang/julia#55767) lowers a mixed immutable struct
+# (one holding both GC-tracked pointers and inline bits) into two LLVM
+# arguments: an inline-bits payload and a separate roots bundle. A nested
+# polyalgorithm like `CompositeAlgorithm` is exactly such a mixed struct, so it
+# gets split, whereas a leaf algorithm like `Tsit5` does not. When the split
+# algorithm reaches the `solve_up` custom rule in `DiffEqBaseEnzymeExt` with the
+# problem marked active (e.g. an MTK problem carrying differentiable
+# `MTKParameters` under `set_runtime_activity(Reverse)`), Enzyme can mark the
+# two halves with disagreeing activities and trips the
+# `roots_activep (DFT_CONSTANT) != activep (DFT_DUP_ARG)` assertion
+# (SciMLSensitivity.jl#1499). Forcing the algorithm inactive makes both halves
+# constant, so the assertion holds. This mirrors the `inactive_type` declaration
+# NonlinearSolveBase uses for `NonlinearSolvePolyAlgorithm`.
+EnzymeRules.inactive_type(::Type{<:AbstractDEAlgorithm}) = true
 
 # Solver-configuration keyword arguments to `solve`, `init`, and `solve!` on
 # SciML problems are never derivative-carrying — they are scalar tolerances,

--- a/test/enzyme_inactive_algorithm.jl
+++ b/test/enzyme_inactive_algorithm.jl
@@ -1,0 +1,24 @@
+using SciMLBase
+using Enzyme
+using Test
+
+import Enzyme: EnzymeRules
+
+# Regression test for SciMLSensitivity.jl#1499.
+#
+# Solver algorithms are pure configuration and are never differentiated with
+# respect to, so the whole `AbstractDEAlgorithm` hierarchy must be declared
+# `EnzymeRules.inactive_type`. Without this, on Julia 1.12+ a nested
+# polyalgorithm (e.g. the `CompositeAlgorithm` behind `DefaultODEAlgorithm`)
+# gets split by the "inline-roots" calling convention and trips Enzyme's
+# `roots_activep != activep` assertion inside the `solve_up` custom rule.
+struct Issue1499ODEAlg <: SciMLBase.AbstractODEAlgorithm end
+struct Issue1499SDEAlg <: SciMLBase.AbstractSDEAlgorithm end
+struct Issue1499DAEAlg <: SciMLBase.AbstractDAEAlgorithm end
+
+@testset "AbstractDEAlgorithm is Enzyme-inactive (SciMLSensitivity#1499)" begin
+    @test EnzymeRules.inactive_type(Issue1499ODEAlg)
+    @test EnzymeRules.inactive_type(Issue1499SDEAlg)
+    @test EnzymeRules.inactive_type(Issue1499DAEAlg)
+    @test EnzymeRules.inactive_type(SciMLBase.AbstractDEAlgorithm)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,9 @@ run_tests(;
         @time @safetestset "NonlinearProblem Zygote cotangents" begin
             include("nonlinearproblem_zygote.jl")
         end
+        @time @safetestset "Enzyme inactive solver algorithms" begin
+            include("enzyme_inactive_algorithm.jl")
+        end
         return if !is_APPVEYOR
             @time @safetestset "Remake" begin
                 include("remake_tests.jl")


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft PR opened by an agent.

## Summary

Fixes SciML/SciMLSensitivity.jl#1499: differentiating an MTK-generated ODE solved with `DefaultODEAlgorithm()` via Enzyme on Julia 1.12 throws

```
AssertionError: roots_activep (DFT_CONSTANT) != activep (DFT_DUP_ARG)
```

while a leaf algorithm like `Tsit5()` works.

This declares the whole `AbstractDEAlgorithm` hierarchy `EnzymeRules.inactive_type`, mirroring the existing rule for `AbstractSensitivityAlgorithm` in this same extension and the rule NonlinearSolveBase uses for `NonlinearSolvePolyAlgorithm`. Solver algorithms are pure configuration — they describe *how* to solve, carry no derivative-carrying data, and are never differentiated with respect to.

## Root cause

On Julia 1.12+, the "inline-roots" split calling convention (JuliaLang/julia#55767) lowers a *mixed* immutable struct (one holding both GC-tracked pointers and inline bits) into two LLVM arguments: an inline-bits payload and a separate roots bundle. The nested `CompositeAlgorithm` behind `DefaultODEAlgorithm` is exactly such a mixed struct, so it gets split; `Tsit5` is not split. When the split algorithm reaches the `solve_up` custom rule in `DiffEqBaseEnzymeExt` with the problem marked active (an MTK problem carries differentiable `MTKParameters`, so under `set_runtime_activity(Reverse)` it becomes `Duplicated`), Enzyme can mark the algorithm's two halves with disagreeing activities (`CONSTANT` inline / `DUP_ARG` roots) and trips the consistency assertion. Forcing the algorithm `inactive_type` makes both halves constant, so the assertion holds.

The underlying disagreement is arguably an Enzyme bug in handling the split-arg convention for a partially-active mixed immutable inside a custom rule, but marking algorithms inactive is correct regardless (they are never differentiated) and is the established SciML pattern for this class of failure.

## Verification

Reproduced the issue's MWE locally on Julia 1.12.6 (Enzyme 0.13.169, ModelingToolkit 11.x):

- **Before:** `Tsit5()` gradient works; `DefaultODEAlgorithm()` throws the `roots_activep` assertion.
- **After** (with this rule applied): `DefaultODEAlgorithm()` gradient computes `[-22.8277, 14.4366]`, matching the `Tsit5()` control to `rtol=1e-3`, no error.

Added `test/enzyme_inactive_algorithm.jl` (wired into the core test group; `Enzyme` added to the test target) asserting the rule fires for `AbstractODEAlgorithm`/`AbstractSDEAlgorithm`/`AbstractDAEAlgorithm` subtypes. Passes locally (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)