### PR TITLE
Bump version to 3.34.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.33.1"
+version = "3.34.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

#1430 (the `lambda_extended` `NonlinearFunction` kwarg) merged after 3.33.1 was registered, so master carries an unreleased public feature. New public API ⇒ minor bump per SemVer.

Releasing this unblocks SciML/NonlinearSolve.jl#1027, which now carries a `SciMLBase = "3.34"` compat floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)