### PR TITLE
Split downstream AD tests into a `DownstreamAD` group that omits `pre`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,9 +101,6 @@ run_tests(;
                 @time @safetestset "Ensemble RNG reproducibility" begin
                     include("downstream/ensemble_rng.jl")
                 end
-                @time @safetestset "Ensemble adjoint gradient correctness" begin
-                    include("downstream/ensemble_adjoints.jl")
-                end
                 @time @safetestset "Solution Indexing" begin
                     include("downstream/solution_interface.jl")
                 end
@@ -116,14 +113,8 @@ run_tests(;
                 @time @safetestset "Integer idxs" begin
                     include("downstream/integer_idxs.jl")
                 end
-                @time @safetestset "Autodiff Remake" begin
-                    include("downstream/remake_autodiff.jl")
-                end
                 @time @safetestset "Partial Functions" begin
                     include("downstream/partial_functions.jl")
-                end
-                @time @safetestset "Autodiff Observable Functions" begin
-                    include("downstream/observables_autodiff.jl")
                 end
                 @time @safetestset "ODE Solution Stripping" begin
                     include("downstream/ode_stripping.jl")
@@ -142,6 +133,20 @@ run_tests(;
                 end
                 @time @safetestset "Scalar RODESolution calculate_solution_errors!" begin
                     include("downstream/rode_calculate_solution_errors.jl")
+                end
+            end
+        end,
+        "DownstreamAD" => function ()
+            return if !is_APPVEYOR
+                activate_downstream_env()
+                @time @safetestset "Autodiff Remake" begin
+                    include("downstream/remake_autodiff.jl")
+                end
+                @time @safetestset "Autodiff Observable Functions" begin
+                    include("downstream/observables_autodiff.jl")
+                end
+                @time @safetestset "Ensemble adjoint gradient correctness" begin
+                    include("downstream/ensemble_adjoints.jl")
                 end
             end
         end,

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,6 +7,15 @@ versions = ["lts", "1", "pre"]
 num_threads = 11
 continue_on_error = true
 
+# AD/gradient downstream tests are split out so they can omit the "pre" Julia
+# version: Mooncake cannot differentiate through `Dict` growth (`rehash!` ->
+# `Core.memoryrefnew(::Memory{UInt8}, ::Int, ::Bool)`) on Julia 1.13, which the
+# symbolic observable-AD path hits. See chalk-lab/Mooncake.jl#1227.
+[DownstreamAD]
+versions = ["lts", "1"]
+num_threads = 11
+continue_on_error = true
+
 [SymbolicIndexingInterface]
 versions = ["lts", "1", "pre"]
 num_threads = 11


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

Splits the autodiff/gradient downstream tests out of the `Downstream` group into a new **`DownstreamAD`** group, and configures its matrix (`test/test_groups.toml`) to run only on `lts` and `1` — **not `pre`**.

Moved (from `Downstream` → `DownstreamAD`):
- `downstream/remake_autodiff.jl` ("Autodiff Remake")
- `downstream/observables_autodiff.jl` ("Autodiff Observable Functions")
- `downstream/ensemble_adjoints.jl` ("Ensemble adjoint gradient correctness")

No test bodies change — this is a pure re-grouping plus a version-matrix carve-out.

## Why

The symbolic observable-AD path makes **Mooncake differentiate through `Dict` growth**, which on **Julia 1.13** (the `pre` runner) hits the builtin `Core.memoryrefnew(::Memory{UInt8}, ::Int, ::Bool)` (via `Base.rehash!` / `ht_keyindex2_shorthash!`) for which Mooncake has no `rrule!!`:

```
memoryrefnew has been called with arguments (Memory{UInt8}, Int64, Bool),
but there is no specialised method of `rrule!!` for this built-in
```

The same code differentiates correctly on Julia 1.10/1.12 — it is a Julia-1.13-specific lowering gap, reproduced with a pure-`Base` + Mooncake MWE and tracked upstream at **chalk-lab/Mooncake.jl#1227**. Since this cannot be fixed in SciMLBase, isolating the AD tests lets the rest of the `Downstream` group keep its `pre` coverage while the AD subset skips the Julia version the upstream gap breaks.

## Verification

- `test/runtests.jl` parses cleanly; the `DownstreamAD` key is present in both `runtests.jl`'s `groups` dict and `test/test_groups.toml`, matching the existing standalone-group pattern (`Downstream`, `Python`).
- Confirmed `SciMLTesting.run_tests` dispatches `GROUP` via `haskey(groups, GROUP)`, so `GROUP=DownstreamAD` routes to the new group.
- Runic-clean.
- I did **not** run the full downstream suite end-to-end locally (it is a ~1h heavy install and the test bodies are unchanged by this re-grouping). On `lts` the AD tests additionally depend on #1400 and #1403 to be green.

## Related

- #1400 — converts a now-passing DAE-adjoint `@test_broken` to `@test`.
- #1403 — fixes the Zygote `getindex(::ODESolution, ::CartesianIndex)` adjoint (#1325).
- chalk-lab/Mooncake.jl#1227 — the upstream Mooncake gap this group carve-out works around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)