### PR TITLE
Parameterize the AliasSpecifier types 

### DIFF
--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -70,7 +70,7 @@ struct AnalyticalAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops)
+                typeof(alias_du0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -36,7 +36,7 @@ end
 export AnalyticalProblem, AbstractAnalyticalProblem
 
 @doc doc"""
-    AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    AnalyticalAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an AnalyticalProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -44,31 +44,34 @@ when solving an AnalyticalProblem. Conforms to the AbstractAliasSpecifier interf
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
     
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
-* `alias_du0::Union{Bool, Nothing}`: alias the `du0` array for DAEs. Defaults to `false`.
-* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the `u0` array.
+* `alias_du0`: alias the `du0` array for DAEs. Defaults to `false`.
+* `alias_tstops`: alias the `tstops` array
+* `alias`: sets all fields of the `AnalyticalAliasSpecifier` to `alias`
 
 """
-struct AnalyticalAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct AnalyticalAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
 
     function AnalyticalAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_du0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end
 end

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -53,25 +53,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct AnalyticalAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-
     function AnalyticalAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_du0, alias_tstops}()
     end
 end
+
+function Base.getproperty(
+        ::AnalyticalAliasSpecifier{P, F, U0, DU0, TS}, s::Symbol
+    ) where {P, F, U0, DU0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("AnalyticalAliasSpecifier has no field $s"))
+end
+Base.propertynames(::AnalyticalAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops)

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -536,25 +536,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct BVPAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-
     function BVPAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_du0, alias_tstops}()
     end
 end
+
+function Base.getproperty(
+        ::BVPAliasSpecifier{P, F, U0, DU0, TS}, s::Symbol
+    ) where {P, F, U0, DU0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("BVPAliasSpecifier has no field $s"))
+end
+Base.propertynames(::BVPAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops)

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -553,7 +553,7 @@ struct BVPAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops)
+                typeof(alias_du0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -519,7 +519,7 @@ function TwoPointSecondOrderBVProblem(
 end
 
 @doc doc"""
-    BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    BVPAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an BVP. Conforms to the AbstractAliasSpecifier interface. 
@@ -527,31 +527,34 @@ when solving an BVP. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `BVPAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops`: alias the tstops array
+* `alias`: sets all fields of the `BVPAliasSpecifier` to `alias`
 
 """
-struct BVPAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct BVPAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
 
     function BVPAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_du0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end
 end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -172,7 +172,7 @@ struct DAEAliasSpecifier{P, F, U0, DU0, TS}
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops)
+                typeof(alias_du0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -138,7 +138,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
 end
 
 @doc doc"""
-    DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    DAEAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DAE. Conforms to the AbstractAliasSpecifier interface. 
@@ -146,31 +146,34 @@ when solving a DAE. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false.
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `DAEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false.
+* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops`: alias the tstops array
+* `alias`: sets all fields of the `DAEAliasSpecifier` to `alias`
 
 """
-struct DAEAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct DAEAliasSpecifier{P, F, U0, DU0, TS}
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
 
     function DAEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_du0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end
 end

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -155,25 +155,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct DAEAliasSpecifier{P, F, U0, DU0, TS}
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-
     function DAEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_du0, alias_tstops}()
     end
 end
+
+function Base.getproperty(
+        ::DAEAliasSpecifier{P, F, U0, DU0, TS}, s::Symbol
+    ) where {P, F, U0, DU0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("DAEAliasSpecifier has no field $s"))
+end
+Base.propertynames(::DAEAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops)

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -447,23 +447,21 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct DDEAliasSpecifier{P, F, U0, TS}
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_tstops::TS
-
     function DDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool}(true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool}(false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true}()
+        alias === false && return new{false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_tstops}()
     end
 end
+
+function Base.getproperty(::DDEAliasSpecifier{P, F, U0, TS}, s::Symbol) where {P, F, U0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("DDEAliasSpecifier has no field $s"))
+end
+Base.propertynames(::DDEAliasSpecifier) = (:alias_p, :alias_f, :alias_u0, :alias_tstops)

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -462,7 +462,7 @@ struct DDEAliasSpecifier{P, F, U0, TS}
             new{Bool, Bool, Bool, Bool}(false, false, false, false)
         elseif isnothing(alias)
             new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_tstops)
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_tstops)
         end
     end

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -430,7 +430,7 @@ function SecondOrderDDEProblem(f::DynamicalDDEFunction, args...; kwargs...)
 end
 
 @doc doc"""
-    DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    DDEAliasSpecifier{P, F, U0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DDE. Conforms to the AbstractAliasSpecifier interface. 
@@ -438,30 +438,32 @@ when solving a DDE. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `DDEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops`: alias the tstops array
+* `alias`: sets all fields of the `DDEAliasSpecifier` to `alias`
 
 """
