### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -11,6 +11,7 @@ down to specific answers, and compute summary statistics on the results.
 ### Building a Problem
 
 ```@docs
+SciMLBase.AbstractEnsembleProblem
 EnsembleProblem
 ```
 
@@ -26,6 +27,8 @@ The choice of ensemble algorithm allows for control over how the multiple trajec
 are handled. Currently, the ensemble algorithm types are:
 
 ```@docs
+SciMLBase.EnsembleAlgorithm
+SciMLBase.BasicEnsembleAlgorithm
 EnsembleSerial
 EnsembleThreads
 EnsembleDistributed

--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -47,6 +47,11 @@ errors and throwing high level messages. Solvers can opt-out of the high level
 error handling by directly defining `SciMLBase.init` and `SciMLBase.solve` instead,
 though this is not recommended in order to allow for uniformity of the error messages.
 
+```@docs
+SciMLBase.__init
+SciMLBase.__solve
+```
+
 ## Low-Level Integrator Interface
 
 ```@docs

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -78,6 +78,10 @@ informative error if the parameter is used or accessed within the user's functio
 for example, `p[1]` will throw an informative error about forgetting to pass
 parameters.
 
+```@docs
+SciMLBase.NullParameters
+```
+
 ### Keyword Argument Splatting
 
 All `AbstractSciMLProblem` types allow for passing keyword arguments that would get forwarded
@@ -222,6 +226,7 @@ SciMLBase.HomotopyProblem
 
 ```@docs
 SciMLBase.StandardODEProblem
+SciMLBase.ImmutableODEProblem
 ```
 
 `SciMLBase.ImmutableODEProblem` is the immutable ODE problem type.

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -128,6 +128,7 @@ SciMLBase.has_initialization_data
 ### Abstract SciML Functions
 
 ```@docs
+SciMLBase.AbstractSciMLFunction
 SciMLBase.AbstractDiffEqFunction
 SciMLBase.AbstractODEFunction
 SciMLBase.AbstractSDEFunction

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -381,6 +381,13 @@ abstract type AbstractSDDEAlgorithm <: AbstractDEAlgorithm end
 
 """
 $(TYPEDEF)
+
+The supertype of all ensemble algorithms, i.e. the algorithms passed as the
+`ensemblealg` argument to `solve(::EnsembleProblem, alg, ensemblealg; ...)` to control
+how the many trajectories of an [`EnsembleProblem`](@ref) are executed. Subtypes select
+the parallelization strategy (serial, threaded, distributed, GPU, ...); see
+[`BasicEnsembleAlgorithm`](@ref) for the CPU-parallelism implementations built into
+SciMLBase.
 """
 abstract type EnsembleAlgorithm <: AbstractSciMLAlgorithm end
 
@@ -526,6 +533,13 @@ abstract type AbstractDiscretizationMetadata{hasTime} end
 # Monte Carlo Simulations
 """
 $(TYPEDEF)
+
+The supertype of all ensemble problem types. An ensemble problem wraps a base
+`AbstractSciMLProblem` together with the functions (`prob_func`, `output_func`,
+`reduction`, ...) needed to generate, run, and reduce many related trajectories under
+the [parallel ensemble interface](@ref ensemble). The concrete implementation is
+[`EnsembleProblem`](@ref); solving one dispatches on the chosen
+[`EnsembleAlgorithm`](@ref).
 """
 abstract type AbstractEnsembleProblem <: AbstractSciMLProblem end
 

--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -1,5 +1,12 @@
 """
 $(TYPEDEF)
+
+The supertype of the CPU-parallelism ensemble algorithms provided by SciMLBase, i.e. the
+ensemble algorithms whose trajectory execution is handled by the generic
+`__solve(prob::AbstractEnsembleProblem, alg, ensemblealg::BasicEnsembleAlgorithm)`
+loop rather than by an external backend. Its subtypes select how the trajectories are
+distributed: [`EnsembleSerial`](@ref), [`EnsembleThreads`](@ref),
+[`EnsembleDistributed`](@ref), and [`EnsembleSplitThreads`](@ref).
 """
 abstract type BasicEnsembleAlgorithm <: EnsembleAlgorithm end
 

--- a/src/problems/problem_utils.jl
+++ b/src/problems/problem_utils.jl
@@ -172,6 +172,26 @@ function Base.summary(io::IO, prob::AbstractEnsembleProblem)
 end
 Base.show(io::IO, mime::MIME"text/plain", A::AbstractEnsembleProblem) = summary(io, A)
 
+"""
+$(TYPEDEF)
+
+A singleton type used as the default value of the parameter argument `p` in
+`AbstractSciMLProblem` constructors (for example `ODEProblem(f, u0, tspan)` with no
+`p` supplied). It marks the absence of parameters.
+
+`NullParameters` is deliberately not indexable or broadcastable: any attempt to index
+into it (such as `p[1]` or `x .+ p` inside a problem's function) throws an error with a
+message explaining that no parameters were passed to the problem. This turns the common
+mistake of forgetting to supply `p` (or using the wrong function signature) into an
+informative error rather than a confusing downstream failure.
+
+## Example
+
+```julia
+prob = ODEProblem(f, u0, tspan)      # prob.p === NullParameters()
+prob = ODEProblem(f, u0, tspan, p)   # prob.p === p
+```
+"""
 struct NullParameters end
 
 const NO_PARAMETERS_INDEX_ERROR_MESSAGE = """


### PR DESCRIPTION
## Summary

Fills documentation gaps for public (exported / `@public`) SciMLBase names that either lacked a real docstring or lacked a rendered `@docs` entry. Audited authoritatively by loading the package on Julia 1 and checking `@doc` output for every `names(SciMLBase; all=false)` entry.

Names addressed:

| Name | Gap found | Fix |
|------|-----------|-----|
| `NullParameters` | no docstring at all (`@doc` -> `nothing`) | new docstring + `@docs` in Problems.md (Default Parameters) |
| `AbstractEnsembleProblem` | bare `$(TYPEDEF)` only, no rendered entry | expanded docstring + `@docs` in Ensembles.md |
| `EnsembleAlgorithm` | bare `$(TYPEDEF)` only, no rendered entry | expanded docstring + `@docs` in Ensembles.md |
| `BasicEnsembleAlgorithm` | bare `$(TYPEDEF)` only, no rendered entry | expanded docstring + `@docs` in Ensembles.md |
| `AbstractSciMLFunction` | had docstring, no rendered entry | `@docs` in SciMLFunctions.md |
| `ImmutableODEProblem` | had docstring, no rendered entry | `@docs` in Problems.md (Concrete ODE Problems) |
| `__init` (+ companion `__solve`) | had docstring, no rendered entry | `@docs` in Init_Solve.md |

All new docstrings are based on the actual implementation (no invented behavior) and follow the surrounding `$(TYPEDEF)` + prose style.

## Validation

Ran a strict Documenter build (`warnonly` excluding `:docs_block` and `:cross_references`) over the new `@docs` entries and their `@ref` targets:
- Every new `@docs` entry resolves to a real docstring (no `docs_block` / "no docstring found" error).
- Every `@ref` cross-reference inside the new docstrings resolves (no `cross_references` error).
- Build exits 0.

Also confirmed on Julia 1 that each of the 7 names now renders a non-empty docstring via `@doc SciMLBase.<name>`.

Runic-clean on all changed `src/*.jl`.

## Note

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)