### PR TITLE
Declare public API round 2 (unlock downstream ExplicitImports)

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1083,4 +1083,35 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Function-argument validation errors
 @public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError
 
+# Abstract problem types
+@public AbstractDEProblem, AbstractDAEProblem, AbstractSDEProblem, AbstractDDEProblem,
+    AbstractDiscreteProblem, AbstractNoiseProblem, AbstractJumpProblem,
+    AbstractEnsembleProblem
+
+# Abstract algorithm types
+@public AbstractNonlinearAlgorithm, AbstractDAEAlgorithm, AbstractSDEAlgorithm,
+    AbstractLinearAlgorithm, AbstractRODEAlgorithm, AbstractSteadyStateAlgorithm,
+    BasicEnsembleAlgorithm
+
+# Abstract solution types
+@public AbstractNoiseProcess, AbstractEnsembleSolution, AbstractNoTimeSolution,
+    AbstractRODESolution
+
+# Abstract function types
+@public AbstractDiffEqFunction, AbstractODEFunction, AbstractSciMLFunction
+
+# Algorithm / problem traits
+@public isadaptive, allowscomplex, allows_arbitrary_number_types, isautodifferentiable,
+    is_diagonal_noise, forwarddiffs_model, forwarddiffs_model_time,
+    allows_late_binding_tstops, alg_order, allowsbounds, allowsconstraints
+
+# Initialization algorithms and interface
+@public NoInit, OverrideInit, get_initial_values
+
+# Solution / integrator interface
+@public DEStats, check_error!, promote_tspan
+
+# Problem types and alias specifiers
+@public ImmutableODEProblem, NonlinearAliasSpecifier
+
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.** Draft.

