### PR TITLE
Interface to MTK and OrdinaryDiffEq for error logging

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -621,7 +621,11 @@ end
 
 has_reinit(i::DEIntegrator) = false
 
-log_instability(integrator) = ""
+log_numerical_instability(integrator; jacobian_logging::Bool = true) = ""
+
+has_mtk_sys(integrator) = false
+
+diagnose_symbolic_instability(integrator) = ""
 
 ### Display
 
@@ -696,12 +700,16 @@ function check_error(integrator::DEIntegrator)
                         true
                 )
             )
-            diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? log_instability(integrator) : ""
+            symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+            numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
+            diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
             EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
             @SciMLMessage(lazy"dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable.$diagnostic", verbose, :dt_min_unstable)
             return ReturnCode.DtLessThanMin
         elseif !step_accepted && integrator.t isa AbstractFloat && abs(integrator.dt) <= abs(eps(integrator.t))
-            diagnostic = verbosity_to_bool(verbose.dt_epsilon) ? log_instability(integrator) : ""
+            symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+            numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
+            diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
             EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
             @SciMLMessage(lazy"At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or it cannot be represented in $(eltype(integrator.u)) precision).$diagnostic", verbose, :dt_epsilon)
             return ReturnCode.Unstable
@@ -709,7 +717,9 @@ function check_error(integrator::DEIntegrator)
     end
     if step_accepted &&
             opts.unstable_check(integrator.dt, integrator.u, integrator.p, integrator.t)
-        diagnostic = verbosity_to_bool(verbose.instability) ? log_instability(integrator) : ""
+        symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+        numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
+        diagnostic = verbosity_to_bool(verbose.instability) ? numeric_diagnostic * symbolic_diagnostic : ""
         @SciMLMessage("Instability detected. Aborting.$diagnostic", verbose, :instability)
         return ReturnCode.Unstable
     end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -625,7 +625,7 @@ log_numerical_instability(integrator; jacobian_logging::Bool = true) = ""
 
 has_mtk_sys(integrator) = false
 
-diagnose_symbolic_instability(integrator) = ""
+diagnose_symbolic_instability(sys, u, uprev) = ""
 
 ### Display
 
@@ -700,14 +700,16 @@ function check_error(integrator::DEIntegrator)
                         true
                 )
             )
-            symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+            sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
+            symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
             numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
             diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
             EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
             @SciMLMessage(lazy"dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable.$diagnostic", verbose, :dt_min_unstable)
             return ReturnCode.DtLessThanMin
         elseif !step_accepted && integrator.t isa AbstractFloat && abs(integrator.dt) <= abs(eps(integrator.t))
-            symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+            sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
+            symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
             numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
             diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
             EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
@@ -717,7 +719,8 @@ function check_error(integrator::DEIntegrator)
     end
     if step_accepted &&
             opts.unstable_check(integrator.dt, integrator.u, integrator.p, integrator.t)
-        symbolic_diagnostic = has_mtk_sys(integrator) ? diagnose_symbolic_instability(integrator) : ""
+        sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
+        symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
         numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
         diagnostic = verbosity_to_bool(verbose.instability) ? numeric_diagnostic * symbolic_diagnostic : ""
         @SciMLMessage("Instability detected. Aborting.$diagnostic", verbose, :instability)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Supports PRs to OrdinaryDiffEq and MTK, builds on prior work in a refactor