### PR TITLE
Document public API entries

### DIFF
--- a/docs/src/interfaces/Algorithms.md
+++ b/docs/src/interfaces/Algorithms.md
@@ -40,7 +40,14 @@ SciMLBase.has_lazy_interpolation
 SciMLBase.allows_late_binding_tstops
 SciMLBase.has_init
 SciMLBase.has_step
+SciMLBase.alg_order
+SciMLBase.allowsbounds
+SciMLBase.allowsconstraints
+SciMLBase.alg_interpretation
 ```
+
+`SciMLBase.AlgorithmInterpretation` is the public enum namespace for stochastic integral
+interpretations used by `SciMLBase.alg_interpretation`.
 
 ### Abstract SciML Algorithms
 
@@ -50,6 +57,7 @@ SciMLBase.AbstractDEAlgorithm
 SciMLBase.AbstractLinearAlgorithm
 SciMLBase.AbstractNonlinearAlgorithm
 SciMLBase.AbstractIntervalNonlinearAlgorithm
+SciMLBase.AbstractIntegralAlgorithm
 SciMLBase.AbstractQuadratureAlgorithm
 SciMLBase.AbstractOptimizationAlgorithm
 SciMLBase.AbstractSteadyStateAlgorithm
@@ -60,4 +68,13 @@ SciMLBase.AbstractSDEAlgorithm
 SciMLBase.AbstractDAEAlgorithm
 SciMLBase.AbstractDDEAlgorithm
 SciMLBase.AbstractSDDEAlgorithm
+SciMLBase.DAEInitializationAlgorithm
+SciMLBase.AbstractDiscretization
+```
+
+### DAE Initialization Algorithms
+
+```@docs
+SciMLBase.NoInit
+SciMLBase.OverrideInit
 ```

--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -46,3 +46,34 @@ implementations across all solvers for doing things such as checking for common
 errors and throwing high level messages. Solvers can opt-out of the high level
 error handling by directly defining `SciMLBase.init` and `SciMLBase.solve` instead,
 though this is not recommended in order to allow for uniformity of the error messages.
+
+## Low-Level Integrator Interface
+
+```@docs
+SciMLBase.DEIntegrator
+SciMLBase.AbstractODEIntegrator
+SciMLBase.AbstractSDEIntegrator
+SciMLBase.AbstractRODEIntegrator
+SciMLBase.AbstractDDEIntegrator
+SciMLBase.AbstractDAEIntegrator
+SciMLBase.AbstractSDDEIntegrator
+SciMLBase.DECache
+SciMLBase.check_error!
+SciMLBase.initialize_dae!
+SciMLBase.has_reinit
+```
+
+## Initialization Interface
+
+```@docs
+SciMLBase.get_initial_values
+```
+
+## Argument Validation
+
+```@docs
+SciMLBase.numargs
+SciMLBase.FunctionArgumentsError
+SciMLBase.TooFewArgumentsError
+SciMLBase.TooManyArgumentsError
+```

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -141,6 +141,7 @@ SciMLBase.AbstractAliasSpecifier
 SciMLBase.LinearAliasSpecifier
 SciMLBase.NonlinearAliasSpecifier
 SciMLBase.ODEAliasSpecifier
+SciMLBase.RODEAliasSpecifier
 SciMLBase.SDEAliasSpecifier
 SciMLBase.DDEAliasSpecifier
 SciMLBase.SDDEAliasSpecifier
@@ -183,6 +184,7 @@ SciMLBase.AbstractIntegralProblem
 SciMLBase.AbstractOptimizationProblem
 SciMLBase.AbstractNoiseProblem
 SciMLBase.AbstractODEProblem
+SciMLBase.AbstractDynamicalODEProblem
 SciMLBase.AbstractDiscreteProblem
 SciMLBase.AbstractAnalyticalProblem
 SciMLBase.AbstractRODEProblem
@@ -196,10 +198,25 @@ SciMLBase.AbstractJumpProblem
 SciMLBase.AbstractSDDEProblem
 SciMLBase.AbstractConstantLagSDDEProblem
 SciMLBase.AbstractPDEProblem
+SciMLBase.AbstractSteadyStateProblem
 ```
 
 ## Concrete Nonlinear Problems
 
 ```@docs
 SciMLBase.HomotopyProblem
+```
+
+## Concrete ODE Problems
+
+```@docs
+SciMLBase.StandardODEProblem
+```
+
+`SciMLBase.ImmutableODEProblem` is the immutable ODE problem type.
+
+## Problem Utilities
+
+```@docs
+SciMLBase.promote_tspan
 ```

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -114,6 +114,13 @@ library documentations.
 
 ```@docs
 SciMLBase.isinplace(f::SciMLBase.AbstractSciMLFunction)
