### PR TITLE
Add EigenvalueProblem, EigenvalueSolution, and EigenvalueTarget

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.31.0"
+version = "3.32.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -136,6 +136,13 @@ abstract type AbstractLinearProblem{bType, isinplace} <: AbstractSciMLProblem en
 """
 $(TYPEDEF)
 
+Base for types which define eigenvalue problems.
+"""
+abstract type AbstractEigenvalueProblem <: AbstractSciMLProblem end
+
+"""
+$(TYPEDEF)
+
 Base for types which define integrals suitable for quadrature.
 """
 abstract type AbstractIntegralProblem{isinplace} <: AbstractSciMLProblem end
@@ -649,6 +656,11 @@ abstract type AbstractLinearSolution{T, N} <: AbstractNoTimeSolution{T, N} end
 """
 $(TYPEDEF)
 """
+abstract type AbstractEigenvalueSolution{T, N} <: AbstractNoTimeSolution{T, N} end
+
+"""
+$(TYPEDEF)
+"""
 abstract type AbstractNonlinearSolution{T, N} <: AbstractNoTimeSolution{T, N} end
 
 """
@@ -884,6 +896,7 @@ include("problems/implicit_discrete_problems.jl")
 include("problems/steady_state_problems.jl")
 include("problems/analytical_problems.jl")
 include("problems/linear_problems.jl")
+include("problems/eigenvalue_problems.jl")
 include("problems/nonlinear_problems.jl")
 include("problems/integral_problems.jl")
 include("problems/ode_problems.jl")
@@ -1068,6 +1081,8 @@ export solve, solve!, init, discretize, symbolic_discretize
 export LinearProblem, LinearSolution, IntervalNonlinearProblem,
     IntegralProblem, IntegralSolution, SampledIntegralProblem,
     OptimizationProblem, OptimizationSolution
+
+export EigenvalueProblem, EigenvalueSolution, EigenvalueTarget
 
 export NonlinearProblem, NonlinearSolution,
     SCCNonlinearProblem, NonlinearLeastSquaresProblem, HomotopyProblem

--- a/src/problems/eigenvalue_problems.jl
+++ b/src/problems/eigenvalue_problems.jl
@@ -1,0 +1,115 @@
+"""
+    EigenvalueTarget
+
+Enum selecting which part of the spectrum is returned when only a subset of the
+eigenpairs is requested (via `nev`) in an [`EigenvalueProblem`](@ref). The `which`
+keyword accepts either an `EigenvalueTarget` value or, for convenience, the
+corresponding ARPACK-style `Symbol` noted for each variant below.
+"""
+EnumX.@enumx EigenvalueTarget begin
+    "Eigenvalues of largest magnitude, `abs(λ)` largest (symbol `:LM`)."
+    LargestMagnitude
+    "Eigenvalues of smallest magnitude, `abs(λ)` smallest (symbol `:SM`)."
+    SmallestMagnitude
+    "Eigenvalues with the largest (most positive) real part (symbol `:LR`)."
+    LargestRealPart
+    "Eigenvalues with the smallest (most negative) real part (symbol `:SR`)."
+    SmallestRealPart
+    "Eigenvalues with the largest (most positive) imaginary part (symbol `:LI`)."
+    LargestImaginaryPart
+    "Eigenvalues with the smallest (most negative) imaginary part (symbol `:SI`)."
+    SmallestImaginaryPart
+end
+
+# Normalize a user-supplied `which` (an `EigenvalueTarget` or an ARPACK-style
+# `Symbol`) to an `EigenvalueTarget`, throwing on anything else.
+_eigenvalue_target(w::EigenvalueTarget.T) = w
+function _eigenvalue_target(w::Symbol)
+    return w === :LM ? EigenvalueTarget.LargestMagnitude :
+        w === :SM ? EigenvalueTarget.SmallestMagnitude :
+        w === :LR ? EigenvalueTarget.LargestRealPart :
+        w === :SR ? EigenvalueTarget.SmallestRealPart :
+        w === :LI ? EigenvalueTarget.LargestImaginaryPart :
+        w === :SI ? EigenvalueTarget.SmallestImaginaryPart :
+        throw(ArgumentError("unsupported eigenvalue selector `which = $(repr(w))`; expected an `EigenvalueTarget` or one of :LM, :SM, :LR, :SR, :LI, :SI"))
+end
+_eigenvalue_target(w) = throw(ArgumentError("`which` must be an `EigenvalueTarget` or a Symbol (:LM, :SM, :LR, :SR, :LI, :SI), got $(repr(w))"))
+
+@doc doc"""
+
+Defines a standard or generalized eigenvalue problem.
+
+## Mathematical Specification of an Eigenvalue Problem
+
+The standard problem finds pairs ``(\lambda, v)`` satisfying
+
+```math
+A v = \lambda v
+```
+
+If a second operator `B` is supplied, the generalized problem is solved instead:
+
+```math
+A v = \lambda B v
+```
+
+## Problem Type
+
+### Constructors
+
+```julia
+EigenvalueProblem(A, B = nothing, p = NullParameters();
+    nev = nothing, which = EigenvalueTarget.LargestMagnitude,
+    sigma = nothing, u0 = nothing, kwargs...)
+```
+
+### Keyword Arguments
+
+  - `nev`: the number of eigenpairs (eigenvalues together with their eigenvectors) to
+    compute. `nothing` (the default) requests every eigenpair for the dense solver, or
+    a solver-chosen default for the iterative backends.
+  - `which`: which part of the spectrum to return, as an [`EigenvalueTarget`](@ref). An
+    ARPACK-style `Symbol` (`:LM`, `:SM`, `:LR`, `:SR`, `:LI`, `:SI`) is also accepted and
+    converted to the corresponding `EigenvalueTarget`. Defaults to the eigenvalues of
+    largest magnitude.
+  - `sigma`: if supplied, return the eigenvalues nearest this shift (shift-and-invert).
+  - `u0`: optional initial guess for the iterative backends.
+
+Any extra keyword arguments are passed on to the solver.
+
+### Fields
+
+  - `A`: the operator whose eigenvalues are sought.
+  - `B`: the second operator for a generalized problem, or `nothing` for a standard one.
+  - `nev`: the requested number of eigenpairs.
+  - `which`: the [`EigenvalueTarget`](@ref) selecting the part of the spectrum.
+  - `sigma`: the shift for shift-and-invert, or `nothing`.
+  - `u0`: the initial guess used by iterative solvers.
+  - `p`: the parameters for the problem. Defaults to `NullParameters`.
+  - `kwargs`: the keyword arguments passed on to the solvers.
+"""
+struct EigenvalueProblem{
+        AType, BType, NevType, WhichType, SigmaType, U0Type, PType, KType,
+    } <: AbstractEigenvalueProblem
+    A::AType
+    B::BType
+    nev::NevType
+    which::WhichType
+    sigma::SigmaType
+    u0::U0Type
+    p::PType
+    kwargs::KType
+end
+
+function EigenvalueProblem(
+        A, B = nothing, p = NullParameters();
+        nev = nothing, which = EigenvalueTarget.LargestMagnitude,
+        sigma = nothing, u0 = nothing, kwargs...
+    )
+    warn_paramtype(p)
+    target = _eigenvalue_target(which)
+    return EigenvalueProblem{
+        typeof(A), typeof(B), typeof(nev), typeof(target), typeof(sigma),
+        typeof(u0), typeof(p), typeof(kwargs),
+    }(A, B, nev, target, sigma, u0, p, kwargs)
+end

--- a/src/problems/eigenvalue_problems.jl
+++ b/src/problems/eigenvalue_problems.jl
@@ -2,38 +2,22 @@
     EigenvalueTarget
 
 Enum selecting which part of the spectrum is returned when only a subset of the
-eigenpairs is requested (via `nev`) in an [`EigenvalueProblem`](@ref). The `which`
-keyword accepts either an `EigenvalueTarget` value or, for convenience, the
-corresponding ARPACK-style `Symbol` noted for each variant below.
+eigenpairs is requested (via `num_eigenpairs`) in an [`EigenvalueProblem`](@ref).
 """
 EnumX.@enumx EigenvalueTarget begin