-struct DDEAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct DDEAliasSpecifier{P, F, U0, TS}
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_tstops::TS
 
     function DDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true)
+            new{Bool, Bool, Bool, Bool}(true, true, true, true)
         elseif alias == false
-            new(false, false, false, false)
+            new{Bool, Bool, Bool, Bool}(false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_tstops)
         end
     end
 end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -184,7 +184,7 @@ function DiscreteProblem(
 end
 
 @doc doc"""
-    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    DiscreteAliasSpecifier{P, F, U0}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a DiscreteProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -192,27 +192,27 @@ when solving a DiscreteProblem. Conforms to the AbstractAliasSpecifier interface
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias::Union{Bool, Nothing}`: sets all fields of the `DiscreteAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias`: sets all fields of the `DiscreteAliasSpecifier` to `alias`
 
 """
-struct DiscreteAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
+struct DiscreteAliasSpecifier{P, F, U0}
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
 
     function DiscreteAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true)
+            new{Bool, Bool, Bool}(true, true, true)
         elseif alias == false
-            new(false, false, false)
+            new{Bool, Bool, Bool}(false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0)
+            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
         end
     end
 end

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -199,20 +199,20 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct DiscreteAliasSpecifier{P, F, U0}
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-
     function DiscreteAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool}(true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool}(false, false, false)
-        elseif isnothing(alias)
-            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
-        end
+        alias === true && return new{true, true, true}()
+        alias === false && return new{false, false, false}()
+        return new{alias_p, alias_f, alias_u0}()
     end
 end
+
+function Base.getproperty(::DiscreteAliasSpecifier{P, F, U0}, s::Symbol) where {P, F, U0}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    throw(ArgumentError("DiscreteAliasSpecifier has no field $s"))
+end
+Base.propertynames(::DiscreteAliasSpecifier) = (:alias_p, :alias_f, :alias_u0)

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -159,20 +159,20 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct ImplicitDiscreteAliasSpecifier{P, F, U0}
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-
     function ImplicitDiscreteAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool}(true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool}(false, false, false)
-        elseif isnothing(alias)
-            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
-        end
+        alias === true && return new{true, true, true}()
+        alias === false && return new{false, false, false}()
+        return new{alias_p, alias_f, alias_u0}()
     end
 end
+
+function Base.getproperty(::ImplicitDiscreteAliasSpecifier{P, F, U0}, s::Symbol) where {P, F, U0}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    throw(ArgumentError("ImplicitDiscreteAliasSpecifier has no field $s"))
+end
+Base.propertynames(::ImplicitDiscreteAliasSpecifier) = (:alias_p, :alias_f, :alias_u0)

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -144,7 +144,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: ImplicitDiscreteP
 end
 
 @doc doc"""
-    ImplicitDiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    ImplicitDiscreteAliasSpecifier{P, F, U0}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
@@ -152,27 +152,27 @@ when solving an ODE. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias::Union{Bool, Nothing}`: sets all fields of the `ImplicitDiscreteAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias`: sets all fields of the `ImplicitDiscreteAliasSpecifier` to `alias`
 
 """
-struct ImplicitDiscreteAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
+struct ImplicitDiscreteAliasSpecifier{P, F, U0}
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
 
     function ImplicitDiscreteAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true)
+            new{Bool, Bool, Bool}(true, true, true)
         elseif alias == false
-            new(false, false, false)
+            new{Bool, Bool, Bool}(false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0)
+            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
         end
     end
 end

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -139,7 +139,7 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
 end
 
 @doc doc"""
-    IntegralAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    IntegralAliasSpecifier{P, F}(alias_p = nothing, alias_f = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an IntegralProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -147,22 +147,22 @@ when solving an IntegralProblem. Conforms to the AbstractAliasSpecifier interfac
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias::Union{Bool, Nothing}`: sets all fields of the `IntegralAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias`: sets all fields of the `IntegralAliasSpecifier` to `alias`
 
 """
