### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -111,6 +111,19 @@ const _ei_nonpublic_qualified_accesses = (
     :fast_matrix_colors, :ismutable, :matrix_colors, :restructure, # ArrayInterface (1.11+)
 )
 
+const _api_docs_rendered_ignore = (
+    # Dependency-owned reexports documented at their defining packages.
+    :AddVector, :AffineOperator, :BlockDiagonalOperator, :DiagonalOperator,
+    :FunctionOperator, :IdentityOperator, :InvertibleOperator, :MatrixOperator,
+    :NullOperator, :ScalarOperator, :SciMLOperators, :StaticWOperator,
+    :TensorProductOperator, :TensorSumOperator, :WOperator, :cache_operator,
+    :concretize, :has_adjoint, :has_concretization, :has_exp, :has_expmv,
+    :has_expmv!, :has_ldiv, :has_ldiv!, :has_mul, :has_mul!, :iscached,
+    :isconstant, :isconvertible, :islinear, :issquare, :kronsum,
+    :update_coefficients, :update_coefficients!,
+    :init, :solve, :solve!,
+)
+
 run_qa(
     SciMLBase;
     aqua = false,
@@ -122,6 +135,10 @@ run_qa(
         ),
         all_explicit_imports_are_public = (; ignore = _ei_nonpublic_explicit_imports),
         all_qualified_accesses_are_public = (; ignore = _ei_nonpublic_qualified_accesses),
+    ),
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = _api_docs_rendered_ignore,
     ),
 )
 


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Enables SciMLTesting rendered public API docs QA with `api_docs_kwargs = (; rendered = true)`.
- Adds a rendered-docs ignore list limited to dependency-owned reexports from `SciMLOperators` and `CommonSolve`.

## Validation

- `git diff --check` passed with no output.
- Runic v1.7.0 on `test/qa/qa.jl` passed with no output.
- Julia 1.10 temporary QA environment: `include("test/qa/qa.jl")` passed (`Aqua tests (performance)` 2/2, `Aqua tests (additional)` 6/6, `Quality Assurance` 6/6, `AllocCheck: scalar in-place interpolation` 6/6).
- Julia 1.10 docs build from a temporary docs environment completed successfully; Documenter emitted existing warnings only.
- Julia 1.12 focused public API docs check passed (`Public API documentation` 2/2), covering the `@public` surface that Julia 1.10 cannot report.

## Known Validation Blockers

- Standard Julia 1.10 `Pkg.instantiate()`/`GROUP=QA Pkg.test` against the committed root `Manifest.toml` fails before tests because `FindFirstFunctions` is a direct dependency missing from the manifest.
- Standard Julia 1.10 docs instantiate against committed `docs/Manifest.toml` fails before docs build because `JuliaSyntaxHighlighting` source cannot be located from the Julia 1.12-generated manifest.