### PR TITLE
Declare public API round 3 (abstract integrator types + predicates)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.28.0"
+version = "3.28.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1078,7 +1078,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public build_solution, numargs
 
 # SciMLFunction derivative traits
-@public has_jac, has_jvp, has_vjp, has_tgrad
+@public has_jac, has_jvp, has_vjp, has_tgrad, has_analytic, has_reinit,
+    has_initialization_data, has_stats
 
 # Function-argument validation errors
 @public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1078,7 +1078,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public build_solution, numargs
 
 # SciMLFunction derivative traits
-@public has_jac, has_jvp, has_vjp
+@public has_jac, has_jvp, has_vjp, has_tgrad
 
 # Function-argument validation errors
 @public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError
@@ -1091,14 +1091,19 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Abstract algorithm types
 @public AbstractNonlinearAlgorithm, AbstractDAEAlgorithm, AbstractSDEAlgorithm,
     AbstractLinearAlgorithm, AbstractRODEAlgorithm, AbstractSteadyStateAlgorithm,
-    BasicEnsembleAlgorithm
+    BasicEnsembleAlgorithm, EnsembleAlgorithm
+
+# Abstract integrator types
+@public DEIntegrator, AbstractODEIntegrator, AbstractSDEIntegrator,
+    AbstractRODEIntegrator, AbstractDDEIntegrator, AbstractDAEIntegrator
 
 # Abstract solution types
 @public AbstractNoiseProcess, AbstractEnsembleSolution, AbstractNoTimeSolution,
     AbstractRODESolution
 
 # Abstract function types
-@public AbstractDiffEqFunction, AbstractODEFunction, AbstractSciMLFunction
+@public AbstractDiffEqFunction, AbstractODEFunction, AbstractSciMLFunction,
+    AbstractParameterizedFunction
 
 # Algorithm / problem traits
 @public isadaptive, allowscomplex, allows_arbitrary_number_types, isautodifferentiable,


### PR DESCRIPTION
## Summary

Round 3 of the fleet-wide make-public campaign. Rounds 1 (#1401) and 2 (#1405) are merged. Round 2 deliberately **skipped** the abstract integrator-type hierarchy and a few documented predicates; this PR declares those `@public`.

## Rationale (downstream ExplicitImports)

Downstream SciML packages qualify SciMLBase API as `SciMLBase.SomeName`. Their QA suites run ExplicitImports `check_all_qualified_accesses_are_public`, which flags every qualified access to a name that SciMLBase has not declared `public`/`export`. The make-public campaign declares documented SciMLBase API `public` so those qualified accesses stop being flagged and downstream packages can drop their `all_qualified_accesses_are_public` ignore-lists. Each name below is a `SciMLBase.X` access that downstream QA currently flags.

## Names publicized

Abstract integrator hierarchy (all carry `$(TYPEDEF)` docstrings; documented by the DiffEq Integrator Interface):
- `DEIntegrator` (root abstract integrator)
- `AbstractODEIntegrator`
- `AbstractSDEIntegrator`
- `AbstractRODEIntegrator`
- `AbstractDDEIntegrator`
- `AbstractDAEIntegrator`

Abstract algorithm / function types (both carry `$(TYPEDEF)` docstrings):
- `EnsembleAlgorithm` (also referenced in `docs/src/interfaces/Ensembles.md`)
- `AbstractParameterizedFunction`

SciMLFunction `has_*` predicate family (the documented predicate interface; same kind as the already-public `has_jac`/`has_jvp`/`has_vjp` from round 1):
- `has_tgrad` — defined identically to and at the same site as the already-public `has_jac`/`has_jvp`/`has_vjp` (`src/scimlfunctions.jl`); the direct fourth member of that derivative-trait family.
- `has_analytic` — `has_analytic(f::AbstractSciMLFunction) = ...` (`src/scimlfunctions.jl`), same family/site as `has_jac`.
- `has_reinit` — defined in `src/integrator_interface.jl` (and `src/solutions/optimization_solutions.jl`); completes the predicate family.
- `has_initialization_data` — defined in `src/scimlfunctions.jl`; completes the predicate family.
- `has_stats` — defined in `src/integrator_interface.jl`; completes the predicate family.

## Names skipped (with reason)

- `AbstractDEIntegrator` — **not defined**. The abstract root is named `DEIntegrator` (not `AbstractDEIntegrator`); publicized `DEIntegrator` instead.
- `AbstractSteadyStateProblem` — skipped-uncertain. It is a bare `const` alias (`= AbstractNonlinearProblem{...}`) with no docstring of its own and no `docs/` reference in this repo. Defaulting to skip per the "documented public API only / when in doubt skip" rule. Can be added in a later round if a docstring is attached.
- `getindepsym`, `getindepsym_defaultt` — defined (`src/symbolic_utils.jl`) but undocumented (no docstring, no `docs/`); `getindepsym_defaultt` is explicitly annotated `# Only for compatibility!`. Treated as internal.
- `StandardODEProblem`, `AbstractDiscretization`, `var`, `plot_indices`, `unwrapped_f`, `__solve`, `__init` — internals (per the candidate list's default-skip guidance); not documented public API.

## Verification

Per campaign constraints, Julia/precompile was **not** run on this contended box. Every publicized name was confirmed defined by grepping `src/`:
- 6 integrator abstracts: `abstract type ... <: DEIntegrator{...}` / `abstract type DEIntegrator{...}` in `src/SciMLBase.jl`.
- `EnsembleAlgorithm`, `AbstractParameterizedFunction`: `abstract type ...` in `src/SciMLBase.jl`.
- `has_*` predicate family: `has_tgrad`/`has_analytic` (`has_*(f::AbstractSciMLFunction) = ...` in `src/scimlfunctions.jl`), `has_initialization_data` (`function has_initialization_data(f)` in `src/scimlfunctions.jl`), `has_reinit` (`src/integrator_interface.jl`:622, `src/solutions/optimization_solutions.jl`:124), `has_stats` (`src/integrator_interface.jl`:928).

Patch version bumped 3.28.0 -> 3.28.1.

---

This PR should be ignored until reviewed by @ChrisRackauckas.