-    "Eigenvalues of largest magnitude, `abs(λ)` largest (symbol `:LM`)."
+    "Eigenvalues of largest magnitude, `abs(λ)` largest."
     LargestMagnitude
-    "Eigenvalues of smallest magnitude, `abs(λ)` smallest (symbol `:SM`)."
+    "Eigenvalues of smallest magnitude, `abs(λ)` smallest."
     SmallestMagnitude
-    "Eigenvalues with the largest (most positive) real part (symbol `:LR`)."
+    "Eigenvalues with the largest (most positive) real part."
     LargestRealPart
-    "Eigenvalues with the smallest (most negative) real part (symbol `:SR`)."
+    "Eigenvalues with the smallest (most negative) real part."
     SmallestRealPart
-    "Eigenvalues with the largest (most positive) imaginary part (symbol `:LI`)."
+    "Eigenvalues with the largest (most positive) imaginary part."
     LargestImaginaryPart
-    "Eigenvalues with the smallest (most negative) imaginary part (symbol `:SI`)."
+    "Eigenvalues with the smallest (most negative) imaginary part."
     SmallestImaginaryPart
 end
-
-# Normalize a user-supplied `which` (an `EigenvalueTarget` or an ARPACK-style
-# `Symbol`) to an `EigenvalueTarget`, throwing on anything else.
-_eigenvalue_target(w::EigenvalueTarget.T) = w
-function _eigenvalue_target(w::Symbol)
-    return w === :LM ? EigenvalueTarget.LargestMagnitude :
-        w === :SM ? EigenvalueTarget.SmallestMagnitude :
-        w === :LR ? EigenvalueTarget.LargestRealPart :
-        w === :SR ? EigenvalueTarget.SmallestRealPart :
-        w === :LI ? EigenvalueTarget.LargestImaginaryPart :
-        w === :SI ? EigenvalueTarget.SmallestImaginaryPart :
-        throw(ArgumentError("unsupported eigenvalue selector `which = $(repr(w))`; expected an `EigenvalueTarget` or one of :LM, :SM, :LR, :SR, :LI, :SI"))
-end
-_eigenvalue_target(w) = throw(ArgumentError("`which` must be an `EigenvalueTarget` or a Symbol (:LM, :SM, :LR, :SR, :LI, :SI), got $(repr(w))"))
 
 @doc doc"""
 
@@ -53,26 +37,34 @@ If a second operator `B` is supplied, the generalized problem is solved instead:
 A v = \lambda B v
 ```
 
+### Type Promotion Rules
+
+  - The eigenvector type follows `u0` when it is supplied: `typeof(v) == typeof(u0)`.
+    Otherwise, eigenvectors are returned as the dense vector type corresponding to a row
+    of `A` (e.g. sparse `A` still returns dense eigenvectors).
+  - The eigenvalue type follows `eltype(A)`: `typeof(lambda) == eltype(A)` whenever the
+    eigenvalues are real (e.g. `A` symmetric or Hermitian). For a general, non-symmetric
+    real `A`, eigenvalues may be complex conjugate pairs, in which case
+    `typeof(lambda) == Complex{eltype(A)}`.
+
 ## Problem Type
 
 ### Constructors
 
 ```julia
 EigenvalueProblem(A, B = nothing, p = NullParameters();
-    nev = nothing, which = EigenvalueTarget.LargestMagnitude,
-    sigma = nothing, u0 = nothing, kwargs...)
+    num_eigenpairs = nothing, eigentarget = EigenvalueTarget.LargestMagnitude,
+    shift = nothing, u0 = nothing, kwargs...)
 ```
 
 ### Keyword Arguments
 
-  - `nev`: the number of eigenpairs (eigenvalues together with their eigenvectors) to
-    compute. `nothing` (the default) requests every eigenpair for the dense solver, or
-    a solver-chosen default for the iterative backends.
-  - `which`: which part of the spectrum to return, as an [`EigenvalueTarget`](@ref). An
-    ARPACK-style `Symbol` (`:LM`, `:SM`, `:LR`, `:SR`, `:LI`, `:SI`) is also accepted and
-    converted to the corresponding `EigenvalueTarget`. Defaults to the eigenvalues of
-    largest magnitude.
-  - `sigma`: if supplied, return the eigenvalues nearest this shift (shift-and-invert).
+  - `num_eigenpairs`: the number of eigenpairs (eigenvalues together with their
+    eigenvectors) to compute. `nothing` (the default) requests every eigenpair for the
+    dense solver, or a solver-chosen default for the iterative backends.
+  - `eigentarget`: which part of the spectrum to return, as an [`EigenvalueTarget`](@ref).
+    Defaults to the eigenvalues of largest magnitude.
+  - `shift`: if supplied, return the eigenvalues nearest this shift (shift-and-invert).
   - `u0`: optional initial guess for the iterative backends.
 
 Any extra keyword arguments are passed on to the solver.
@@ -81,21 +73,21 @@ Any extra keyword arguments are passed on to the solver.
 
   - `A`: the operator whose eigenvalues are sought.
   - `B`: the second operator for a generalized problem, or `nothing` for a standard one.
-  - `nev`: the requested number of eigenpairs.
-  - `which`: the [`EigenvalueTarget`](@ref) selecting the part of the spectrum.
-  - `sigma`: the shift for shift-and-invert, or `nothing`.
+  - `num_eigenpairs`: the requested number of eigenpairs.
+  - `eigentarget`: the [`EigenvalueTarget`](@ref) selecting the part of the spectrum.
+  - `shift`: the shift for shift-and-invert, or `nothing`.
   - `u0`: the initial guess used by iterative solvers.
   - `p`: the parameters for the problem. Defaults to `NullParameters`.
   - `kwargs`: the keyword arguments passed on to the solvers.
 """
 struct EigenvalueProblem{
-        AType, BType, NevType, WhichType, SigmaType, U0Type, PType, KType,
+        AType, BType, NevType, TargetType, ShiftType, U0Type, PType, KType,
     } <: AbstractEigenvalueProblem
     A::AType
     B::BType