Part of the fleet-wide ExplicitImports campaign. The sweep restored a set of SciMLBase names that downstream packages legitimately use as API but which were neither exported nor declared `public`. This PR declares the documented, user-facing, SciMLBase-owned ones `public` (via `SciMLPublic.@public`, matching the module's existing convention) so downstream can drop their ExplicitImports ignores.

Vetting rule applied: a candidate is made public only if it is (a) documented (a real docstring and/or appears in a `@docs` block rendered into the published docs), (b) user-facing API, (c) defined and owned by SciMLBase (not a re-export), and (d) not already exported (already-exported = already public; `@public` on an exported name errors on 1.11+). When in doubt, skipped — a leftover downstream ignore is preferable to false-publicizing an internal.

### Verification
- Loads/precompiles on Julia 1.10 (floor) and 1.12. All 41 names defined on both.
- On 1.12, every newly-public name satisfies `Base.ispublic(SciMLBase, :name) == true` and `Base.isexported(SciMLBase, :name) == false`.
- Runic-formatted.

### Made public (41)
Abstract problem types: `AbstractDEProblem`, `AbstractDAEProblem`, `AbstractSDEProblem`, `AbstractDDEProblem`, `AbstractDiscreteProblem`, `AbstractNoiseProblem`, `AbstractJumpProblem`, `AbstractEnsembleProblem` — all in the Problems.md `@docs` block.

Abstract algorithm types: `AbstractNonlinearAlgorithm`, `AbstractDAEAlgorithm`, `AbstractSDEAlgorithm`, `AbstractLinearAlgorithm`, `AbstractRODEAlgorithm`, `AbstractSteadyStateAlgorithm` (Algorithms.md `@docs`), `BasicEnsembleAlgorithm` (Ensembles.md `@docs` signature, documented).

Abstract solution types: `AbstractNoiseProcess`, `AbstractEnsembleSolution`, `AbstractNoTimeSolution`, `AbstractRODESolution` — Solutions.md `@docs`.

Abstract function types: `AbstractDiffEqFunction`, `AbstractODEFunction`, `AbstractSciMLFunction` — SciMLFunctions.md `@docs` / API section.

Traits: `isadaptive`, `allowscomplex`, `allows_arbitrary_number_types`, `isautodifferentiable`, `is_diagonal_noise`, `forwarddiffs_model`, `forwarddiffs_model_time`, `allows_late_binding_tstops` (Algorithms.md/Problems.md `@docs`), `alg_order` (documented convergence-order trait), `allowsbounds`, `allowsconstraints` (documented optimization-capability traits, analogous to already-public `allowscomplex`).

Initialization: `NoInit`, `OverrideInit` (documented DAE initialization algorithms, used as `initializealg=`), `get_initial_values` (documented initialization-algorithm dispatch interface).

Solution/integrator interface: `DEStats` (documented `sol.stats` type, analog of already-public `NLStats`), `check_error!` (documented mutating integrator-interface variant of exported `check_error`), `promote_tspan` (documented tspan-conversion utility used by downstream problem constructors).

Problem types / alias specifiers: `ImmutableODEProblem` (documented immutable ODE problem type), `NonlinearAliasSpecifier` (Problems.md `@docs`).

### Skipped (with reason)
- `__solve`, `__init`, `__has_jac`, `__has_controljac`, `_unwrap_val` — underscore/double-underscore-prefixed internals (explicit skip; `__solve`/`__init` are documented as solver-extension hooks but the `__` convention marks them internal).
- `save_discretes_if_enabled!`, `save_final_discretes!` — `save_*!` internal save helpers.
- `postamble!`, `done`, `interp_summary`, `solution_new_retcode`, `calculate_solution_errors!`, `updated_u0_p`, `tighten_container_eltype`, `solve_batch`, `build_linear_solution`, `specialization`, `isdenseplot`, `plottable_indices`, `has_tgrad`, `has_analytic`, `has_reinit`, `has_stats`, `has_initialization_data`, `get_colorizers`, `unwrapped_f`, `default_rng_func`, `generate_sim_seeds`, `@add_kwonly`, `DefaultOptimizationCache` — undocumented (no prose docstring) or documented-but-internal implementation helpers / codegen utilities; not part of the published public interface.
- `INITIALIZE_DEFAULT`, `DEFAULT_REDUCTION`, `FINALIZE_DEFAULT` — `*_DEFAULT`/default-sentinel internal consts (compared internally with `===`).
- `LeftRootFind`, `NoRootFind`, `RootfindOpt` — undocumented rootfind option internals.
- `getindepsym`, `getindepsym_defaultt` — undocumented (`getindepsym_defaultt` is even marked "Only for compatibility!").
- `AbstractSteadyStateProblem` — undocumented type alias of `AbstractNonlinearProblem` (sibling `AbstractSteadyStateAlgorithm` is documented and was made public).
- `EnsembleAlgorithm`, `DEIntegrator`, `AbstractODEIntegrator`, `AbstractContinuousCallback`, `AbstractDiscreteCallback`, `AbstractDiscretization`, `AbstractDiscretizationMetadata`, `AbstractDiffEqInterpolation`, `ConstantInterpolation`, `LinearInterpolation`, `StandardODEProblem`, `StandardBVProblem`, `AbstractBVPAlgorithm`, `AbstractParameterizedFunction` — autogenerated-signature-only docs with no descriptive prose and not present in any `@docs` block; not surfaced as documented public interface (left for a follow-up if downstream needs them documented).
- `AbstractDEAlgorithm`, `AbstractODEProblem`, `AbstractODEAlgorithm`, `build_solution`, `CheckInit` — already exported / already `@public`; declaring `public` would error or be redundant.
- `current_time`, `parameter_values`, `state_values`, `symbolic_container`, `variable_symbols` (owned by SymbolicIndexingInterface), `recursive_bottom_eltype` (owned by RecursiveArrayTools) — re-exports, not owned by SciMLBase. `NullParameters`/ADTypes/SciMLStructures/AbstractSciMLOperator skipped per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
