### PR TITLE
Test table traits on IntegralSolution

### DIFF
--- a/test/downstream/traits.jl
+++ b/test/downstream/traits.jl
@@ -7,7 +7,7 @@ using OrdinaryDiffEq, DataFrames, SymbolicIndexingInterface
 @test !Tables.isrowtable(DAESolution)
 @test !Tables.isrowtable(SciMLBase.NonlinearSolution)
 @test !Tables.isrowtable(SciMLBase.LinearSolution)
-@test !Tables.isrowtable(SciMLBase.QuadratureSolution)
+@test !Tables.isrowtable(SciMLBase.IntegralSolution)
 @test !Tables.isrowtable(SciMLBase.OptimizationSolution)
 
 function rhs(u, p, t)


### PR DESCRIPTION
## Summary

- replace the stale `QuadratureSolution` target in the downstream Tables trait test with `IntegralSolution`
- preserve the assertion that integral solutions are not row tables

Please ignore this PR until reviewed by @ChrisRackauckas.

## Root cause

SciMLBase #1423 (commit `7e7042a084ef4a8b2e96d554674e6b20dbaa2d61`) intentionally removed the deprecated, non-public `QuadratureSolution` binding, but `test/downstream/traits.jl` still referenced it. ModelingToolkit's integration workflow clones SciMLBase master and runs `GROUP=Downstream`, so the test errors before checking the Tables trait.

`IntegralSolution` is the current exported, documented public API.

## Validation

- `git bisect run` identified `7e7042a084ef4a8b2e96d554674e6b20dbaa2d61` as the first bad commit for the deleted binding
- exact native downstream workflow on ModelingToolkit `f33a9699b5dd6206d5df94a60e9dc0e7fcff13a8` and unmodified SciMLBase `e3293b9b7ebcfd5ca318235f71add5004cfb65f7`: reproduced `UndefVarError: QuadratureSolution not defined in SciMLBase` with Table Traits 9 passed / 1 errored
- identical workflow with this one-line change: Table Traits 10/10, SplitODEProblem cache 1/1, scalar RODE 17/17, and `SciMLBase tests passed` (exit 0)
- Runic check: 132/132 Julia files passed