-struct IntegralAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
+struct IntegralAliasSpecifier{P, F} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
 
     function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
         return if alias == true
-            new(true, true)
+            new{Bool, Bool}(true, true)
         elseif alias == false
-            new(false, false)
+            new{Bool, Bool}(false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f)
+            new{typeof(alias_p), typeof(alias_f)}(alias_p, alias_f)
         end
     end
 end

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -153,16 +153,16 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct IntegralAliasSpecifier{P, F} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-
     function IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
-        return if alias == true
-            new{Bool, Bool}(true, true)
-        elseif alias == false
-            new{Bool, Bool}(false, false)
-        elseif isnothing(alias)
-            new{typeof(alias_p), typeof(alias_f)}(alias_p, alias_f)
-        end
+        alias === true && return new{true, true}()
+        alias === false && return new{false, false}()
+        return new{alias_p, alias_f}()
     end
 end
+
+function Base.getproperty(::IntegralAliasSpecifier{P, F}, s::Symbol) where {P, F}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    throw(ArgumentError("IntegralAliasSpecifier has no field $s"))
+end
+Base.propertynames(::IntegralAliasSpecifier) = (:alias_p, :alias_f)

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -198,16 +198,16 @@ Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothi
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.
 """
 struct LinearAliasSpecifier{A, B} <: AbstractAliasSpecifier
-    alias_A::A
-    alias_b::B
-
     function LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
-        return if alias == true
-            new{Bool, Bool}(true, true)
-        elseif alias == false
-            new{Bool, Bool}(false, false)
-        elseif isnothing(alias)
-            new{typeof(alias_A), typeof(alias_b)}(alias_A, alias_b)
-        end
+        alias === true && return new{true, true}()
+        alias === false && return new{false, false}()
+        return new{alias_A, alias_b}()
     end
 end
+
+function Base.getproperty(::LinearAliasSpecifier{A, B}, s::Symbol) where {A, B}
+    s === :alias_A && return A
+    s === :alias_b && return B
+    throw(ArgumentError("LinearAliasSpecifier has no field $s"))
+end
+Base.propertynames(::LinearAliasSpecifier) = (:alias_A, :alias_b)

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -181,7 +181,7 @@ function SymbolicIndexingInterface.set_parameter!(
 end
 
 @doc doc"""
-    LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
+    LinearAliasSpecifier{A, B}(; alias_A = nothing, alias_b = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a LinearProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -190,24 +190,24 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 ### Keywords
 
-* `alias_A::Union{Bool, Nothing}`: alias the `A` array.
-* `alias_b::Union{Bool, Nothing}`: alias the `b` array. 
-* `alias::Union{Bool, Nothing}`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
+* `alias_A`: alias the `A` array.
+* `alias_b`: alias the `b` array. 
+* `alias`: sets all fields of the `LinearAliasSpecifier` to `alias`. 
 
 Creates a `LinearAliasSpecifier` where `alias_A` and `alias_b` default to `nothing`.
 When `alias_A` or `alias_b` is nothing, the default value of the solver is used.
 """
-struct LinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_A::Union{Bool, Nothing}
-    alias_b::Union{Bool, Nothing}
+struct LinearAliasSpecifier{A, B} <: AbstractAliasSpecifier
+    alias_A::A
+    alias_b::B
 
     function LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
         return if alias == true
-            new(true, true)
+            new{Bool, Bool}(true, true)
         elseif alias == false
-            new(false, false)
+            new{Bool, Bool}(false, false)
         elseif isnothing(alias)
-            new(alias_A, alias_b)
+            new{typeof(alias_A), typeof(alias_b)}(alias_A, alias_b)
         end
     end
 end

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -642,22 +642,22 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 * `alias`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
 """
 struct NonlinearAliasSpecifier{P, F, U0} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-
     function NonlinearAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
         )
-        return if isnothing(alias)
-            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
-        elseif alias
-            new{Bool, Bool, Bool}(true, true, true)
-        elseif !alias
-            new{Bool, Bool, Bool}(false, false, false)
-        end
+        isnothing(alias) && return new{alias_p, alias_f, alias_u0}()
+        alias && return new{true, true, true}()
+        return new{false, false, false}()
     end
 end
