### PR TITLE
Make AbstractAliasSpecifier public

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1151,7 +1151,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Abstract interface types
 @public AbstractSciMLProblem, AbstractSciMLSolution, AbstractDEAlgorithm,
     AbstractODEProblem, AbstractODEAlgorithm, AbstractNonlinearProblem,
-    AbstractDynamicalODEProblem, AbstractIntegralAlgorithm
+    AbstractDynamicalODEProblem, AbstractIntegralAlgorithm, AbstractAliasSpecifier
 
 # Solution / problem support types
 @public NLStats, NullParameters, AutoSpecialize


### PR DESCRIPTION
I think this should have already been the case since it's a documented type.

Would it be possible to make a new release with it?

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
