### PR TITLE
Make docstring cross-references self-contained for downstream Documenter builds

### DIFF
--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -226,6 +226,7 @@ SciMLBase.HermiteInterpolation
 SciMLBase.BasicInterpolation
 SciMLBase.SensitivityInterpolation
 SciMLBase.interp_summary
+SciMLBase.enable_interpolation_sensitivitymode
 ```
 
 ### Symbolic Utilities

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -337,7 +337,7 @@ const AbstractSteadyStateProblem{
 $(TYPEDEF)
 
 Base interface for problems that directly solve or sample an
-[`AbstractNoiseProcess`](@ref). Concrete noise problems should provide a `noise`
+[`AbstractNoiseProcess`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoiseProcess). Concrete noise problems should provide a `noise`
 field, a `tspan`, and solver keyword arguments. Their in-place behavior delegates
 to the stored noise process through [`isinplace`](@ref).
 """
@@ -1303,8 +1303,8 @@ abstract type AbstractNoiseProcess{T, N, A, isinplace} <: AbstractDiffEqArray{T,
     AbstractSciMLSolution
 
 Union of all base SciML solution interfaces:
-[`AbstractTimeseriesSolution`](@ref), [`AbstractNoTimeSolution`](@ref),
-[`AbstractEnsembleSolution`](@ref), and [`AbstractNoiseProcess`](@ref).
+[`AbstractTimeseriesSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractTimeseriesSolution), [`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution),
+[`AbstractEnsembleSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractEnsembleSolution), and [`AbstractNoiseProcess`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoiseProcess).
 
 This is a union rather than an abstract supertype so each solution family can
 subtype the appropriate array interface directly. Use it for dispatch that
@@ -1323,7 +1323,7 @@ $(TYPEDEF)
 
 Abstract interface for no-time solutions of linear systems. Concrete subtypes
 store the computed solution in `u` and should follow the
-[`AbstractNoTimeSolution`](@ref) array-forwarding contract. Linear solve
+[`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) array-forwarding contract. Linear solve
 solutions commonly include `resid`, `alg`, `retcode`, `iters`, `cache`, and
 `stats` fields so callers can inspect convergence and reuse solver caches.
 """
@@ -1334,7 +1334,7 @@ $(TYPEDEF)
 
 Abstract interface for no-time eigenvalue problem solutions. Concrete subtypes
 store the computed eigenvalues in `u`, follow the
-[`AbstractNoTimeSolution`](@ref) contract, and should document where eigenvectors,
+[`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) contract, and should document where eigenvectors,
 residuals, the original problem, algorithm, return code, and solver statistics
 are stored.
 """
@@ -1346,7 +1346,7 @@ $(TYPEDEF)
 Abstract interface for no-time nonlinear equation solutions. Concrete subtypes
 store the root or fixed point in `u` and the residual in a solver-specific
 `resid` field when available. These solutions follow the
-[`AbstractNoTimeSolution`](@ref) contract and commonly provide `prob`, `alg`,
+[`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) contract and commonly provide `prob`, `alg`,
 `retcode`, `original`, bracket endpoints for interval methods, and `stats`.
 """
 abstract type AbstractNonlinearSolution{T, N} <: AbstractNoTimeSolution{T, N} end
@@ -1356,7 +1356,7 @@ $(TYPEDEF)
 
 Abstract interface for no-time integral or quadrature solutions. Concrete
 subtypes store the estimated integral in `u`, follow the