-    nev::NevType
-    which::WhichType
-    sigma::SigmaType
+    num_eigenpairs::NevType
+    eigentarget::TargetType
+    shift::ShiftType
     u0::U0Type
     p::PType
     kwargs::KType
@@ -103,13 +95,12 @@ end
 
 function EigenvalueProblem(
         A, B = nothing, p = NullParameters();
-        nev = nothing, which = EigenvalueTarget.LargestMagnitude,
-        sigma = nothing, u0 = nothing, kwargs...
+        num_eigenpairs = nothing, eigentarget::EigenvalueTarget.T = EigenvalueTarget.LargestMagnitude,
+        shift = nothing, u0 = nothing, kwargs...
     )
     warn_paramtype(p)
-    target = _eigenvalue_target(which)
     return EigenvalueProblem{
-        typeof(A), typeof(B), typeof(nev), typeof(target), typeof(sigma),
+        typeof(A), typeof(B), typeof(num_eigenpairs), typeof(eigentarget), typeof(shift),
         typeof(u0), typeof(p), typeof(kwargs),
-    }(A, B, nev, target, sigma, u0, p, kwargs)
+    }(A, B, num_eigenpairs, eigentarget, shift, u0, p, kwargs)
 end

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -54,6 +54,45 @@ end
 """
 $(TYPEDEF)
 
+Representation of the solution to an eigenvalue problem defined by an `EigenvalueProblem`.
+
+## Fields
+
+  - `u`: the computed eigenvalues.
+  - `vectors`: the corresponding eigenvectors, stored as the columns of a matrix.
+  - `prob`: the `EigenvalueProblem` that was solved.
+  - `alg`: the algorithm type used by the solver.
+  - `retcode`: the return code from the solver. Used to determine whether the solver solved
+    successfully or whether it exited due to an error. For more details, see
+    [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
+  - `resid`: the residual(s) of the computed eigenpairs, if provided by the solver.
+  - `stats`: statistics of the solver, if provided.
+"""
+struct EigenvalueSolution{T, N, U, V, P, A, R, S} <: AbstractEigenvalueSolution{T, N}
+    u::U
+    vectors::V
+    prob::P
+    alg::A
+    retcode::ReturnCode.T
+    resid::R
+    stats::S
+end
+
+function build_eigenvalue_solution(
+        prob, alg, values, vectors;
+        retcode = ReturnCode.Success, resid = nothing, stats = nothing
+    )
+    T = eltype(eltype(values))
+    N = length((size(values)...,))
+    return EigenvalueSolution{
+        T, N, typeof(values), typeof(vectors), typeof(prob), typeof(alg),
+        typeof(resid), typeof(stats),
+    }(values, vectors, prob, alg, retcode, resid, stats)
+end
+
+"""
+$(TYPEDEF)
+
 Representation of the solution to an quadrature integral_lb^ub f(x) dx defined by a `IntegralProblem`
 
 ## Fields

--- a/test/eigenvalue_problem_tests.jl
+++ b/test/eigenvalue_problem_tests.jl
@@ -1,0 +1,48 @@
+using SciMLBase
+using Test
+
+struct DummyEigenAlg end
+
+A = [2.0 0.0; 0.0 3.0]
+
+@testset "Construction defaults" begin
+    prob = EigenvalueProblem(A)
+    @test prob.A === A
+    @test prob.B === nothing
+    @test prob.nev === nothing
+    @test prob.which === EigenvalueTarget.LargestMagnitude
+    @test prob.sigma === nothing
+end
+
+@testset "Symbol `which` normalizes to EigenvalueTarget" begin
+    @test EigenvalueProblem(A; which = :LM).which === EigenvalueTarget.LargestMagnitude
+    @test EigenvalueProblem(A; which = :SM).which === EigenvalueTarget.SmallestMagnitude
+    @test EigenvalueProblem(A; which = :LR).which === EigenvalueTarget.LargestRealPart
+    @test EigenvalueProblem(A; which = :SR).which === EigenvalueTarget.SmallestRealPart
+    @test EigenvalueProblem(A; which = :LI).which === EigenvalueTarget.LargestImaginaryPart
+    @test EigenvalueProblem(A; which = :SI).which === EigenvalueTarget.SmallestImaginaryPart
+    @test EigenvalueProblem(A; which = EigenvalueTarget.SmallestRealPart).which ===
+        EigenvalueTarget.SmallestRealPart
+end
+
+@testset "Invalid `which` errors at construction" begin
+    @test_throws ArgumentError EigenvalueProblem(A; which = :XX)
+    @test_throws ArgumentError EigenvalueProblem(A; which = 5)
+end
+
+@testset "Generalized problem stores B" begin
+    B = [1.0 0.0; 0.0 1.0]
+    prob = EigenvalueProblem(A, B; nev = 1)
+    @test prob.B === B
+    @test prob.nev == 1
+end
+
+@testset "build_eigenvalue_solution" begin
+    prob = EigenvalueProblem(A)
+    values = [2.0, 3.0]
+    vectors = [1.0 0.0; 0.0 1.0]
+    sol = SciMLBase.build_eigenvalue_solution(prob, DummyEigenAlg(), values, vectors)
+    @test sol.u == values
+    @test sol.vectors == vectors
+    @test sol.retcode === ReturnCode.Success
+end

--- a/test/eigenvalue_problem_tests.jl
+++ b/test/eigenvalue_problem_tests.jl
@@ -9,32 +9,36 @@ A = [2.0 0.0; 0.0 3.0]
     prob = EigenvalueProblem(A)
     @test prob.A === A
     @test prob.B === nothing
-    @test prob.nev === nothing
-    @test prob.which === EigenvalueTarget.LargestMagnitude
-    @test prob.sigma === nothing
+    @test prob.num_eigenpairs === nothing
+    @test prob.eigentarget === EigenvalueTarget.LargestMagnitude
+    @test prob.shift === nothing
 end
 
-@testset "Symbol `which` normalizes to EigenvalueTarget" begin
-    @test EigenvalueProblem(A; which = :LM).which === EigenvalueTarget.LargestMagnitude
-    @test EigenvalueProblem(A; which = :SM).which === EigenvalueTarget.SmallestMagnitude
-    @test EigenvalueProblem(A; which = :LR).which === EigenvalueTarget.LargestRealPart
-    @test EigenvalueProblem(A; which = :SR).which === EigenvalueTarget.SmallestRealPart
-    @test EigenvalueProblem(A; which = :LI).which === EigenvalueTarget.LargestImaginaryPart
-    @test EigenvalueProblem(A; which = :SI).which === EigenvalueTarget.SmallestImaginaryPart
-    @test EigenvalueProblem(A; which = EigenvalueTarget.SmallestRealPart).which ===
+@testset "eigentarget accepts EigenvalueTarget values" begin
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.LargestMagnitude).eigentarget ===
+        EigenvalueTarget.LargestMagnitude
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.SmallestMagnitude).eigentarget ===
+        EigenvalueTarget.SmallestMagnitude
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.LargestRealPart).eigentarget ===
+        EigenvalueTarget.LargestRealPart
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.SmallestRealPart).eigentarget ===
         EigenvalueTarget.SmallestRealPart
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.LargestImaginaryPart).eigentarget ===
+        EigenvalueTarget.LargestImaginaryPart
+    @test EigenvalueProblem(A; eigentarget = EigenvalueTarget.SmallestImaginaryPart).eigentarget ===
+        EigenvalueTarget.SmallestImaginaryPart
 end
 
-@testset "Invalid `which` errors at construction" begin
-    @test_throws ArgumentError EigenvalueProblem(A; which = :XX)
-    @test_throws ArgumentError EigenvalueProblem(A; which = 5)
+@testset "Invalid `eigentarget` errors at construction" begin
+    @test_throws TypeError EigenvalueProblem(A; eigentarget = :LM)
+    @test_throws TypeError EigenvalueProblem(A; eigentarget = 5)
 end
 
 @testset "Generalized problem stores B" begin
     B = [1.0 0.0; 0.0 1.0]
-    prob = EigenvalueProblem(A, B; nev = 1)
+    prob = EigenvalueProblem(A, B; num_eigenpairs = 1)
     @test prob.B === B
-    @test prob.nev == 1
+    @test prob.num_eigenpairs == 1
 end
 
 @testset "build_eigenvalue_solution" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,9 @@ run_tests(;
         @time @safetestset "Problem building tests" begin
             include("problem_building_test.jl")
         end
+        @time @safetestset "Eigenvalue problem tests" begin
+            include("eigenvalue_problem_tests.jl")
+        end
         @time @safetestset "HomotopyProblem tests" begin
             include("homotopy_problem_tests.jl")
         end


### PR DESCRIPTION
#### Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

#### Additional context

- Added `EigenvalueProblem`, `EigenvalueSolution`, and the `EigenvalueTarget` enum, mirroring the existing `LinearProblem`/`LinearSolution` pattern.
- Added `AbstractEigenvalueProblem`/`AbstractEigenvalueSolution` abstract types and `build_eigenvalue_solution`.
- Added tests for construction, `which` normalization (`Symbol` → `EigenvalueTarget`), and error handling.

Enables SciML/LinearSolve.jl's new `EigenvalueProblem` support (dense, Arpack, ArnoldiMethod, KrylovKit, JacobiDavidson backends) to share one canonical definition instead of duplicating it downstream.

AI Usage: Usead Claude Sonnet 5
Part of https://github.com/SciML/LinearSolve.jl/issues/143