### PR TITLE
Declare __solve/__init public (solver-author extension API)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.28.3"
+version = "3.28.4"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -47,7 +47,29 @@ using SciMLPublic: @public
 
 using SciMLLogging: @SciMLMessage, verbosity_to_bool
 
+"""
+    __solve(prob, alg, args...; kwargs...)
+
+The low-level entry point that `CommonSolve.solve` forwards to after performing the
+common pre-solve handling (such as argument checking and high-level error messages).
+Solver packages add methods to `SciMLBase.__solve` dispatched on their problem and
+algorithm types; this is the documented extension hook for implementing a solver.
+Defining `__solve` rather than `solve` directly allows `SciMLBase.solve` to keep a
+common implementation across all solvers. See also [`__init`](@ref).
+"""
 function __solve end
+
+"""
+    __init(prob, alg, args...; kwargs...)
+
+The low-level entry point that `CommonSolve.init` forwards to after performing the
+common pre-init handling (such as argument checking and high-level error messages).
+Solver packages add methods to `SciMLBase.__init` dispatched on their problem and
+algorithm types, returning the iterator/integrator object used by `solve!`; this is
+the documented extension hook for implementing a solver. Defining `__init` rather than
+`init` directly allows `SciMLBase.init` to keep a common implementation across all
+solvers. See also [`__solve`](@ref).
+"""
 function __init end
 
 """
@@ -1156,5 +1178,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Function-wrapper / solution interface helpers
 @public unwrapped_f, solution_new_retcode
+
+# Low-level solver-author extension entry points
+@public __solve, __init
 
 end


### PR DESCRIPTION
## Rationale

`SciMLBase.__solve` and `SciMLBase.__init` are the low-level entry points that
`CommonSolve.solve` / `CommonSolve.init` forward to after SciMLBase performs the
common pre-solve/pre-init handling (argument checking, high-level error messages).
Solver packages implement a solver by adding methods to these functions dispatched
on their own problem/algorithm types — e.g. `DiffEqBase.__solve`, `DASKR.__solve`,
and many others throughout the ecosystem. This is documented in
`docs/src/interfaces/Init_Solve.md` ("`__solve` and High-Level Handling"):

> While `init` and `solve` are the common entry point for users, solver packages will
> mostly define dispatches on `SciMLBase.__init` and `SciMLBase.__solve`.

In other words these double-underscore names are already the **de-facto public
extension API** for solver authors, even though they were never declared `public`.

## Change

- Declare `@public __solve, __init` in `src/SciMLBase.jl`.
- Add concise docstrings to both generic-function declarations documenting that they
  are the low-level entry points `solve`/`init` forward to, and the documented
  extension hook solver packages overload (matching the existing docs page).
- Bump patch version (3.28.3 → 3.28.4).

Neither name was previously exported, so declaring them `@public` is safe (no
"cannot declare public; already exported" conflict).

## Downstream ExplicitImports

Solver packages qualify these as `SciMLBase.__solve` / `SciMLBase.__init`. With
ExplicitImports' `all_qualified_accesses_are_public` check, those accesses currently
flag because the names weren't public. Declaring them public lets the downstream
qualified accesses pass without ignore-lists.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)