### PR TITLE
Declare unwrapped_f + solution_new_retcode public (round 4 follow-up)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.28.2"
+version = "3.28.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -773,6 +773,15 @@ include("scimlfunctions.jl")
 include("alg_traits.jl")
 include("debug.jl")
 
+"""
+    unwrapped_f(f)
+
+Return the underlying user function with any function-wrapper layers removed. When `f`
+has been wrapped (e.g. by `FunctionWrapperSpecialize` specialization, which specializes
+`f` to a fixed `(u, p, t)` signature via a `FunctionWrappersWrapper`), this recovers the
+original unwrapped function so it can be called on other argument types. If `f` is not
+wrapped, it is returned unchanged.
+"""
 unwrapped_f(f) = f
 unwrapped_f(f::Void) = unwrapped_f(f.f)
 function unwrapped_f(f::FunctionWrappersWrappers.FunctionWrappersWrapper)
@@ -1144,5 +1153,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Automatic differentiation markers
 @public NoAD
+
+# Function-wrapper / solution interface helpers
+@public unwrapped_f, solution_new_retcode
 
 end

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -678,6 +678,13 @@ function build_solution(sol::ODESolution{T, N}, u_analytic, errors) where {T, N}
     return @set sol.errors = errors
 end
 
+"""
+    solution_new_retcode(sol, retcode)
+
+Return a copy of the solution `sol` with its return code replaced by `retcode`. The
+solution is otherwise left unchanged; this is used to update the `retcode` of an existing
+solution (e.g. when an integrator finishes and the final status becomes known).
+"""
 function solution_new_retcode(sol::ODESolution{T, N}, retcode) where {T, N}
     return @set sol.retcode = retcode
 end


### PR DESCRIPTION
These two names were intended to ship as part of #1408 (round 4 of the documented public-API declarations), but #1408 merged before the follow-up commit adding them was pushed, so they were stranded and never landed on master. This PR adds just them, based on current master (on top of #1408).

## What this adds

- `@public unwrapped_f, solution_new_retcode`
- An accurate docstring for each (both were previously undocumented).

## Rationale

Both `unwrapped_f` (the function-wrapper unwrapping helper) and `solution_new_retcode` (the solution-retcode rebuild function) are legitimate **SciMLBase-owned** interface names. Downstream packages qualify-access them (e.g. `SciMLBase.unwrapped_f`, `SciMLBase.solution_new_retcode`), which makes them surface in downstream `ExplicitImports` `all_qualified_accesses_are_public` checks as non-public. Declaring them `public` (and documenting them) lets downstream packages drop them from their EI ignore-lists rather than treating SciMLBase-owned names as third-party internals.

## Diff

Exactly: the two new `@public` names, their two docstrings, and a `Project.toml` version bump 3.28.2 -> 3.28.3.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)