+SciMLBase.unwrapped_f
+SciMLBase.has_analytic
+SciMLBase.has_jac
+SciMLBase.has_jvp
+SciMLBase.has_vjp
+SciMLBase.has_tgrad
+SciMLBase.has_initialization_data
 ```
 
 ## AbstractSciMLFunction API
@@ -130,4 +137,21 @@ SciMLBase.AbstractRODEFunction
 SciMLBase.AbstractDiscreteFunction
 SciMLBase.AbstractSDDEFunction
 SciMLBase.AbstractNonlinearFunction
+SciMLBase.AbstractParameterizedFunction
+SciMLBase.AbstractHistoryFunction
+```
+
+### Automatic Differentiation Markers
+
+```@docs
+SciMLBase.NoAD
+```
+
+### Function Wrappers
+
+```@docs
+SciMLBase.TimeDerivativeWrapper
+SciMLBase.TimeGradientWrapper
+SciMLBase.UDerivativeWrapper
+SciMLBase.UJacobianWrapper
 ```

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -147,6 +147,10 @@ result(0.5)                  # interpolate the sub-result
 
 ## Solution Traits
 
+```@docs
+SciMLBase.has_stats
+```
+
 ## AbstractSciMLSolution API
 
 ### Abstract SciML Solutions
@@ -166,4 +170,37 @@ SciMLBase.AbstractODESolution
 SciMLBase.AbstractDDESolution
 SciMLBase.AbstractRODESolution
 SciMLBase.AbstractDAESolution
