### PR TITLE
Release prep: bump version to 3.35.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.35.1"
+version = "3.35.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps the `version` field in Project.toml from 3.35.1 to 3.35.2 to release the one commit merged since the last registered release.

## What changed since 3.35.1 (commit 85e5c33)

- #1439 "Allow Sundials 6 in downstream tests" — widens the `Sundials` compat bound in `test/downstream/Project.toml` (a test-only sub-project, not the package's own `[compat]`) from `"4.11, 5"` to `"4.11, 5, 6"`, and adds a missing `@test` wrapper / `using Test` in `test/downstream/integer_idxs.jl`.

No source files under `src/` were touched, and no exported API changed. This is a test/CI-only change.

## Bump type: PATCH (3.35.1 -> 3.35.2)

The only diff since the last release touches `test/downstream/`, which is test infrastructure, not the package itself. No new features, no breaking changes, no compat changes to the main package's `[compat]` section — so this is a patch release per the release-sweep policy (docs/tests/CI-only => PATCH).

## Compat bounds

No changes to the main `Project.toml` `[compat]` section were needed or made. The only compat touched was `Sundials` in the test-only `test/downstream/Project.toml`, done by the prior commit (#1439) itself, not by this release-prep change.