### PR TITLE
Repair downstream monorepo and group routing

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,33 +12,33 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: DelayDiffEq.jl, group: Interface}
-          - {user: SciML, repo: DelayDiffEq.jl, group: Integrators}
-          - {user: SciML, repo: DelayDiffEq.jl, group: Regression}
-          - {user: SciML, repo: DiffEqBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqDevTools.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream2}
-          - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DelayDiffEq, group: Interface}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DelayDiffEq, group: Integrators}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DelayDiffEq, group: Regression}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqDevTools, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream2}
+          - {user: SciML, repo: DiffEqFlux.jl, group: All}
           - {user: SciML, repo: JumpProcesses.jl, group: All}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface1}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface2}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface3}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: AlgConvergence}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface1}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface2}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: Interface3}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/StochasticDiffEq, group: AlgConvergence}
           - {user: SciML, repo: Sundials.jl, group: All}
           - {user: SciML, repo: LinearSolve.jl, group: All}
           - {user: SciML, repo: NonlinearSolve.jl, group: Core}
-          - {user: SciML, repo: Optimization.jl, group: All}
+          - {user: SciML, repo: Optimization.jl, group: Core}
           - {user: SciML, repo: Integrals.jl, group: All}
           - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All}
           - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceI}
           - {user: SciML, repo: ModelingToolkit.jl, group: Initialization}
           - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII}
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
-          - {user: SciML, repo: ModelingToolkit.jl, group: Extended}
+          - {user: SciML, repo: ModelingToolkit.jl, subdir: lib/ModelingToolkitBase, group: Extended}
           - {user: SciML, repo: ModelingToolkit.jl, group: Downstream}
           - {user: SciML, repo: ModelingToolkit.jl, group: FMI}
           - {user: SciML, repo: ModelingToolkit.jl, group: Extensions}
@@ -57,6 +57,7 @@ jobs:
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1.10"
       julia-arch: "x64"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- route DelayDiffEq, DiffEqBase, DiffEqDevTools, and StochasticDiffEq rows to their registered packages inside the OrdinaryDiffEq monorepo
- forward each optional matrix `subdir` to the reusable workflow
- replace the nonexistent DiffEqFlux `DiffEqFlux` group with `All`
- narrow Optimization from its oversized default to the relevant `Core` group
- point ModelingToolkit `Extended` at `lib/ModelingToolkitBase`, where that suite now lives

## Why

The legacy repository rows still looked plausible but no longer selected the registered packages after the monorepo moves. Several target runners also ignored the reusable workflow's generic `GROUP`, so a requested group could silently fall through to a default or run nothing.

This PR depends on:

- SciML/.github#115 for reusable-workflow subdirectory support
- SciML/OrdinaryDiffEq.jl#3909 for generic group forwarding in the four OrdinaryDiffEq sublibrary runners
- SciML/ModelingToolkit.jl#4763 for DataInterpolations 9 compatibility in the ModelingToolkitBase test environment
- SciML/OrdinaryDiffEq.jl#3914 for the clean-base callback regression exposed by DiffEqBase `Downstream2`

## Local verification

Exact changed-target evidence collected so far:

- DelayDiffEq `Interface`: package tests passed
- DelayDiffEq `Regression`: package tests passed; Allocation 12/12, Waltman 26/26, issue #3636 20/20, plus 18 pre-existing broken inference checks
- DiffEqDevTools `Core`: package tests passed
- DiffEqBase `Downstream2`: the matrix reached substantive community tests and exposed the clean-base callback bug; #3914 then passed the full group (Community 16/16, Distributed 4/4)
- StochasticDiffEq `Interface1`, `Interface2`, and `Interface3`: all three package tests passed
- Optimization `Core`: package tests passed; Utils 110/110, Verbosity 22/22, Interface Compatibility 14/14, Sense Handling 18/18
- ModelingToolkitBase `Extended`: package tests passed with DataInterpolations 9

The long DelayDiffEq `Integrators` and DiffEqFlux `All` controls are still running locally and will be reported in follow-up comments rather than hidden from the draft.

Static verification:

- actionlint: passed
- Runic 1.7 repository check: passed
- `git diff --check`: passed
- organization-wide analyzer resolves every proposed row to a canonical selected group (193 targeted rows plus 5 intentional full-suite runners)