### PR TITLE
Allow EigenvalueTarget in ExplicitImports QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -43,10 +43,13 @@ end
     # Aqua.test_piracy(SciMLBase) # failing
 end
 
-# `ReturnCode` and `AlgorithmInterpretation` are `EnumX.@enumx`-generated submodules;
+# `ReturnCode`, `AlgorithmInterpretation`, and `EigenvalueTarget` are
+# `EnumX.@enumx`-generated submodules;
 # their dynamically generated bodies are unanalyzable by ExplicitImports, so they are
 # explicitly allowed rather than analyzed (they import nothing, so nothing is hidden).
-const _ei_unanalyzable = (SciMLBase.ReturnCode, SciMLBase.AlgorithmInterpretation)
+const _ei_unanalyzable = (
+    SciMLBase.ReturnCode, SciMLBase.AlgorithmInterpretation, SciMLBase.EigenvalueTarget,
+)
 
 # Names explicitly imported from dependencies/Base that are not "public" by
 # ExplicitImports' measure, so the public-API import check would otherwise flag them.


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Adds `SciMLBase.EigenvalueTarget` to the existing ExplicitImports unanalyzable allowlist for EnumX-generated modules.
- Keeps the QA check enabled; this mirrors the existing handling for `ReturnCode` and `AlgorithmInterpretation`.

## Local verification
- `timeout 3600 env GROUP=QA ~/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
  - Result: `QA | 15 pass / 15 total`; `Testing SciMLBase tests passed`
- `timeout 3600 ~/.juliaup/bin/julia +1 -e 'using Runic; exit(Runic.main(["--check", "."]))'`
  - Result: passed
- `git diff --check`
  - Result: passed

## Base failure audit
Clean upstream master `c2b0cceef236107656a369c4d5c5aec8f8124d2b` fails the same QA command with `UnanalyzableModuleException` for `SciMLBase.EigenvalueTarget`.

Sidecar audit identified culprit `b892a3809ed8c89cf62215e361ecd11cea4392cc` (`Add EigenvalueProblem, EigenvalueSolution, and EigenvalueTarget (#1417)`), which introduced `EigenvalueTarget` as an `EnumX.@enumx` module after the EnumX allowlist was added.