-[`AbstractNoTimeSolution`](@ref) contract, and commonly provide `resid`, `prob`,
+[`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) contract, and commonly provide `resid`, `prob`,
 `alg`, `retcode`, `chi`, and `stats` fields for solver diagnostics.
 """
 abstract type AbstractIntegralSolution{T, N} <: AbstractNoTimeSolution{T, N} end
@@ -1366,7 +1366,7 @@ $(TYPEDEF)
 
 Abstract interface for no-time optimization solutions. Concrete subtypes store
 the optimizer or minimizer in `u` and follow the
-[`AbstractNoTimeSolution`](@ref) contract. Optimization solutions commonly expose
+[`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) contract. Optimization solutions commonly expose
 `alg`, `objective`, `retcode`, `original`, `stats`, and a cache that supplies the
 problem function and parameters for symbolic indexing.
 """
@@ -1378,7 +1378,7 @@ $(TYPEDEF)
 Alias for nonlinear solutions used by steady-state solvers. A steady-state
 solution represents a state `u` satisfying the nonlinear system induced by the
 differential equation right-hand side, and therefore follows the
-[`AbstractNonlinearSolution`](@ref) and [`AbstractNoTimeSolution`](@ref)
+[`AbstractNonlinearSolution`](@ref) and [`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution)
 contracts.
 """
 const AbstractSteadyStateSolution{T, N} = AbstractNonlinearSolution{T, N}
@@ -1387,7 +1387,7 @@ const AbstractSteadyStateSolution{T, N} = AbstractNonlinearSolution{T, N}
 $(TYPEDEF)
 
 Abstract interface for analytical time-series solutions. These solutions follow
-the [`AbstractTimeseriesSolution`](@ref) contract and are used when the solution
+the [`AbstractTimeseriesSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractTimeseriesSolution) contract and are used when the solution
 values are generated from or compared against an analytical representation of
 the problem. Plotting and error-calculation code may use analytical solution
 metadata stored on the concrete solution or its problem.
@@ -1398,7 +1398,7 @@ abstract type AbstractAnalyticalSolution{T, N, S} <: AbstractTimeseriesSolution{
 $(TYPEDEF)
 
 Abstract interface for ordinary differential equation time-series solutions.
-Concrete subtypes follow the [`AbstractTimeseriesSolution`](@ref) contract and
+Concrete subtypes follow the [`AbstractTimeseriesSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractTimeseriesSolution) contract and
 typically provide saved states `u`, saved times `t`, interpolation data `interp`,
 the original problem `prob`, the algorithm `alg`, solver `stats`, a `retcode`,
 and optional analytical values, dense-output data, discrete parameter
@@ -1441,7 +1441,7 @@ abstract type AbstractDAESolution{T, N, S} <: AbstractODESolution{T, N, S} end
 $(TYPEDEF)
 
 Abstract interface for PDE solutions with a saved time axis. These solutions
-follow the [`AbstractTimeseriesSolution`](@ref) contract and additionally carry
+follow the [`AbstractTimeseriesSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractTimeseriesSolution) contract and additionally carry
 discretization metadata. Concrete subtypes should provide `disc_data`,
 `original_sol`, `ivdomain`, `ivs`, and `dvs` fields so downstream discretizer
 packages can recover the PDE variables, domains, and original discretized solve.
@@ -1455,7 +1455,7 @@ AbstractTimeseriesSolution{T, N, S} end
 $(TYPEDEF)
 
 Abstract interface for PDE solutions without a saved time axis. These solutions
-follow the [`AbstractNoTimeSolution`](@ref) contract and additionally carry
+follow the [`AbstractNoTimeSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoTimeSolution) contract and additionally carry
 discretization metadata. Concrete subtypes should provide `disc_data`,
 `original_sol`, `ivdomain`, `ivs`, and `dvs` fields so downstream discretizer
 packages can recover the PDE variables, domains, and original discretized solve.
