### PR TITLE
Remove field requirements from AbstractAliasSpecifier

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -789,7 +789,6 @@ abstract type ADOriginator end
 $(TYPEDEF)
 
 Used to specify which variables can be aliased in a solve.
-Every concrete AbstractAliasSpecifier should have at least the fields `alias_p` and `alias_f`.
 """
 abstract type AbstractAliasSpecifier end
 


### PR DESCRIPTION
These are already not followed by `LinearAliasSpecifier`, and I don't believe they make sense for libraries like CurveFit.jl.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API