### PR TITLE
Fix Zygote sol[:, j] (getindex ::Colon, ::Integer) returning zero gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.30.1"
+version = "3.30.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -53,6 +53,30 @@ end
     return res, Base.tail ∘ pullback
 end
 
+# `sol[:, j::Integer]` selects the whole state at timestep `j` (i.e. `VA.u[j]`).
+# Under RecursiveArrayTools v4 this getindex has no VectorOfArray-specific
+# adjoint, so it would fall through to ChainRules' generic `∇getindex`, whose
+# cotangent the solve reverse pass reads as zero — making `Zygote.gradient` of,
+# e.g., `sum(sol[:, end])` come back all zeros. Scatter `Δ` into the `j`-th slot
+# of a per-timestep cotangent, matching the `sol[i::Integer]` rule below. The
+# `::Colon` method is more specific than the `sym` method above, so `sol[:, j]`
+# dispatches here.
+@adjoint function Base.getindex(VA::ODESolution, ::Colon, j::Integer)
+    function ODESolution_colon_getindex_pullback(Δ)
+        Δ′ = map(enumerate(VA.u)) do (k, x)
+            if k == j
+                δu = zero(x)
+                copyto!(δu, Δ)
+                δu
+            else
+                Zygote.FillArrays.Fill(zero(eltype(x)), size(x))
+            end
+        end
+        return (Δ′, nothing, nothing)
+    end
+    return VA[:, j], ODESolution_colon_getindex_pullback
+end
+
 @adjoint function EnsembleSolution(sim, time, converged, stats)
     out = EnsembleSolution(sim, time, converged, stats)
     function EnsembleSolution_adjoint(p̄::AbstractArray{T, N}) where {T, N}


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Under RecursiveArrayTools v4, `AbstractVectorOfArray` getindex adjoints are inherited from Zygote's generic `AbstractArray` rules, so `sol[:, j]` (whole state at timestep `j`) had **no** VectorOfArray-specific adjoint and fell through to ChainRules' generic `∇getindex` — whose cotangent the solve reverse pass reads as zero. So `Zygote.gradient` of e.g. `sum(sol[:, end])` came back **all zeros** (silently wrong), while `sol[i]`, `sol[:, :]`, and `sol.u[end]` were fine.

Adds an `@adjoint getindex(::ODESolution, ::Colon, ::Integer)` that scatters the cotangent into the `j`-th slot of a per-timestep cotangent, mirroring the existing `sol[i::Integer]` rule. `::Colon` is more specific than the existing `(sym, j::Integer)` method, so `sol[:, j]` dispatches here.

**Verified (Julia 1.10.11):** `Zygote.gradient` of `sum(solve(prob; p)[:, end])` and `[:, 2]` now match `ForwardDiff.gradient` (were `[0,0,0,0]`); `sol[:, :]`/`sol.u[end]` unchanged. Fixes SciMLSensitivity #1522 (the Core1 "VecOfArray - Zygote" failure) — same family as #1410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)