@@ -1488,7 +1488,7 @@ const AbstractPDESolution{
 $(TYPEDEF)
 
 Abstract interface for time-series solutions that store sensitivity quantities.
-Sensitivity solutions follow the [`AbstractTimeseriesSolution`](@ref) contract,
+Sensitivity solutions follow the [`AbstractTimeseriesSolution`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractTimeseriesSolution) contract,
 but their saved values represent derivatives or augmented sensitivity states
 rather than only the primal state. Concrete subtypes should document which
 sensitivity method produced the values, how the sensitivity axes are arranged in

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -72,7 +72,7 @@ Trait declaring whether an algorithm supports nonstandard numeric scalar types.
 Algorithms that return `true` should be implemented generically enough to work
 with SciML-compatible state, parameter, and time number types beyond standard
 floating-point and complex floating-point types, subject to the additional rules
-in the [SciML container and number interface](@ref arrayandnumber). Wrapped
+in the [SciML container and number interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/Array_and_Number/). Wrapped
 C/Fortran solvers and algorithms that assume a concrete floating-point storage
 format usually cannot support this and should keep the default.
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -197,7 +197,7 @@ end
     terminate!(i::DEIntegrator[, retcode = :Terminated])
 
 Terminates the integrator by emptying `tstops`. This can be used in events and callbacks to immediately
-end the solution process.  Optionally, `retcode` may be specified (see: [Return Codes (RetCodes)](@ref retcodes)).
+end the solution process.  Optionally, `retcode` may be specified (see: [Return Codes (RetCodes)](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes)).
 """
 function terminate!(i::DEIntegrator)
     error("terminate!: method has not been implemented for the integrator")

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -1,3 +1,13 @@
+"""
+    enable_interpolation_sensitivitymode(interp)
+
+Return a copy of the interpolation object `interp` with sensitivity-analysis mode
+enabled, sharing the original's data arrays (and interval-search state where
+applicable) rather than copying them. Sensitivity mode restricts interpolation to
+the behavior that is correct on a solution rebuilt during adjoint/sensitivity
+analysis. `nothing` passes through as `nothing`; interpolation types without a
+sensitivity mode pass through unchanged.
+"""
 function enable_interpolation_sensitivitymode end
 
 enable_interpolation_sensitivitymode(interp::Nothing) = nothing

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -38,7 +38,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -78,7 +78,7 @@ DDEProblem{isinplace,specialize}(f[, u0], h, tspan[, p]; <keyword arguments>)
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](@ref specialization_levels)
+the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -91,7 +91,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions).
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/).
 
 ### Arguments
 
@@ -109,7 +109,7 @@ For specifying Jacobians and mass matrices, see the
 
 ## Dynamical Delay Differential Equations
 
-Much like the [dynamical ODE problem](@ref differential_equation_problem_types), a
+Much like the dynamical ODE problem (see the Differential Equation Problem Types page of the SciMLBase interface documentation), a
 Dynamical DDE is a partitioned DDE
 of the form:
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -43,7 +43,7 @@ u_{n+1} = u_n + dt f(u_{n},p,t_{n+1})
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](@ref specialization_levels)
+the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -56,7 +56,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -36,7 +36,7 @@ dt: the time step
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](@ref specialization_levels)
+the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -49,7 +49,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -159,7 +159,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[nonlinear function types](@ref nonlinear_optimization_boundary_function_types).
+nonlinear function types page of the SciMLBase interface documentation.
 
 ### Fields
 
@@ -319,7 +319,7 @@ will be used, which will throw nice errors if you try to index non-existent
 parameters.
 
 For specifying Jacobians and mass matrices, see the
-[nonlinear function types](@ref nonlinear_optimization_boundary_function_types).
+nonlinear function types page of the SciMLBase interface documentation.
 
 ### Fields
 

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -55,7 +55,7 @@ are:
   Defines the ODE with the specified functions. `isinplace` optionally sets whether
   the function is inplace or not. This is determined automatically, but not inferred.
   `specialize` optionally controls the specialization level. See the
-  [Specialization Levels](@ref specialization_levels)
+  [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
   for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -512,7 +512,7 @@ Therefore, you can solve a `SplitODEProblem` using the same solvers for `ODEProb
 Solver packages document which methods specialize on split structure.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -25,7 +25,7 @@ to numbers or vectors for `u₀`; one is allowed to provide `u₀` as arbitrary 
   Defines the RODE with the specified functions. The default noise is `WHITE_NOISE`.
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
-  the specialization level. See [Specialization Levels](@ref specialization_levels)
+  the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
   for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction documentation.
@@ -37,7 +37,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -67,7 +67,7 @@ SDDEProblem{isinplace,specialize}(f,g[, u0], h, tspan[, p]; <keyword arguments>)
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](@ref specialization_levels)
+the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction documentation.
@@ -80,7 +80,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions).
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/).
 
 ### Arguments
 

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -49,7 +49,7 @@ with initial condition `u0`.
   Defines the SDE with the specified functions. The default noise is `WHITE_NOISE`.
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
-  the specialization level. See [Specialization Levels](@ref specialization_levels)
+  the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
   for more details. The default is `AutoSpecialize`.
 
 Parameters are optional, and if not given then a `NullParameters()` singleton
@@ -59,7 +59,7 @@ if you set a `callback` in the problem, then that `callback` will be added in
 every solve call.
 
 For specifying Jacobians and mass matrices, see the
-[SciMLFunctions interface](@ref scimlfunctions)
+[SciMLFunctions interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/SciMLFunctions/)
 page.
 
 ### Fields

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -34,7 +34,7 @@ SteadyStateProblem{isinplace, specialize}(f, u0, p = NullParameters(); kwargs...
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](@ref specialization_levels)
+the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 Parameters are optional, and if not given, a `NullParameters()` singleton

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -359,7 +359,7 @@ The available specialization levels are:
 * `SciMLBase.FunctionWrapperSpecialize`: this is an eager function wrapping form. It is
   unsafe with many solvers, and thus is mostly used for development testing.
 
-For more details, see [Specialization Levels](@ref specialization_levels).
+For more details, see [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels).
 
 ## Fields
 


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

Two related docs breakages:

1. **Downstream docs CI is red** (e.g. NonlinearSolve master Documentation since 3.34.0 registered): docstrings ship `@ref` links to SciMLBase's own doc-page anchors (`specialization_levels`, `scimlfunctions`, `nonlinear_optimization_boundary_function_types`, …). Downstream packages splice these docstrings via `@docs` blocks, the anchors don't exist in their builds, and strict Documenter fails with `Cannot resolve @ref`.
2. **SciMLBase's own docs build fails** (blocking the dev-docs deploy): `BasicInterpolation`'s docstring `@ref`-links `enable_interpolation_sensitivitymode`, which had no docstring anywhere.

## Fix

- Docstring anchor-`@ref`s whose target pages are live on stable → absolute `docs.sciml.ai` URLs (each verified 200).
- The three refs to the two interface pages **not yet published** on stable (`Nonlinear_Optimization_and_Boundary_Function_Types`, `Differential_Equation_Problem_Types`) → plain text, so no downstream linkcheck ever depends on docs-deploy timing.
- `AbstractNoTimeSolution`-family binding `@ref`s in the #1432 solution-contract docstrings → absolute URLs into `interfaces/Solutions`.
- `enable_interpolation_sensitivitymode`: docstring added + `@docs` entry in Solutions.md (public-and-documented together).
- `@ref numargs` (internal utility docstring, binding ref, never spliced downstream) left as is.

## Verification (local, observed)

- SciMLBase docs build with this patch: **exit 0**, zero cross-reference errors, zero linkcheck failures, no ignore-list additions.
- NonlinearSolve docs built against this SciMLBase: **`Cannot resolve @ref` errors 3 → 0**, no `docs.sciml.ai` linkcheck failures. (Remaining local failures are github.com 429 rate-limits on long-standing cminpack links — an artifact of this machine's API usage, unrelated to the patch.)

After merge, a **3.34.1 release** is needed for downstream docs CI to actually heal, since the broken docstrings shipped in 3.34.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)