### PR TITLE
Propagate release downstream resolver failures

### DIFF
--- a/.github/workflows/ReleaseTest.yml
+++ b/.github/workflows/ReleaseTest.yml
@@ -39,21 +39,11 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            Pkg.activate("downstream")
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.add("${{ matrix.package.package }}")
-            Pkg.update()
-            Pkg.test("Catalyst"; coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.activate("downstream")
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.add("${{ matrix.package.package }}")
+          Pkg.update()
+          Pkg.test("Catalyst"; coverage=true)
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:


### PR DESCRIPTION
## Summary

- remove the `ResolverError` catch from the release downstream job
- let dependency-resolution and Catalyst test failures propagate to GitHub Actions
- retain the existing local SciMLBase development and Catalyst test sequence

This is stacked on #1445; the extra concurrency-context commit will disappear from this diff when that PR merges.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local verification

- `/home/crackauc/.juliaup/bin/julialauncher +1.12 --startup-file=no -m Runic --check .`
- reproduced the workflow's downstream environment locally with the branch version of SciMLBase and ran `Pkg.test("Catalyst"; coverage=true)`
- the command ran Catalyst's real test suite and exited 1 at the already-investigated `UndefKeywordError: keyword argument parent_sys not assigned` failure (20 passed, 1 errored in `Symbolic Stoichiometry`), rather than converting it to success

The Catalyst failure is pre-existing on the unmodified base and is tracked separately; this PR intentionally exposes it.