+
+function Base.getproperty(::NonlinearAliasSpecifier{P, F, U0}, s::Symbol) where {P, F, U0}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    throw(ArgumentError("NonlinearAliasSpecifier has no field $s"))
+end
+Base.propertynames(::NonlinearAliasSpecifier) = (:alias_p, :alias_f, :alias_u0)
 
 struct ImmutableNonlinearProblem{uType, iip, P, F, K, PT} <:
     AbstractNonlinearProblem{uType, iip}

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -627,7 +627,7 @@ function SymbolicIndexingInterface.set_parameter!(prob::SCCNonlinearProblem, val
 end
 
 @doc doc"""
-    NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+    NonlinearAliasSpecifier{P, F, U0}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias when solving a `NonlinearProblem`. 
 Conforms to the AbstractAliasSpecifier interface. 
@@ -636,25 +636,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 ### Keywords
 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array.
-* `alias::Union{Bool, Nothing}`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the `u0` array.
+* `alias`: sets all fields of the `NonlinearAliasSpecifier` to `alias`. 
 """
-struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
+struct NonlinearAliasSpecifier{P, F, U0} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
 
     function NonlinearAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
         )
         return if isnothing(alias)
-            new(alias_p, alias_f, alias_u0)
+            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
         elseif alias
-            new(true, true, true)
+            new{Bool, Bool, Bool}(true, true, true)
         elseif !alias
-            new(false, false, false)
+            new{Bool, Bool, Bool}(false, false, false)
         end
     end
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -567,43 +567,46 @@ end
 @doc doc"""
     ODEAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
-Holds information on what variables to alias
-when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
+Holds information on what variables to alias when solving an ODE.
+Conforms to the AbstractAliasSpecifier interface.
 
-When a keyword argument is `nothing`, the default behaviour of the solver is used.
+The choices are stored as the type parameters, so they are available at compile
+time. When a keyword argument is `nothing`, the default behaviour of the solver
+is used.
 
-### Keywords 
-* `alias_p`
-* `alias_f`
-* `alias_u0`: alias the u0 array. Defaults to false .
-* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops`: alias the tstops array
-* `alias`: sets all fields of the `ODEAliasSpecifier` to `alias`
+### Keywords
+* `alias_p`: alias the parameters `p`.
+* `alias_f`: alias the function `f`.
+* `alias_u0`: alias the `u0` array.
+* `alias_du0`: alias the `du0` array for DAEs.
+* `alias_tstops`: alias the `tstops` array.
+* `alias`: sets all fields of the `ODEAliasSpecifier` to `alias`.
 
 """
 struct ODEAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-
     function ODEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_du0, alias_tstops}()
     end
 end
