### PR TITLE
Accept λ-extended derivative arities in NonlinearFunction for HomotopyProblem

### DIFF
--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -762,9 +762,12 @@ argument convention with ``\lambda`` in place of `t`:
 ### Fields
 
 * `f`: The residual function, called as `f(u, p, λ)` (or `f(du, u, p, λ)` in-place).
-  Optional derivative fields of the wrapped `NonlinearFunction` (e.g. `jac`), if
-  provided, must follow the same λ-extended argument convention; continuation solvers
-  do not consume them yet.
+  Optional derivative fields of the wrapped `NonlinearFunction` (`jac`, `jac_prototype`,
+  `sparsity`, `colorvec`, ...), if provided, must follow the same λ-extended argument
+  convention, e.g. `jac(u, p, λ)` (or `jac(J, u, p, λ)` in-place); they are consumed by
+  NonlinearSolve.jl's continuation solvers. Pass `lambda_extended = true` to the
+  `NonlinearFunction` constructor so that `jac`, `jvp`, and `vjp` are validated against
+  the λ-extended arities instead of the standard nonlinear ones.
 * `u0`: The initial guess (a solution of the simplified system at `λspan[1]`).
 * `p`: The parameters, passed through to `f` unchanged; ``\lambda`` is not part of `p`.
 * `λspan`: the `(start, stop)` continuation interval; the target system is at `stop`.

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1756,6 +1756,17 @@ the usage of `f`. These include:
   internally computed on demand when required. The cost of this operation is highly dependent
   on the sparsity pattern.
 
+## lambda_extended: λ-Extended Argument Convention for `HomotopyProblem`
+
+When the function is destined for a [`HomotopyProblem`](@ref), every function follows
+the λ-extended argument convention with the scalar continuation parameter λ as a
+trailing argument: the residual is `f(u, p, λ)` / `f!(du, u, p, λ)` and the derivative
+functions gain the same trailing argument, e.g. `jac(u, p, λ)` / `jac(J, u, p, λ)`.
+Passing the keyword argument `lambda_extended = true` to the constructor validates
+`jac`, `jvp`, and `vjp` against these λ-extended arities instead of the standard
+nonlinear ones, so a bare λ-extended Jacobian is accepted. `lambda_extended` only
+affects constructor-time argument checking; it is not stored as a field.
+
 ## iip: In-Place vs Out-Of-Place
 
 For more details on this argument, see the ODEFunction documentation.
@@ -4357,7 +4368,8 @@ function NonlinearFunction{iip, specialize}(
         sys = __has_sys(f) ? f.sys : nothing,
         resid_prototype = __has_resid_prototype(f) ? f.resid_prototype : nothing,
         initialization_data = __has_initialization_data(f) ? f.initialization_data :
-            nothing
+            nothing,
+        lambda_extended = false
     ) where {
         iip, specialize,
     }