+```
+
+### Solution Statistics
+
+```@docs
+SciMLBase.DEStats
+SciMLBase.NLStats
+```
+
+### Solution Construction and Errors
+
+```@docs
+SciMLBase.build_solution
+SciMLBase.calculate_solution_errors!
+SciMLBase.solution_new_retcode
+```
+
+### Interpolation Types
+
+```@docs
+SciMLBase.AbstractDiffEqInterpolation
+SciMLBase.ConstantInterpolation
+SciMLBase.LinearInterpolation
+SciMLBase.HermiteInterpolation
+SciMLBase.SensitivityInterpolation
+SciMLBase.interp_summary
+```
+
+### Symbolic Utilities
+
+```@docs
+SciMLBase.getindepsym
+SciMLBase.getindepsym_defaultt
 ```

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -280,7 +280,19 @@ Defaults to false
 """
 requires_additive_noise(alg::AbstractSDEAlgorithm) = false
 
+"""
+    AlgorithmInterpretation
+
+Enum of stochastic integral interpretations used by SDE algorithms. The values are
+`AlgorithmInterpretation.Ito` and `AlgorithmInterpretation.Stratonovich`.
+"""
 EnumX.@enumx AlgorithmInterpretation Ito Stratonovich
+@doc """
+    AlgorithmInterpretation
+
+Enum of stochastic integral interpretations used by SDE algorithms. The values are
+`AlgorithmInterpretation.Ito` and `AlgorithmInterpretation.Stratonovich`.
+""" AlgorithmInterpretation
 
 """
     alg_interpretation(alg)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -619,7 +619,17 @@ end
 
 ### Integrator traits
 
+"""
+    has_reinit(i::DEIntegrator)
+
+Return whether `i` supports reinitialization through `reinit!`.
+"""
 has_reinit(i::DEIntegrator) = false
+@doc """
+    has_reinit(i::DEIntegrator)
+
+Return whether `i` supports reinitialization through `reinit!`.
+""" has_reinit
 
 log_instability(integrator) = ""
 
@@ -925,7 +935,17 @@ function step!(integ::DEIntegrator, dt, stop_at_tdt = false)
     return
 end
 
+"""
+    has_stats(i::DEIntegrator)
+
+Return whether `i` stores solve statistics.
+"""
 has_stats(i::DEIntegrator) = false
+@doc """
+    has_stats(i::DEIntegrator)
+
+Return whether `i` stores solve statistics.
+""" has_stats
 
 """
     isadaptive(i::DEIntegrator)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -5326,12 +5326,37 @@ __has_f_prototype(f) = hasfield(typeof(f), :f_prototype)
 
 # compatibility
 has_invW(f::AbstractSciMLFunction) = false
+"""
+    has_analytic(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` analytic solution callback.
+"""
 has_analytic(f::AbstractSciMLFunction) = __has_analytic(f) && f.analytic !== nothing
+"""
+    has_jac(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` Jacobian callback.
+"""
 has_jac(f::AbstractSciMLFunction) = __has_jac(f) && f.jac !== nothing
 has_jac_u(f::AbstractSciMLFunction) = __has_jac_u(f) && f.jac_u !== nothing
 has_jac_du(f::AbstractSciMLFunction) = __has_jac_du(f) && f.jac_du !== nothing
+"""
+    has_jvp(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` Jacobian-vector product callback.
+"""
 has_jvp(f::AbstractSciMLFunction) = __has_jvp(f) && f.jvp !== nothing
+"""
+    has_vjp(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` vector-Jacobian product callback.
+"""
 has_vjp(f::AbstractSciMLFunction) = __has_vjp(f) && f.vjp !== nothing
+"""
+    has_tgrad(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` time-gradient callback.
+"""
 has_tgrad(f::AbstractSciMLFunction) = __has_tgrad(f) && f.tgrad !== nothing
 has_Wfact(f::AbstractSciMLFunction) = __has_Wfact(f) && f.Wfact !== nothing
 has_Wfact_t(f::AbstractSciMLFunction) = __has_Wfact_t(f) && f.Wfact_t !== nothing
@@ -5351,9 +5376,44 @@ end
 function has_initializeprobpmap(f::AbstractSciMLFunction)
     return __has_initializeprobpmap(f) && f.initialization_data.initializeprobpmap !== nothing
 end
+"""
+    has_initialization_data(f)
+
+Return whether `f` carries non-`nothing` initialization metadata.
+"""
 function has_initialization_data(f)
     return __has_initialization_data(f) && f.initialization_data !== nothing
 end
+@doc """
+    has_analytic(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` analytic solution callback.
+""" has_analytic
+@doc """
+    has_jac(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` Jacobian callback.
+""" has_jac
+@doc """
+    has_jvp(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` Jacobian-vector product callback.
+""" has_jvp
+@doc """
+    has_vjp(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` vector-Jacobian product callback.
+""" has_vjp
+@doc """
+    has_tgrad(f::AbstractSciMLFunction)
+
+Return whether `f` has a non-`nothing` time-gradient callback.
+""" has_tgrad
+@doc """
+    has_initialization_data(f)
+
+Return whether `f` carries non-`nothing` initialization metadata.
+""" has_initialization_data
 has_polynomialize(f) = __has_polynomialize(f) && f.polynomialize !== nothing
 has_unpolynomialize(f) = __has_unpolynomialize(f) && f.unpolynomialize !== nothing
 has_denominator(f) = __has_denominator(f) && f.denominator !== nothing

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -119,6 +119,13 @@ end
 struct QuadratureSolution end
 @deprecate QuadratureSolution(args...; kwargs...) IntegralSolution(args...; kwargs...)
 
+"""
+    build_solution(prob, alg, args...; kwargs...)
+
+Construct the solution object returned by a SciML solver for `prob` solved with `alg`.
+Solver implementations use this helper to attach standard fields such as the original
+problem, algorithm, return code, statistics, dense interpolation, and saved values.
+"""
 function build_solution(
         prob::AbstractIntegralProblem,
         alg, u, resid; chi = nothing,
@@ -140,6 +147,13 @@ function build_solution(
         stats
     )
 end
+@doc """
+    build_solution(prob, alg, args...; kwargs...)
+
+Construct the solution object returned by a SciML solver for `prob` solved with `alg`.
+Solver implementations use this helper to attach standard fields such as the original
+problem, algorithm, return code, statistics, dense interpolation, and saved values.
+""" build_solution
 
 function wrap_sol(sol)
     return if hasproperty(sol, :prob) && hasproperty(sol.prob, :problem_type)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -96,6 +96,12 @@ struct TooManyArgumentsError <: Exception
     fname::String
     f::Any
 end
+@doc """
+    TooManyArgumentsError
+
+Exception thrown when a model function defines methods with more arguments than the
+SciML problem interface accepts.
+""" TooManyArgumentsError
 
 function Base.showerror(io::IO, e::TooManyArgumentsError)
     println(io, TOO_MANY_ARGUMENTS_ERROR_MESSAGE)
@@ -182,6 +188,12 @@ struct TooFewArgumentsError <: Exception
     f::Any
     isoptimization::Bool
 end
+@doc """
+    TooFewArgumentsError
+
+Exception thrown when a model function defines methods with fewer arguments than the
+SciML problem interface requires.
+""" TooFewArgumentsError
 
 function Base.showerror(io::IO, e::TooFewArgumentsError)
     if e.isoptimization
@@ -208,6 +220,12 @@ struct FunctionArgumentsError <: Exception
     fname::String
     f::Any
 end
+@doc """
+    FunctionArgumentsError
+
+Exception thrown when a model function's methods do not match the accepted SciML
+problem interface signatures.
+""" FunctionArgumentsError
 
 function Base.showerror(io::IO, e::FunctionArgumentsError)
     println(io, ARGUMENTS_ERROR_MESSAGE)


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add docs coverage for names recently marked public.
- Add concise docstrings for public bindings that needed renderable API docs.

## Verification
- `/home/crackauc/.juliaup/bin/julia +release --project=. scan_public_docs.jl public_target_repos` from the parent workspace reported `SciMLBase.jl	SciMLBase	118	0`.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=docs -e 'using Pkg; Pkg.develop(Pkg.PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` exited 0.\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -m Runic --check .` exited 0.\n- `git diff --check` exited 0.