### PR TITLE
Zero allocations in scalar interpolation: FindFirstFunctions search, deriv specialization, Guesser warm start

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.34.0"
+version = "3.35.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -13,6 +13,7 @@ ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+FindFirstFunctions = "64ca27bc-2ba2-4a57-88aa-44e436879224"
 FunctionWrappersWrappers = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -79,6 +80,7 @@ SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore"]
 [compat]
 ADTypes = "1.9.0"
 Accessors = "0.1.39"
+AllocCheck = "0.2"
 Adapt = "4.3"
 ArrayInterface = "7.19"
 ChainRules = "1.58.0"
@@ -93,6 +95,7 @@ EnumX = "1"
 Enzyme = "0.13"
 ForwardDiff = "0.10.36, 1"
 FunctionProperties = "1.1"
+FindFirstFunctions = "3"
 FunctionWrappersWrappers = "1"
 IteratorInterfaceExtensions = "^1"
 LinearAlgebra = "1.10"
@@ -132,6 +135,7 @@ Zygote = "0.7"
 julia = "1.10"
 
 [extras]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
@@ -152,4 +156,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "DifferentiationInterface", "Enzyme", "ForwardDiff", "FunctionProperties", "PartialFunctions", "Pkg", "SafeTestsets", "SciMLTesting", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]
+test = ["AllocCheck", "Aqua", "DifferentiationInterface", "Enzyme", "ForwardDiff", "FunctionProperties", "PartialFunctions", "Pkg", "SafeTestsets", "SciMLTesting", "Serialization", "StableRNGs", "StaticArrays", "Tables", "Test", "UnicodePlots", "Zygote"]

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -40,6 +40,7 @@ using Markdown: Markdown, @doc_str
 using Printf: Printf, @printf
 import Preferences
 using PreallocationTools: get_tmp, DiffCache, FixedSizeDiffCache
+using FindFirstFunctions: Guesser, GuesserHint, KIND_BRACKET_GALLOP, searchsorted_first
 
 import Logging, ArrayInterface, Random
 import IteratorInterfaceExtensions

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -153,6 +153,18 @@ identical to using those types directly in the corresponding mode. The `dense`
 branch happens inside the interpolation methods — no wrapper object is
 constructed and both branches return values of the same type, so calls are
 type-stable and allocation-free on the in-place paths.
+
+The `guesser` field holds a `FindFirstFunctions.Guesser` over `t` that
+warm-starts the interval search of scalar interpolation calls (its only state
+is a `Ref`, so the struct stays immutable and the concrete type still depends
+only on the container types). Correlated access patterns — adjoint solves
+sweeping time monotonically, `saveat` post-processing — thereby skip the
+per-call bisection. The guesser decides at construction whether `t` is evenly
+spaced enough for a linear-extrapolation guess; either way every lookup
+returns exact `searchsortedfirst` results, so the guess quality only affects
+speed, never values. Constructors build it automatically; pass one explicitly
+only to share state across reconstructions (as
+[`enable_interpolation_sensitivitymode`](@ref) does).
 """
 struct BasicInterpolation{tType, uType, duType} <: AbstractDiffEqInterpolation
     t::tType
@@ -160,14 +172,21 @@ struct BasicInterpolation{tType, uType, duType} <: AbstractDiffEqInterpolation
     du::duType
     dense::Bool
     sensitivitymode::Bool
+    guesser::Guesser{tType}
 end
 
 function BasicInterpolation(t, u, du, dense; sensitivitymode = false)
-    return BasicInterpolation(t, u, du, dense, sensitivitymode)
+    return BasicInterpolation(t, u, du, dense, sensitivitymode, Guesser(t))
+end
+
+function BasicInterpolation(t, u, du, dense::Bool, sensitivitymode::Bool)
+    return BasicInterpolation(t, u, du, dense, sensitivitymode, Guesser(t))
 end
 
 function enable_interpolation_sensitivitymode(interp::BasicInterpolation)
-    return BasicInterpolation(interp.t, interp.u, interp.du, interp.dense, true)
+    return BasicInterpolation(
+        interp.t, interp.u, interp.du, interp.dense, true, interp.guesser
+    )
 end
 
 """
