### PR TITLE
Declare DDE/SDE/RODE/BVP solver-author API public (round 5)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.30.0"
+version = "3.30.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1182,4 +1182,35 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Low-level solver-author extension entry points
 @public __solve, __init
 
+# Round 5: DDE/SDE/RODE/BVP solver-author extension API
+# Abstract problem types solver packages subtype/dispatch on
+@public AbstractBVProblem, AbstractRODEProblem, AbstractSDDEProblem
+
+# Abstract algorithm / initialization-algorithm supertypes
+@public AbstractDDEAlgorithm, DAEInitializationAlgorithm
+
+# Abstract function types
+@public AbstractDDEFunction, AbstractSDEFunction, AbstractSDDEFunction
+
+# History function interface for delay equations
+@public AbstractHistoryFunction
+
+# Abstract integrator / solution types
+@public AbstractSDDEIntegrator, AbstractODESolution
+
+# Abstract solver cache supertype
+@public DECache
+
+# Specialization markers
+@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize
+
+# SDE interpretation trait
+@public AlgorithmInterpretation, alg_interpretation
+
+# AD / sensitivity function wrappers
+@public TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper
+
+# Problem alias specifiers
+@public RODEAliasSpecifier, SDEAliasSpecifier
+
 end


### PR DESCRIPTION
Round 5 of the make-public campaign. Marks the documented/intended **solver-author extension API** (surfaced by the OrdinaryDiffEq #3777 sublibrary ExplicitImports sweep) as `@public`, so downstream solver packages can extend/dispatch on these names without ExplicitImports `all_qualified_accesses_are_public` violations.

All names are **defined and owned in SciMLBase src/**, are genuine documented extension API, and none were already exported (no collisions). Verified the package loads on Julia 1.12 and all 23 names report `Base.ispublic == true`.

Names made public:

- **Abstract problem types**: `AbstractBVProblem`, `AbstractRODEProblem`, `AbstractSDDEProblem`
- **Abstract algorithm / init-algorithm supertypes**: `AbstractDDEAlgorithm`, `DAEInitializationAlgorithm`
- **Abstract function types**: `AbstractDDEFunction`, `AbstractSDEFunction`, `AbstractSDDEFunction`, `AbstractHistoryFunction`
- **Abstract integrator / solution types**: `AbstractSDDEIntegrator`, `AbstractODESolution`
- **Abstract solver cache supertype**: `DECache`
- **Specialization markers**: `FullSpecialize`, `NoSpecialize`, `FunctionWrapperSpecialize` (completes the family alongside the already-public `AutoSpecialize`)
- **SDE interpretation trait**: `AlgorithmInterpretation`, `alg_interpretation`
- **AD / sensitivity function wrappers**: `TimeDerivativeWrapper`, `TimeGradientWrapper`, `UDerivativeWrapper`, `UJacobianWrapper`
- **Problem alias specifiers**: `RODEAliasSpecifier`, `SDEAliasSpecifier`

Note: pure codegen/perf macros (`@fold`/`@threaded`/`@OnDemandTableauExtract`/`@cache`) are **not** in this PR — they live in OrdinaryDiffEqCore, not SciMLBase, and are deliberately kept private there.

Patch version bump 3.30.0 -> 3.30.1.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)