### PR TITLE
Re-export ConstructionBase.constructorof from SciMLBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.34.0"
+version = "3.34.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -3,7 +3,7 @@ if isdefined(Base, :Experimental) &&
         isdefined(Base.Experimental, Symbol("@max_methods"))
     @eval Base.Experimental.@max_methods 1
 end
-using ConstructionBase: ConstructionBase, getproperties, setproperties
+using ConstructionBase: ConstructionBase, constructorof, getproperties, setproperties
 using RecipesBase: RecipesBase, @recipe, @series
 using RecursiveArrayTools: RecursiveArrayTools, AbstractDiffEqArray,
     AbstractVectorOfArray, ArrayPartition, DiffEqArray,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -75,6 +75,11 @@ const _ei_stale_allowed = (
     # defines `function SciMLBase.setproperties(::DAEResidualJacobianWrapper, ...)`), so it
     # must be a binding in SciMLBase even though SciMLBase only ever uses the qualified form.
     :setproperties,
+    # `ConstructionBase.constructorof` is extended for the problem, function, and solution
+    # types and accessed as `SciMLBase.constructorof` by downstream packages (e.g.
+    # OrdinaryDiffEqCore's `strip_cache` calls `SciMLBase.constructorof(typeof(cache))`), so
+    # it must be a binding in SciMLBase even though SciMLBase only uses the qualified form.
+    :constructorof,
 )
 const _ei_nonpublic_qualified_accesses = (
     # --- Genuine Base/Core internals: not public on any Julia version, no public


### PR DESCRIPTION
## Summary

PR #1397 narrowed the ConstructionBase import to `using ConstructionBase: ConstructionBase, getproperties, setproperties`, dropping `constructorof` as a binding in the `SciMLBase` namespace. Downstream packages access it qualified through SciMLBase, so on the currently-registered downstream versions this throws `UndefVarError: constructorof not defined`:

- `OrdinaryDiffEqCore` (v4.6.0) `strip_cache` calls `SciMLBase.constructorof(typeof(cache))` (`src/interp_func.jl:90`), reached via `SciMLBase.strip_interpolation`.
- `OrdinaryDiffEqDifferentiation` (v3.2.2) does `import SciMLBase: constructorof` (`src/OrdinaryDiffEqDifferentiation.jl:24`).

This turns the OrdinaryDiffEq downstream test lanes red on master (`ode_strip_test.jl` errors with `UndefVarError: constructorof not defined`).

`constructorof` is the exact analogue of `setproperties`: SciMLBase extends it for the problem/function/solution types (`ConstructionBase.constructorof(::Type{...})`) and only ever uses the qualified form internally, while downstream depends on the re-exported binding. #1397 correctly re-added `setproperties` to both the import and the ExplicitImports stale-import allow-list, but missed `constructorof`.

## Change

- Restore `constructorof` to the `using ConstructionBase: ...` import in `src/SciMLBase.jl`.
- Add `:constructorof` to `_ei_stale_allowed` in `test/qa/qa.jl` (same rationale/comment as `setproperties`), so the ExplicitImports stale-import QA check stays green.
- Patch version bump 3.34.0 → 3.34.1 (restores backward-compatible re-export).

## Verification (Julia 1.11, local)

- Before: `isdefined(SciMLBase, :constructorof) == false`, `SciMLBase.constructorof` → `UndefVarError`.
- After: `isdefined(SciMLBase, :constructorof) == true`, `SciMLBase.constructorof === ConstructionBase.constructorof`, and `SciMLBase.constructorof(typeof(prob))` (the downstream call pattern) resolves.
- `GROUP=QA` suite passes 15/15 (includes the ExplicitImports stale-import check that would otherwise flag `constructorof`).
- Runic `--check`: clean.

## Note

This does **not** fix the separate `FastConvergence not defined` precompile failure also seen on the OrdinaryDiffEq downstream lane — that is an OrdinaryDiffEq-internal registry incompatibility (`OrdinaryDiffEqFIRK` v2.3.2 imports `FastConvergence` from `OrdinaryDiffEqNonlinearSolve`, which dropped the re-export in v2.1.0) and requires an OrdinaryDiffEq release, not a SciMLBase change.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ytoUu26H96NbfYv9ABLEc