+
+function Base.getproperty(
+        ::ODEAliasSpecifier{P, F, U0, DU0, TS}, s::Symbol
+    ) where {P, F, U0, DU0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("ODEAliasSpecifier has no field $s"))
+end
+
+Base.propertynames(::ODEAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops)
 
 struct ImmutableODEProblem{uType, tType, isinplace, P, F, K, PT} <:
     AbstractODEProblem{uType, tType, isinplace}

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -599,7 +599,7 @@ struct ODEAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops)
+                typeof(alias_du0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -565,7 +565,7 @@ function IncrementingODEProblem{iip}(
 end
 
 @doc doc"""
-    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+    ODEAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an ODE. Conforms to the AbstractAliasSpecifier interface. 
@@ -573,31 +573,34 @@ when solving an ODE. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `ODEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops`: alias the tstops array
+* `alias`: sets all fields of the `ODEAliasSpecifier` to `alias`
 
 """
-struct ODEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct ODEAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
 
     function ODEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_du0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end
 end

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -176,19 +176,19 @@ when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier inte
 
 """
 struct OptimizationAliasSpecifier{P, F, U0} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-
     function OptimizationAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool}(true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool}(false, false, false)
-        elseif isnothing(alias)
-            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
-        end
+        alias === true && return new{true, true, true}()
+        alias === false && return new{false, false, false}()
+        return new{alias_p, alias_f, alias_u0}()
     end
 end
+
+function Base.getproperty(::OptimizationAliasSpecifier{P, F, U0}, s::Symbol) where {P, F, U0}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    throw(ArgumentError("OptimizationAliasSpecifier has no field $s"))
+end
+Base.propertynames(::OptimizationAliasSpecifier) = (:alias_p, :alias_f, :alias_u0)

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -163,32 +163,32 @@ isinplace(f::OptimizationFunction{iip}) where {iip} = iip
 isinplace(f::OptimizationProblem{iip}) where {iip} = iip
 
 @doc doc"""
-    OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias = nothing)
+    OptimizationAliasSpecifier{P, F, U0}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an OptimizationProblem. Conforms to the AbstractAliasSpecifier interface. 
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias::Union{Bool, Nothing}`: sets all fields of the `OptimizationAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias`: sets all fields of the `OptimizationAliasSpecifier` to `alias`
 
 """
-struct OptimizationAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
+struct OptimizationAliasSpecifier{P, F, U0} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
 
     function OptimizationAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true)
+            new{Bool, Bool, Bool}(true, true, true)
         elseif alias == false
-            new(false, false, false)
+            new{Bool, Bool, Bool}(false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0)
+            new{typeof(alias_p), typeof(alias_f), typeof(alias_u0)}(alias_p, alias_f, alias_u0)
         end
     end
 end

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -141,7 +141,7 @@ struct RODEAliasSpecifier{P, F, U0, DU0, TS, N, J} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_du0),
-                typeof(alias_tstops), typeof(alias_noise), typeof(alias_jumps)
+                typeof(alias_tstops), typeof(alias_noise), typeof(alias_jumps),
             }(
                 alias_p, alias_f, alias_u0, alias_du0,
                 alias_tstops, alias_noise, alias_jumps

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -98,7 +98,7 @@ function RODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
 end
 
 @doc doc"""
-    RODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = false, alias_du0 = false, alias_tstops = false, alias = nothing)
+    RODEAliasSpecifier{P, F, U0, DU0, TS, N, J}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias_noise = nothing, alias_jumps = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an RODEProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -106,24 +106,24 @@ when solving an RODEProblem. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the u0 array. Defaults to false .
-* `alias_du0::Union{Bool, Nothing}`: alias the du0 array for DAEs. Defaults to false.
-* `alias_tstops::Union{Bool, Nothing}`: alias the tstops array
-* `alias_noise::Union{Bool,Nothing}`: alias the noise process
-* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a JumpProcess
-* `alias::Union{Bool, Nothing}`: sets all fields of the `RODEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the u0 array. Defaults to false .
+* `alias_du0`: alias the du0 array for DAEs. Defaults to false.
+* `alias_tstops`: alias the tstops array
+* `alias_noise`: alias the noise process
+* `alias_jumps`: alias jump process if wrapped in a JumpProcess
+* `alias`: sets all fields of the `RODEAliasSpecifier` to `alias`
 
 """
-struct RODEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-    alias_noise::Union{Bool, Nothing}
-    alias_jumps::Union{Bool, Nothing}
+struct RODEAliasSpecifier{P, F, U0, DU0, TS, N, J} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
+    alias_noise::N
+    alias_jumps::J
 
     function RODEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
@@ -131,11 +131,18 @@ struct RODEAliasSpecifier <: AbstractAliasSpecifier
             alias_jumps = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool, Bool, Bool}(
+                true, true, true, true, true, true, true
+            )
         elseif alias == false
-            new(false, false, false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool, Bool, Bool}(
+                false, false, false, false, false, false, false
+            )
         elseif isnothing(alias)
-            new(
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_du0),
+                typeof(alias_tstops), typeof(alias_noise), typeof(alias_jumps)
+            }(
                 alias_p, alias_f, alias_u0, alias_du0,
                 alias_tstops, alias_noise, alias_jumps
             )

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -117,35 +117,30 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct RODEAliasSpecifier{P, F, U0, DU0, TS, N, J} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-    alias_noise::N
-    alias_jumps::J
-
     function RODEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias_noise = nothing,
             alias_jumps = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool, Bool, Bool}(
-                true, true, true, true, true, true, true
-            )
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool, Bool, Bool}(
-                false, false, false, false, false, false, false
-            )
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0), typeof(alias_du0),
-                typeof(alias_tstops), typeof(alias_noise), typeof(alias_jumps),
-            }(
-                alias_p, alias_f, alias_u0, alias_du0,
-                alias_tstops, alias_noise, alias_jumps
-            )
-        end
+        alias === true && return new{true, true, true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false, false, false}()
+        return new{
+            alias_p, alias_f, alias_u0, alias_du0, alias_tstops, alias_noise, alias_jumps,
+        }()
     end
 end
+
+function Base.getproperty(
+        ::RODEAliasSpecifier{P, F, U0, DU0, TS, N, J}, s::Symbol
+    ) where {P, F, U0, DU0, TS, N, J}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    s === :alias_noise && return N
+    s === :alias_jumps && return J
+    throw(ArgumentError("RODEAliasSpecifier has no field $s"))
+end
+Base.propertynames(::RODEAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops, :alias_noise, :alias_jumps)

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -186,7 +186,7 @@ end
 SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob.h
 
 @doc doc"""
-    SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    SDDEAliasSpecifier{P, F, U0, TS, J}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an SDDEProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -194,31 +194,34 @@ when solving an SDDEProblem. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
-* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
-* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a `JumpProcess`
-* `alias::Union{Bool, Nothing}`: sets all fields of the `SDDEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the `u0` array. Defaults to `false`.
+* `alias_tstops`: alias the `tstops` array
+* `alias_jumps`: alias jump process if wrapped in a `JumpProcess`
+* `alias`: sets all fields of the `SDDEAliasSpecifier` to `alias`
 
 """
-struct SDDEAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-    alias_jumps::Union{Bool, Nothing}
+struct SDDEAliasSpecifier{P, F, U0, TS, J}
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_tstops::TS
+    alias_jumps::J
 
     function SDDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_tstops), typeof(alias_jumps)
+            }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end
 end

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -203,25 +203,23 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct SDDEAliasSpecifier{P, F, U0, TS, J}
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_tstops::TS
-    alias_jumps::J
-
     function SDDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_tstops), typeof(alias_jumps),
-            }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_tstops, alias_jumps}()
     end
 end
+
+function Base.getproperty(::SDDEAliasSpecifier{P, F, U0, TS, J}, s::Symbol) where {P, F, U0, TS, J}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_tstops && return TS
+    s === :alias_jumps && return J
+    throw(ArgumentError("SDDEAliasSpecifier has no field $s"))
+end
+Base.propertynames(::SDDEAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_tstops, :alias_jumps)

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -220,7 +220,7 @@ struct SDDEAliasSpecifier{P, F, U0, TS, J}
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_tstops), typeof(alias_jumps)
+                typeof(alias_tstops), typeof(alias_jumps),
             }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -277,7 +277,7 @@ struct SDEAliasSpecifier{P, F, U0, TS, J} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_tstops), typeof(alias_jumps)
+                typeof(alias_tstops), typeof(alias_jumps),
             }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -243,7 +243,7 @@ function DynamicalSDEProblem{iip}(
 end
 
 @doc doc"""
-    SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias = nothing)
+    SDEAliasSpecifier{P, F, U0, TS, J}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving an SDEProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -251,31 +251,34 @@ when solving an SDEProblem. Conforms to the AbstractAliasSpecifier interface.
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
-* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
-* `alias_jumps::Union{Bool, Nothing}`: alias jump process if wrapped in a `JumpProcess`.
-* `alias::Union{Bool, Nothing}`: sets all fields of the `SDEAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the `u0` array. Defaults to `false`.
+* `alias_tstops`: alias the `tstops` array
+* `alias_jumps`: alias jump process if wrapped in a `JumpProcess`.
+* `alias`: sets all fields of the `SDEAliasSpecifier` to `alias`
 
 """
-struct SDEAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
-    alias_jumps::Union{Bool, Nothing}
+struct SDEAliasSpecifier{P, F, U0, TS, J} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_tstops::TS
+    alias_jumps::J
 
     function SDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_tstops), typeof(alias_jumps)
+            }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
         end
     end
 end

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -260,25 +260,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct SDEAliasSpecifier{P, F, U0, TS, J} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_tstops::TS
-    alias_jumps::J
-
     function SDEAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_tstops), typeof(alias_jumps),
-            }(alias_p, alias_f, alias_u0, alias_tstops, alias_jumps)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_tstops, alias_jumps}()
     end
 end
+
+function Base.getproperty(
+        ::SDEAliasSpecifier{P, F, U0, TS, J}, s::Symbol
+    ) where {P, F, U0, TS, J}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_tstops && return TS
+    s === :alias_jumps && return J
+    throw(ArgumentError("SDEAliasSpecifier has no field $s"))
+end
+Base.propertynames(::SDEAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_tstops, :alias_jumps)

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -174,7 +174,7 @@ struct SteadyStateAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
         elseif isnothing(alias)
             new{
                 typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops)
+                typeof(alias_du0), typeof(alias_tstops),
             }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -140,7 +140,7 @@ end
 SymbolicIndexingInterface.is_time_dependent(::SteadyStateProblem) = true
 
 @doc doc"""
-    SteadyStateAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+    SteadyStateAliasSpecifier{P, F, U0, DU0, TS}(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
 
 Holds information on what variables to alias
 when solving a SteadyStateProblem. Conforms to the AbstractAliasSpecifier interface. 
@@ -148,31 +148,34 @@ when solving a SteadyStateProblem. Conforms to the AbstractAliasSpecifier interf
 When a keyword argument is `nothing`, the default behaviour of the solver is used.
 
 ### Keywords 
-* `alias_p::Union{Bool, Nothing}`
-* `alias_f::Union{Bool, Nothing}`
-* `alias_u0::Union{Bool, Nothing}`: alias the `u0` array. Defaults to `false`.
-* `alias_du0::Union{Bool, Nothing}`: alias the `du0` array for DAEs. Defaults to `false`.
-* `alias_tstops::Union{Bool, Nothing}`: alias the `tstops` array
-* `alias::Union{Bool, Nothing}`: sets all fields of the `SteadStateAliasSpecifier` to `alias`
+* `alias_p`
+* `alias_f`
+* `alias_u0`: alias the `u0` array. Defaults to `false`.
+* `alias_du0`: alias the `du0` array for DAEs. Defaults to `false`.
+* `alias_tstops`: alias the `tstops` array
+* `alias`: sets all fields of the `SteadStateAliasSpecifier` to `alias`
 
 """
-struct SteadyStateAliasSpecifier <: AbstractAliasSpecifier
-    alias_p::Union{Bool, Nothing}
-    alias_f::Union{Bool, Nothing}
-    alias_u0::Union{Bool, Nothing}
-    alias_du0::Union{Bool, Nothing}
-    alias_tstops::Union{Bool, Nothing}
+struct SteadyStateAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
+    alias_p::P
+    alias_f::F
+    alias_u0::U0
+    alias_du0::DU0
+    alias_tstops::TS
 
     function SteadyStateAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
         return if alias == true
-            new(true, true, true, true, true)
+            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
         elseif alias == false
-            new(false, false, false, false, false)
+            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
         elseif isnothing(alias)
-            new(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
+            new{
+                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
+                typeof(alias_du0), typeof(alias_tstops)
+            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
         end
     end
 end

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -157,25 +157,25 @@ When a keyword argument is `nothing`, the default behaviour of the solver is use
 
 """
 struct SteadyStateAliasSpecifier{P, F, U0, DU0, TS} <: AbstractAliasSpecifier
-    alias_p::P
-    alias_f::F
-    alias_u0::U0
-    alias_du0::DU0
-    alias_tstops::TS
-
     function SteadyStateAliasSpecifier(;
             alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
             alias_du0 = nothing, alias_tstops = nothing, alias = nothing
         )
-        return if alias == true
-            new{Bool, Bool, Bool, Bool, Bool}(true, true, true, true, true)
-        elseif alias == false
-            new{Bool, Bool, Bool, Bool, Bool}(false, false, false, false, false)
-        elseif isnothing(alias)
-            new{
-                typeof(alias_p), typeof(alias_f), typeof(alias_u0),
-                typeof(alias_du0), typeof(alias_tstops),
-            }(alias_p, alias_f, alias_u0, alias_du0, alias_tstops)
-        end
+        alias === true && return new{true, true, true, true, true}()
+        alias === false && return new{false, false, false, false, false}()
+        return new{alias_p, alias_f, alias_u0, alias_du0, alias_tstops}()
     end
 end
+
+function Base.getproperty(
+        ::SteadyStateAliasSpecifier{P, F, U0, DU0, TS}, s::Symbol
+    ) where {P, F, U0, DU0, TS}
+    s === :alias_p && return P
+    s === :alias_f && return F
+    s === :alias_u0 && return U0
+    s === :alias_du0 && return DU0
+    s === :alias_tstops && return TS
+    throw(ArgumentError("SteadyStateAliasSpecifier has no field $s"))
+end
+Base.propertynames(::SteadyStateAliasSpecifier) =
+    (:alias_p, :alias_f, :alias_u0, :alias_du0, :alias_tstops)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This should help with trimming problems. 

The only drawbacks I can see are : 
adding even more type information to types that are already pretty huge,
changing the aliasing will cause recompilation. 

I don't think either of those will be much of an issue though, to me it's doubtful that users will need to interactively change  the aliasing settings very much. 