@@ -241,16 +260,39 @@ function (id::BasicInterpolation)(
     return interpolation!(val, tvals, id, idxs, deriv, p, continuity)
 end
 
-# `searchsortedfirst(t, tval; rev = tdir < 0)` with a runtime `Bool` makes the
-# ordering value-dependent (a boxed union from `Base.Order.ord`); branching on
-# the direction keeps each call concretely ordered and allocation-free.
-@inline function tdir_searchsortedfirst(t, tval, tdir)
+# Interval search routed through FindFirstFunctions, mirroring what
+# SciML/OrdinaryDiffEq.jl#3826 did for OrdinaryDiffEqCore. Branching on the
+# direction keeps each call on a concrete const ordering — a runtime
+# `rev::Bool` kwarg would box a value-dependent ordering union on every call.
+# Every strategy returns exact `Base.searchsortedfirst` results; only lookup
+# speed differs.
+@inline function fff_searchsortedfirst(t, tval, guess::Integer, tdir)
     return if tdir < 0
-        searchsortedfirst(t, tval, Base.Order.Reverse)
+        searchsorted_first(KIND_BRACKET_GALLOP, t, tval, guess; order = Base.Order.Reverse)
     else
-        searchsortedfirst(t, tval, Base.Order.Forward)
+        searchsorted_first(KIND_BRACKET_GALLOP, t, tval, guess; order = Base.Order.Forward)
     end
 end
+
+# Scalar-path search. `BasicInterpolation` warm-starts from its `Guesser`
+# (linear-extrapolation guess on evenly spaced grids, previous hit otherwise),
+# which turns the correlated lookups of adjoint sweeps and `saveat`
+# post-processing into O(1) instead of a fresh bisection. The legacy types
+# carry no hint state (their positional constructors and field layouts are
+# public API constructed across the ecosystem) and use the plain search.
+@inline function scalar_searchsortedfirst(g::Guesser, t, tval, tdir)
+    return if tdir < 0
+        searchsorted_first(GuesserHint(g), t, tval; order = Base.Order.Reverse)
+    else
+        searchsorted_first(GuesserHint(g), t, tval; order = Base.Order.Forward)
+    end
+end
+@inline function scalar_searchsortedfirst(::Nothing, t, tval, tdir)
+    return fff_searchsortedfirst(t, tval, firstindex(t), tdir)
+end
+
+@inline interp_search_hint(id) = nothing
+@inline interp_search_hint(id::BasicInterpolation) = id.guesser
 
 @inline function interpolation(
         tvals, id::I, idxs, deriv::D, p,
@@ -277,7 +319,9 @@ end
     end
     for j in idx
         tval = tvals[j]
-        i = tdir_searchsortedfirst(@view(t[i:end]), tval, tdir) + i - 1 # It's in the interval t[i-1] to t[i]
+        # `max` reproduces the previous view-based search's lower bound of `i`
+        # exactly (the sorted-`tvals` sweep never moves backward)
+        i = max(i, fff_searchsortedfirst(t, tval, clamp(i, firstindex(t), lastindex(t)), tdir)) # It's in the interval t[i-1] to t[i]
         avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
         avoid_constant_ends && i == 1 && (i += 1)
         if !avoid_constant_ends && t[i - 1] == tval # Can happen if it's the first value!
@@ -345,7 +389,9 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
     for j in idx
         tval = tvals[j]
-        i = tdir_searchsortedfirst(@view(t[i:end]), tval, tdir) + i - 1 # It's in the interval t[i-1] to t[i]
+        # `max` reproduces the previous view-based search's lower bound of `i`
+        # exactly (the sorted-`tvals` sweep never moves backward)
+        i = max(i, fff_searchsortedfirst(t, tval, clamp(i, firstindex(t), lastindex(t)), tdir)) # It's in the interval t[i-1] to t[i]
         avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
         avoid_constant_ends && i == 1 && (i += 1)
         if !avoid_constant_ends && t[i - 1] == tval # Can happen if it's the first value!
@@ -431,7 +477,7 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
-    @inbounds i = tdir_searchsortedfirst(t, tval, tdir) # It's in the interval t[i-1] to t[i]
+    i = scalar_searchsortedfirst(interp_search_hint(id), t, tval, tdir) # It's in the interval t[i-1] to t[i]
     avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
     avoid_constant_ends && i == 1 && (i += 1)
     if !avoid_constant_ends && t[i] == tval
@@ -493,22 +539,28 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
-    @inbounds i = tdir_searchsortedfirst(t, tval, tdir) # It's in the interval t[i-1] to t[i]
+    i = scalar_searchsortedfirst(interp_search_hint(id), t, tval, tdir) # It's in the interval t[i-1] to t[i]
     avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
     avoid_constant_ends && i == 1 && (i += 1)
+    # `copyto!`, not `copy!`: the between-node kernel path has always required
+    # a correctly-sized `out` (it broadcasts into it), so the exact-node
+    # branches match that contract instead of silently resizing — and `copy!`'s
+    # `resize!` branches are reachable allocations that would break the static
+    # no-allocation guarantee of this path (`copyto!` is also alias-safe
+    # without broadcast's defensive-copy machinery).
     return if !avoid_constant_ends && t[i] == tval
         lasti = lastindex(t)
         k = continuity == :right && i + 1 <= lasti && t[i + 1] == tval ? i + 1 : i
         if idxs === nothing
-            copy!(out, u[k])
+            copyto!(out, u[k])
         else
-            copy!(out, u[k][idxs])
+            copyto!(out, view(u[k], idxs))
         end
     elseif !avoid_constant_ends && t[i - 1] == tval # Can happen if it's the first value!
         if idxs === nothing
-            copy!(out, u[i - 1])
+            copyto!(out, u[i - 1])
         else
-            copy!(out, u[i - 1][idxs])
+            copyto!(out, view(u[i - 1], idxs))
         end
     else
         id.sensitivitymode && error(SENSITIVITY_INTERP_MESSAGE)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -196,29 +196,60 @@ or use the keyword argument sensealg=SensitivityADPassThrough() to revert
 to AD-based derivatives.
 """
 
-function (id::HermiteInterpolation)(tvals, idxs, deriv, p, continuity::Symbol = :left)
+# `deriv` is passed as a `Type` (e.g. `Val{1}`), which Julia heuristically does
+# not specialize on for an unannotated slot; the `::D ... where {D}` forces
+# specialization so the inner interpolation call is statically dispatched
+# instead of boxing its arguments on every call.
+function (id::HermiteInterpolation)(
+        tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation(tvals, id, idxs, deriv, p, continuity)
 end
-function (id::HermiteInterpolation)(val, tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::HermiteInterpolation)(
+        val, tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation!(val, tvals, id, idxs, deriv, p, continuity)
 end
-function (id::LinearInterpolation)(tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::LinearInterpolation)(
+        tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation(tvals, id, idxs, deriv, p, continuity)
 end
-function (id::LinearInterpolation)(val, tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::LinearInterpolation)(
+        val, tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation!(val, tvals, id, idxs, deriv, p, continuity)
 end
-function (id::ConstantInterpolation)(tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::ConstantInterpolation)(
+        tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation(tvals, id, idxs, deriv, p, continuity)
 end
-function (id::ConstantInterpolation)(val, tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::ConstantInterpolation)(
+        val, tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation!(val, tvals, id, idxs, deriv, p, continuity)
 end
-function (id::BasicInterpolation)(tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::BasicInterpolation)(
+        tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation(tvals, id, idxs, deriv, p, continuity)
 end
-function (id::BasicInterpolation)(val, tvals, idxs, deriv, p, continuity::Symbol = :left)
+function (id::BasicInterpolation)(
+        val, tvals, idxs, deriv::D, p, continuity::Symbol = :left
+    ) where {D}
     return interpolation!(val, tvals, id, idxs, deriv, p, continuity)
+end
+
+# `searchsortedfirst(t, tval; rev = tdir < 0)` with a runtime `Bool` makes the
+# ordering value-dependent (a boxed union from `Base.Order.ord`); branching on
+# the direction keeps each call concretely ordered and allocation-free.
+@inline function tdir_searchsortedfirst(t, tval, tdir)
+    return if tdir < 0
+        searchsortedfirst(t, tval, Base.Order.Reverse)
+    else
+        searchsortedfirst(t, tval, Base.Order.Forward)
+    end
 end
 
 @inline function interpolation(
@@ -246,7 +277,7 @@ end
     end
     for j in idx
         tval = tvals[j]
-        i = searchsortedfirst(@view(t[i:end]), tval, rev = tdir < 0) + i - 1 # It's in the interval t[i-1] to t[i]
+        i = tdir_searchsortedfirst(@view(t[i:end]), tval, tdir) + i - 1 # It's in the interval t[i-1] to t[i]
         avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
         avoid_constant_ends && i == 1 && (i += 1)
         if !avoid_constant_ends && t[i - 1] == tval # Can happen if it's the first value!
@@ -314,7 +345,7 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
     for j in idx
         tval = tvals[j]
-        i = searchsortedfirst(@view(t[i:end]), tval, rev = tdir < 0) + i - 1 # It's in the interval t[i-1] to t[i]
+        i = tdir_searchsortedfirst(@view(t[i:end]), tval, tdir) + i - 1 # It's in the interval t[i-1] to t[i]
         avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
         avoid_constant_ends && i == 1 && (i += 1)
         if !avoid_constant_ends && t[i - 1] == tval # Can happen if it's the first value!
@@ -400,7 +431,7 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
-    @inbounds i = searchsortedfirst(t, tval, rev = tdir < 0) # It's in the interval t[i-1] to t[i]
+    @inbounds i = tdir_searchsortedfirst(t, tval, tdir) # It's in the interval t[i-1] to t[i]
     avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
     avoid_constant_ends && i == 1 && (i += 1)
     if !avoid_constant_ends && t[i] == tval
@@ -462,7 +493,7 @@ times t (sorted), with values u and derivatives ks
         error("Solution interpolation cannot extrapolate past the final timepoint. Either solve on a longer timespan or use the local extrapolation from the integrator interface.")
     tdir * tval < tdir * t[1] &&
         error("Solution interpolation cannot extrapolate before the first timepoint. Either start solving earlier or use the local extrapolation from the integrator interface.")
-    @inbounds i = searchsortedfirst(t, tval, rev = tdir < 0) # It's in the interval t[i-1] to t[i]
+    @inbounds i = tdir_searchsortedfirst(t, tval, tdir) # It's in the interval t[i-1] to t[i]
     avoid_constant_ends = deriv != Val{0} #|| tval isa ForwardDiff.Dual
     avoid_constant_ends && i == 1 && (i += 1)
     return if !avoid_constant_ends && t[i] == tval

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -117,24 +117,25 @@ end
         end
     end
 
-    # The dense branch happens inside the interpolation method — no wrapper
-    # object may be constructed per call. The scalar in-place path is not
-    # allocation-free even for the legacy types on master (~80-96 bytes from
-    # shared machinery, e.g. `searchsortedfirst(...; rev = tdir < 0)` with a
-    # runtime Bool creating a small ordering-union box), so the assertion that
-    # locks out per-call wrapper construction is allocation PARITY: the
-    # switched type must allocate no more than the legacy type it corresponds
-    # to on the identical call.
-    function scalar_inplace_allocs(itp, out)
-        itp(out, 1.5, nothing, Val{0}, nothing, :left)
-        itp(out, 1.5, nothing, Val{0}, nothing, :left)
-        return @allocated itp(out, 1.5, nothing, Val{0}, nothing, :left)
+    # The scalar in-place path must be allocation-free post-warmup for the
+    # switched type in both modes AND the legacy types: no per-call wrapper
+    # construction, no dynamic dispatch from the Type-argument
+    # non-specialization heuristic on `deriv` (hence `deriv::D where {D}` in
+    # this harness too — an unannotated Type slot would re-box in the harness
+    # itself and be misattributed to the library), and no boxed ordering from
+    # a runtime-`rev` sorted search.
+    function scalar_inplace_allocs(itp, out, deriv::D) where {D}
+        itp(out, 1.5, nothing, deriv, nothing, :left)
+        itp(out, 1.5, nothing, deriv, nothing, :left)
+        return @allocated itp(out, 1.5, nothing, deriv, nothing, :left)
     end
     out = zeros(2)
-    @test scalar_inplace_allocs(basic_dense, out) <=
-        scalar_inplace_allocs(hermite, out)
-    @test scalar_inplace_allocs(basic_nondense, out) <=
-        scalar_inplace_allocs(linear, out)
+    for deriv in (Val{0}, Val{1})
+        @test scalar_inplace_allocs(basic_dense, out, deriv) == 0
+        @test scalar_inplace_allocs(basic_nondense, out, deriv) == 0
+        @test scalar_inplace_allocs(hermite, out, deriv) == 0
+        @test scalar_inplace_allocs(linear, out, deriv) == 0
+    end
 
     # Vector-tvals calls return a DiffEqArray whose two SymbolCache metadata
     # type parameters are not inferred for ANY interpolation type (a

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1,5 +1,6 @@
 using SciMLBase
 using Test
+using Random: Xoshiro, shuffle
 
 # Synthetic saved data for a two-state trajectory.
 t = [0.0, 1.0, 2.0, 3.0]
@@ -168,9 +169,63 @@ end
     @test !snondense.dense
     # type still invariant after enabling sensitivity mode
     @test typeof(sdense) == typeof(snondense)
+    # the warm-start state survives the reconstruction (same ts, same guesses)
+    @test sdense.guesser === basic_dense.guesser
     # exact node lookups still work under sensitivity mode
     @test getu(oop(sdense, 1.0, nothing, Val{0}, :left)) == u[2]
     # interpolating between nodes must error under sensitivity mode
     @test_throws ErrorException oop(sdense, 1.5, nothing, Val{0}, :left)
     @test_throws ErrorException oop(snondense, 1.5, nothing, Val{0}, :left)
+end
+
+# The scalar paths warm-start their interval search from the Guesser stored in
+# BasicInterpolation. Pin that this is a pure speedup: scalar results equal the
+# hint-free legacy types' results exactly, for correlated (ascending /
+# descending) and uncorrelated (shuffled) access orders, on evenly spaced grids
+# (linear-extrapolation guess) and geometrically stretched grids (previous-hit
+# guess), in both time directions, for both continuities.
+@testset "Guesser warm-started scalar search" begin
+    npts = 401
+    uniform_t = collect(range(0.0, 10.0; length = npts))
+    r = 1.015 .^ (0:(npts - 2))
+    geometric_t = vcat(0.0, 10.0 .* cumsum(r) ./ sum(r))
+    @test SciMLBase.BasicInterpolation(
+        uniform_t, [[0.0]], [[0.0]], true
+    ).guesser.linear_lookup
+    @test !SciMLBase.BasicInterpolation(
+        geometric_t, [[0.0]], [[0.0]], true
+    ).guesser.linear_lookup
+    for base_t in (uniform_t, geometric_t), reverse_time in (false, true)
+        tg = reverse_time ? reverse(base_t) : base_t
+        ug = [[sin(x), cos(x)] for x in tg]
+        dug = [[cos(x), -sin(x)] for x in tg]
+        bd = SciMLBase.BasicInterpolation(tg, ug, dug, true)
+        bn = SciMLBase.BasicInterpolation(tg, ug, similar(dug, 0), false)
+        h = SciMLBase.HermiteInterpolation(tg, ug, dug)
+        l = SciMLBase.LinearInterpolation(tg, ug)
+        tq = collect(range(0.005, 9.995; length = 499))
+        for tvals in (tq, reverse(tq), shuffle(Xoshiro(1), tq)),
+                cont in (:left, :right)
+
+            @test all(
+                bd(tv, nothing, Val{0}, nothing, cont) ==
+                    h(tv, nothing, Val{0}, nothing, cont) for tv in tvals
+            )
+            @test all(
+                bn(tv, nothing, Val{0}, nothing, cont) ==
+                    l(tv, nothing, Val{0}, nothing, cont) for tv in tvals
+            )
+        end
+        # node values are hit exactly through the hinted path too
+        @test all(
+            bd(tg[k], nothing, Val{0}, nothing, :left) == ug[k]
+                for k in eachindex(tg)
+        )
+        # the warm start engages: a scalar query records a previous hit
+        if !bd.guesser.linear_lookup
+            bd.guesser.idx_prev[] = 1
+            bd(tg[end ÷ 2] + 1.0e-3, nothing, Val{0}, nothing, :left)
+            @test bd.guesser.idx_prev[] != 1
+        end
+    end
 end

--- a/test/qa/alloccheck.jl
+++ b/test/qa/alloccheck.jl
@@ -1,0 +1,48 @@
+# Static allocation proof for the scalar in-place interpolation path, on top
+# of the runtime `@allocated == 0` checks in test/interpolation_tests.jl:
+# AllocCheck analyzes the compiled code and fails if a reachable allocation
+# site exists, so a regression shows up even on inputs the runtime test does
+# not exercise.
+#
+# Two documented exclusions, each the tightest truthful bound available:
+#
+# - `ignore_throw = true` is AllocCheck's documented option for genuine
+#   user-facing error branches: the interpolation path's extrapolation-bound
+#   errors, the sensitivitymode error, and broadcast shape checks construct
+#   exceptions, which necessarily allocates. Only throw-path allocations are
+#   excluded by this.
+#
+# - Alias-guard sites: the interpolant kernels broadcast into `out`
+#   (`@. out = ...`), and Base broadcast's `preprocess` contains a
+#   conditional defensive copy (`unaliascopy`) taken only when `out` aliases
+#   the interpolant's own stored timeseries — required for broadcast
+#   correctness and unremovable without abandoning broadcast in the kernels.
+#   It never fires for a caller-owned output buffer. The test asserts that
+#   every reported site IS such an alias guard (identified by `unaliascopy`
+#   in its backtrace), so any unconditional allocation still fails.
+using SciMLBase, AllocCheck, Test
+
+t_ac = [0.0, 1.0, 2.0, 3.0]
+u_ac = [[1.0, 2.0], [1.5, 2.4], [2.1, 2.9], [2.8, 3.5]]
+du_ac = [[0.4, 0.3], [0.5, 0.4], [0.6, 0.5], [0.7, 0.6]]
+
+# Concrete entry point matching the solution-interpolation call shape.
+scalar_interp!(itp, out, tval, deriv::D) where {D} =
+    itp(out, tval, nothing, deriv, nothing, :left)
+
+is_alias_guard(site) = any(fr -> fr.func === :unaliascopy, site.backtrace)
+
+@testset "AllocCheck: scalar in-place interpolation" begin
+    # BasicInterpolation dense and non-dense share one concrete type, so a
+    # single signature covers both runtime modes of the method instance.
+    interps = (
+        SciMLBase.HermiteInterpolation(t_ac, u_ac, du_ac),
+        SciMLBase.LinearInterpolation(t_ac, u_ac),
+        SciMLBase.BasicInterpolation(t_ac, u_ac, du_ac, true),
+    )
+    for itp in interps, deriv in (Val{0}, Val{1})
+        sig = (typeof(itp), Vector{Float64}, Float64, Type{deriv})
+        allocs = AllocCheck.check_allocs(scalar_interp!, sig; ignore_throw = true)
+        @test all(is_alias_guard, allocs)
+    end
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -125,4 +125,6 @@ run_qa(
     ),
 )
 
+include("alloccheck.jl")
+
 nothing


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

Follow-up to #1436: the allocation fixes below were pushed to that PR's branch after the merge snapshot was taken, so they missed the merge window. Per follow-up review direction, the interval search is additionally routed through FindFirstFunctions.jl (mirroring SciML/OrdinaryDiffEq.jl#3826's treatment of OrdinaryDiffEqCore) rather than a hand-rolled search wrapper, with a `Guesser` warm start for the scalar paths.

## Why were there any allocations? (the two root causes)

Profiled with `Profile.Allocs.@profile sample_rate=1` — the scalar in-place interpolation path allocated 80 B (`BasicInterpolation`, either mode) / 96 B (`HermiteInterpolation`) / 80 B (`LinearInterpolation`) per call, from exactly two shared-machinery sources, both pre-existing on master:

1. **64 B — dynamic dispatch at the callable boundary (Type-argument non-specialization).** The interpolation callables took `deriv` in an unannotated slot; `deriv` is a `Type` (`Val{0}`/`Val{1}`), and Julia heuristically does not specialize on `Type`-valued arguments in unannotated slots, so the callables were compiled with `deriv::Type` abstract and the inner `interpolation`/`interpolation!` call became a runtime dispatch (argument box + tuple) on every call. Fixed with `deriv::D, ...) where {D}` on all eight callables (Hermite, Linear, Constant, Basic).
2. **16 B — runtime-`rev` ordering box in the sorted search.** `searchsortedfirst(t, tval; rev = tdir < 0)` passes a runtime `Bool` into `Base.Order.ord`, making the ordering value-dependent (a boxed `ForwardOrdering`/`ReverseOrdering` union per call). Fixed by branching on the direction and searching with a concrete const ordering in each branch.

## FindFirstFunctions routing (per #3826 precedent)

- All interval searches in `interpolation`/`interpolation!` now go through `FindFirstFunctions.searchsorted_first` with `KIND_BRACKET_GALLOP` (exact `Base.searchsortedfirst` results; strategy only affects speed). New dependency `FindFirstFunctions` with compat `"3"` — same as OrdinaryDiffEqCore.
- The vector-`tvals` loops keep their previous-hit warm start through the hint argument; a `max` clamp reproduces the previous view-based search's lower bound exactly.
- **`Guesser` warm start — `BasicInterpolation` only.** `BasicInterpolation` gains a `FindFirstFunctions.Guesser` field (its state is a `Ref`, so the struct stays immutable and its concrete type still depends only on the container types — the dense/non-dense type-invariance contract is unaffected). Scalar lookups warm-start from it via `GuesserHint`: linear-extrapolation guess on evenly spaced grids, previous hit otherwise. Constructor signatures are unchanged (the guesser is built internally); `enable_interpolation_sensitivitymode` shares the guesser state across reconstruction. **The legacy types are FFF-routed but unhinted**: their positional constructors and exact field layouts are years-old public API constructed across the ecosystem (StochasticDiffEq-style positional construction, ConstructionBase/Accessors-based reconstruction), so adding a field there has ecosystem-wide ripple for marginal gain — `BasicInterpolation` is brand-new with a single known consumer (SciML/Sundials.jl#547, unchanged constructor calls).
- One edge-behavior alignment: the exact-node branches of scalar `interpolation!` now use `copyto!` instead of `copy!`. `copy!`'s `resize!` is a statically reachable allocation, and the between-node kernel path has always required a correctly-sized `out` — silently resizing `out` only when `tval` hit a saved node exactly was inconsistent edge behavior.

## Allocation results (Julia 1.10, scalar in-place, post-warmup)

| call | before | after |
|---|---|---|
| `BasicInterpolation` dense | 80 B | **0** |
| `BasicInterpolation` non-dense | 80 B | **0** |
| `HermiteInterpolation` (legacy) | 96 B | **0** |
| `LinearInterpolation` (legacy) | 80 B | **0** |

Zero holds for `Val{0}` and `Val{1}` and for reversed time direction (confirmed by both `@allocated` behind a specialized function barrier and `Profile.Allocs` reporting 0 allocations). Through a Sundials solution (SciML/Sundials.jl#547 branch dev'd), `sol(out, t)` measures 0 B in dense and saveat modes with `@inferred` passing. Measurement gotcha, documented in the test: the harness itself needs `deriv::D where {D}` or the same non-specialization heuristic re-boxes in the harness and misattributes 32–48 B to the library.

## Hinted-search microbenchmark

100k-point grid, 50k scalar queries, min of 9 runs (Julia 1.10):

| access pattern | plain (legacy Hermite) | hinted `BasicInterpolation` |
|---|---|---|
| descending sweep (adjoint-like) | 199.9 ns/query | **85.8 ns/query** |
| random access, uniform grid | 389.1 ns/query | **180.6 ns/query** |

## AllocCheck static QA test

New `test/qa/alloccheck.jl` (wired into the QA group, AllocCheck added to test extras/targets) statically proves the scalar in-place path has **no unconditional allocation site** for `HermiteInterpolation`, `LinearInterpolation`, and `BasicInterpolation` (dense and non-dense share one concrete type/method instance), both `deriv` orders:

- `ignore_throw = true` — AllocCheck's documented option for genuine user-facing error branches (extrapolation bounds, sensitivitymode error, broadcast shape checks), whose exception construction necessarily allocates.
- The interpolant kernels broadcast into `out`, and Base broadcast's `preprocess` contains a **conditional** defensive copy (`unaliascopy`) taken only when `out` aliases the interpolant's own stored timeseries — required for broadcast correctness and unremovable without abandoning broadcast in the kernels. The test asserts every reported site IS such an alias guard, so any unconditional allocation still fails. Site census: hermite 6/9 (Val{0}/Val{1}), linear 2/2, basic 8/11 — all alias guards, zero others.

## Versioning

Master is at `3.34.0` (the post-merge `Update Project.toml` reset it to the last registered release). New dependency + new field → **minor** bump `3.34.0 → 3.35.0` per SemVer; the next release must be ≥ 3.35.0 anyway since master already carries the unreleased `BasicInterpolation` public API.

## Tests (all run locally, Julia 1.10)

`test/interpolation_tests.jl` — 427/427:
```
Type invariance across dense/non-dense   |    3
interp_summary                           |    4
Out-of-place correctness vs delegates    |  280
In-place scalar correctness vs delegates |   48
In-place vector correctness vs delegates |    8
strip_interpolation                      |    2
Inference and allocations                |   16   (@allocated == 0 × 8, inference parity × 8)
sensitivitymode toggling                 |   10   (incl. guesser sharing)
Guesser warm-started scalar search       |   56   (asc/desc/shuffled sweeps × uniform/geometric grids × both time directions × both continuities, node exactness, warm-start engagement)
```
QA AllocCheck 6/6. Legacy regression: `solution_interface.jl` 35/35, `display.jl` 4/4, `public_interface.jl` 155/155, `detect_ambiguities(SciMLBase)` empty. Downstream: Sundials#547 interpolation tests (invariance + `@inferred` both modes) pass against this branch; its compat floor is updated to `SciMLBase = "3.35"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY
