### PR TITLE
Restore ConstructionBase compatibility bindings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.34.0"
+version = "3.34.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -3,7 +3,7 @@ if isdefined(Base, :Experimental) &&
         isdefined(Base.Experimental, Symbol("@max_methods"))
     @eval Base.Experimental.@max_methods 1
 end
-using ConstructionBase: ConstructionBase, getproperties, setproperties
+using ConstructionBase: ConstructionBase, constructorof, getfields, getproperties, setproperties
 using RecipesBase: RecipesBase, @recipe, @series
 using RecursiveArrayTools: RecursiveArrayTools, AbstractDiffEqArray,
     AbstractVectorOfArray, ArrayPartition, DiffEqArray,

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -1,4 +1,7 @@
-using Test, SciMLBase, SymbolicIndexingInterface, Accessors, StaticArrays
+using Test, SciMLBase, SymbolicIndexingInterface, Accessors, ConstructionBase, StaticArrays
+
+@test SciMLBase.constructorof === ConstructionBase.constructorof
+@test SciMLBase.getfields === ConstructionBase.getfields
 
 function simplependulum!(du, u, p, t)
     θ = u[1]

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -70,11 +70,10 @@ const _ei_nonpublic_explicit_imports = (
 # `function SciMLBase.name(...)` method extension), but never called as a bare name
 # inside SciMLBase itself, so ExplicitImports would otherwise report them as stale.
 const _ei_stale_allowed = (
-    # `ConstructionBase.setproperties` is extended for the solution types and accessed
-    # as `SciMLBase.setproperties` by downstream packages (e.g. OrdinaryDiffEqNonlinearSolve
-    # defines `function SciMLBase.setproperties(::DAEResidualJacobianWrapper, ...)`), so it
-    # must be a binding in SciMLBase even though SciMLBase only ever uses the qualified form.
-    :setproperties,
+    # These ConstructionBase exports remain bindings in SciMLBase for compatibility with
+    # downstream qualified accesses and method extensions. SciMLBase itself uses their
+    # owner-qualified forms, so ExplicitImports otherwise reports the bindings as stale.
+    :constructorof, :getfields, :setproperties,
 )
 const _ei_nonpublic_qualified_accesses = (
     # --- Genuine Base/Core internals: not public on any Julia version, no public


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- restore `SciMLBase.constructorof` and `SciMLBase.getfields` as bindings to their public ConstructionBase owners
- add focused regression assertions for both qualified compatibility bindings
- retain the bindings in ExplicitImports QA and bump the patch version to 3.34.1

## Regression evidence

Commit `150cfc68f6` changed `using ConstructionBase` to an explicit list and unintentionally omitted two of ConstructionBase 1.6.0s five exports. Local boundary verification on Julia 1.10.11 showed:

- parent `77a86c02e`: `constructorof=true`, `getfields=true`, `setproperties=true`
- introducing commit `150cfc68f6`: `constructorof=false`, `getfields=false`, `setproperties=true`
- unmodified `origin/master` at `a13a7d3b4`: `constructorof=false`

SciMLBase master downstream CI also reports `could not import SciMLBase.constructorof into OrdinaryDiffEqDifferentiation`, followed by `UndefVarError: constructorof` in OrdinaryDiffEq interpolation/cache stripping. With this patch, released `OrdinaryDiffEqDifferentiation v3.2.2` precompiles and its imported binding is identical to `SciMLBase.constructorof`.

The adjacent removed ConstructionBase name was `getfields`; code search found no current SciML qualified consumer, but restoring it preserves the same pre-refactor compatibility surface.

## Separate OrdinaryDiffEq release skew

The same master downstream run exposes `OrdinaryDiffEqFIRK v2.3.2 + OrdinaryDiffEqNonlinearSolve v2.1.0` failing with `UndefVarError: FastConvergence`. I reproduced that exact version pair locally. It is independent of SciMLBase commit `150cfc68f6`: OrdinaryDiffEq commit `661f605` removed the `FastConvergence` binding from OrdinaryDiffEqNonlinearSolve while moving FIRK source to import the enum from its owner, OrdinaryDiffEqCore. The registered FIRK 2.3.2 predates that caller migration, while the current OrdinaryDiffEq source already contains the owner-correct import and has version 2.4.0 staged. This PR does not define an OrdinaryDiffEq-owned enum in SciMLBase.

## Local verification

Julia 1.10.11 with a depot local to the worktree:

- focused binding assertions: 2/2 passed
- released downstream import/precompile: `OrdinaryDiffEqDifferentiation v3.2.2 constructorof import/precompile passed`
- `GROUP=QA Pkg.test()`: 13/13 passed
- full `Pkg.test()`: all groups passed, including Problem building 36/36 and Remake 4430/4430; final output `Testing SciMLBase tests passed`
- Runic 1.7.0 `--check` on all changed Julia files: passed with no changes

## Process

The investigation used isolated worktrees for `origin/master` and the regression boundary, inspected the introducing diff and ConstructionBase exports, reproduced both downstream import failures with released versions, applied the smallest owner-correct SciMLBase compatibility restoration, and removed all temporary depots/environments before committing.