@@ -4380,9 +4392,12 @@ function NonlinearFunction{iip, specialize}(
         _colorvec = colorvec
     end
 
-    jaciip = jac !== nothing ? isinplace(jac, 3, "jac", iip) : iip
-    jvpiip = jvp !== nothing ? isinplace(jvp, 4, "jvp", iip) : iip
-    vjpiip = vjp !== nothing ? isinplace(vjp, 4, "vjp", iip) : iip
+    # `lambda_extended` shifts every derivative-function arity by one for the trailing
+    # continuation parameter λ of `HomotopyProblem`: `jac(J, u, p, λ)` / `jac(u, p, λ)`.
+    argshift = lambda_extended ? 1 : 0
+    jaciip = jac !== nothing ? isinplace(jac, 3 + argshift, "jac", iip) : iip
+    jvpiip = jvp !== nothing ? isinplace(jvp, 4 + argshift, "jvp", iip) : iip
+    vjpiip = vjp !== nothing ? isinplace(vjp, 4 + argshift, "vjp", iip) : iip
 
     nonconforming = (jaciip, jvpiip, vjpiip) .!= iip
     if any(nonconforming)
@@ -4435,8 +4450,11 @@ function NonlinearFunction{iip}(f; kwargs...) where {iip}
     return NonlinearFunction{iip, DEFAULT_SPECIALIZATION}(f; kwargs...)
 end
 NonlinearFunction{iip}(f::NonlinearFunction; kwargs...) where {iip} = f
-function NonlinearFunction(f; kwargs...)
-    return NonlinearFunction{isinplace(f, 3), DEFAULT_SPECIALIZATION}(f; kwargs...)
+function NonlinearFunction(f; lambda_extended = false, kwargs...)
+    iip = isinplace(f, lambda_extended ? 4 : 3)
+    return NonlinearFunction{iip, DEFAULT_SPECIALIZATION}(
+        f; lambda_extended = lambda_extended, kwargs...
+    )
 end
 NonlinearFunction(f::NonlinearFunction; kwargs...) = f
 

--- a/test/homotopy_problem_tests.jl
+++ b/test/homotopy_problem_tests.jl
@@ -89,3 +89,72 @@ end
     @test SciMLBase.isinplace(newprob) == false
     @test newprob.λspan == (0.0, 1.0)                     # preserved
 end
+
+# Derivative fields follow the λ-extended convention: jac(u, p, λ) / jac(J, u, p, λ).
+# `lambda_extended = true` makes the NonlinearFunction constructor validate jac/jvp/vjp
+# against these arities so a bare λ-extended jac (no λ-free dummy method) is accepted.
+j_oop(u, p, λ) = reshape([(1 - λ) + λ * 2 * u[1];;], 1, 1)
+j_iip(J, u, p, λ) = (J[1, 1] = (1 - λ) + λ * 2 * u[1]; nothing)
+
+@testset "λ-extended jac: bare 3-arg oop / 4-arg iip construct with lambda_extended" begin
+    # without the opt-in, the standard conformance check rejects them (unchanged)
+    @test_throws SciMLBase.NonconformingFunctionsError NonlinearFunction{false}(
+        f_oop; jac = j_oop
+    )
+    @test_throws SciMLBase.TooManyArgumentsError NonlinearFunction{true}(
+        f_iip; jac = j_iip
+    )
+
+    nf_oop = NonlinearFunction{false}(f_oop; jac = j_oop, lambda_extended = true)
+    @test SciMLBase.__has_jac(nf_oop)
+    @test nf_oop.jac === j_oop
+    prob_oop = HomotopyProblem(nf_oop, u0, p)
+    @test SciMLBase.isinplace(prob_oop) == false
+    @test prob_oop.f.jac === j_oop
+
+    nf_iip = NonlinearFunction{true}(f_iip; jac = j_iip, lambda_extended = true)
+    @test nf_iip.jac === j_iip
+    prob_iip = HomotopyProblem(nf_iip, u0, p)
+    @test SciMLBase.isinplace(prob_iip) == true
+    @test prob_iip.f.jac === j_iip
+end
+
+@testset "λ-extended autodetect: NonlinearFunction(f; lambda_extended = true)" begin
+    nf_oop = NonlinearFunction(f_oop; jac = j_oop, lambda_extended = true)
+    @test SciMLBase.isinplace(nf_oop) == false
+    nf_iip = NonlinearFunction(f_iip; jac = j_iip, lambda_extended = true)
+    @test SciMLBase.isinplace(nf_iip) == true
+end
+
+@testset "λ-extended jvp/vjp arities shift too" begin
+    jvp_oop(v, u, p, λ) = ((1 - λ) + λ * 2 * u[1]) .* v
+    vjp_iip(vJ, v, u, p, λ) = (vJ[1] = ((1 - λ) + λ * 2 * u[1]) * v[1]; nothing)
+    nf_oop = NonlinearFunction{false}(f_oop; jvp = jvp_oop, lambda_extended = true)
+    @test nf_oop.jvp === jvp_oop
+    nf_iip = NonlinearFunction{true}(f_iip; vjp = vjp_iip, lambda_extended = true)
+    @test nf_iip.vjp === vjp_iip
+end
+
+@testset "lambda_extended still rejects nonconforming derivative functions" begin
+    # an iip λ-extended jac with an oop residual is still nonconforming
+    @test_throws SciMLBase.NonconformingFunctionsError NonlinearFunction{false}(
+        f_oop; jac = j_iip, lambda_extended = true
+    )
+    j_toomany(J, u, p, λ, x) = nothing
+    @test_throws SciMLBase.TooManyArgumentsError NonlinearFunction{true}(
+        f_iip; jac = j_toomany, lambda_extended = true
+    )
+end
+
+@testset "λ-extended structure fields pass through" begin
+    import LinearAlgebra
+    proto = LinearAlgebra.Diagonal(ones(1))
+    nf = NonlinearFunction{true}(
+        f_iip; jac = j_iip, jac_prototype = proto, colorvec = [1],
+        lambda_extended = true
+    )
+    prob = HomotopyProblem(nf, u0, p)
+    @test prob.f.jac_prototype === proto
+    @test prob.f.sparsity === proto            # sparsity defaults to jac_prototype
+    @test prob.f.colorvec == [1]
+end


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What

`HomotopyProblem`'s docstring documents that **all** functions of the wrapped `NonlinearFunction` follow the λ-extended argument convention: residual `f(u, p, λ)` (oop) / `f(du, u, p, λ)` (iip), and derivative fields likewise, e.g. `jac(u, p, λ)` / `jac(J, u, p, λ)`. As of SciML/NonlinearSolve.jl#1022 (for SciML/NonlinearSolve.jl#1020), NonlinearSolve's continuation solvers actually consume the derivative fields (`jac`, `jac_prototype`, `sparsity`, `colorvec`).

However, the `NonlinearFunction` constructor validates `jac`/`jvp`/`vjp` against the **standard** nonlinear arities (`jac(u, p)` / `jac(J, u, p)`), so a bare λ-extended jac is rejected at construction time:

- oop, 3-argument `jac(u, p, λ)` → `NonconformingFunctionsError` (classified as an iip jac attached to an oop function)
- iip, 4-argument `jac(J, u, p, λ)` → `TooManyArgumentsError`

NonlinearSolve#1022's tests currently work around this by defining a dummy λ-free method on every jac purely to get past the constructor.

## Fix

Add a `lambda_extended` keyword (default `false`, consumed by the constructor, not stored as a field) to the `NonlinearFunction` constructor that shifts the `jac`/`jvp`/`vjp` conformance-check arities by the one trailing λ argument, and shifts the residual in-place autodetection in `NonlinearFunction(f; ...)` from `isinplace(f, 3)` to `isinplace(f, 4)` the same way:

```julia
nf = NonlinearFunction{true}(f; jac = (J, u, p, λ) -> ..., lambda_extended = true)
prob = HomotopyProblem(nf, u0, p)
```

- With the keyword unset, behavior is byte-for-byte unchanged: the standard conformance checks for ordinary `NonlinearProblem`s are untouched (existing `@test_throws` for both error paths are included in the new tests).
- With `lambda_extended = true`, nonconforming functions are still rejected with the same error types, just against the λ-extended arities (also tested).

## Why this design (and not the alternatives)

- *Validating inside `HomotopyProblem`'s constructor path instead:* not possible for the documented usage pattern `HomotopyProblem(NonlinearFunction{iip}(f; jac = ...), u0, p)` — the `NonlinearFunction` is fully constructed (and throws) before `HomotopyProblem` ever sees anything, and no `HomotopyProblem` signature receives bare derivative fields. Making `HomotopyProblem(f, u0, p; jac = ..., ...)` split function-field kwargs out of its solver-kwarg passthrough would be a larger, more ambiguous API change and would still need a check bypass inside.
- *Relaxing the standard check:* a 3-argument oop λ-extended jac is arity-indistinguishable from a mistakenly-passed standard iip jac, so silently accepting it would weaken the conformance check for ordinary nonlinear problems. Hence an explicit opt-in.
- SciMLBase has no existing conformance-skip mechanism (only the fully-typed positional inner constructor, which would duplicate the derived-default logic for `sparsity`/`colorvec`/operator jacs and be brittle to field changes).

Docstring updates: `NonlinearFunction` documents the new keyword; `HomotopyProblem` no longer says continuation solvers "do not consume them yet" and points to `lambda_extended` for construction.

## Verification (all run locally, Julia 1.11.9)

- Reproduced both failures on master first (`NonconformingFunctionsError` oop / `TooManyArgumentsError` iip), then made them pass.
- `test/homotopy_problem_tests.jl` (including the new λ-extended testsets): **48/48 pass**.
- `test/function_building_error_messages.jl` (conformance/`isinplace`/`numargs` machinery): **265/265 pass**.
- `test/problem_building_test.jl`: **34/34 pass**.
- End-to-end against NonlinearSolve#1022's `homotopy-jac-passthrough` branch with this SciMLBase `Pkg.develop`ed in: ran `test/Core/homotopy_jac_tests__item1.jl` with **all six dummy λ-free jac methods removed** and `lambda_extended = true` added to the jac-carrying constructions — **30/30 pass** (analytic jac consumed in oop/iip/polyalg/SimpleHomotopySweep paths, Tridiagonal `jac_prototype` honored).
- Runic run on the three changed files (no further changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)