### PR TITLE
[v2-backport] Fix spelling in AD extension comments

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -60,7 +60,7 @@ end
 
 # `sol[i::Integer]` returns the state vector at time step `i`, not a
 # state-variable slice. A dedicated rrule prevents the broader
-# `getindex(VA::ODESolution, sym)` rule below from mis-treating `i` as a
+# `getindex(VA::ODESolution, sym)` rule below from mistaking `i` for a
 # state index (#1325). Dispatch picks this more-specific method for
 # integer arguments.
 function ChainRulesCore.rrule(::typeof(getindex), VA::ODESolution, i::Integer)

--- a/ext/SciMLBaseMooncakeExt.jl
+++ b/ext/SciMLBaseMooncakeExt.jl
@@ -278,7 +278,7 @@ end
 # `sol[i::Integer]` returns the state vector at time step `i` (a different
 # operation from `sol[sym]`). A dedicated, more-specific primitive routes
 # integer time-step indexing to the correct scatter so the generic symbolic
-# rrule above does not mis-treat `i` as a state-variable index (#1325).
+# rrule above does not mistake `i` for a state-variable index (#1325).
 @is_primitive MinimalCtx Tuple{typeof(getindex), AbstractTimeseriesSolution, Integer}
 
 # Differentiate the observed function `getter(sym, u, p, t)` once with


### PR DESCRIPTION
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- Replace two instances of `mis-treating` in AD extension comments with wording accepted by the repository spell checker.
- Keep the explanatory meaning unchanged.
- Make no runtime code or API changes.

## Root cause

Commit `8a891d49334c7fe7ec490a331a264ac0001ec13b` added both comments. The hyphen causes `typos-cli 1.18.0` to parse `mis` as a standalone typo, so the clean `v2-backport` branch fails its spell-check workflow.

## Validation

- Reproduced both failures on clean `upstream/v2-backport` with the workflow's exact `typos-cli 1.18.0` release.
- Ran `git bisect run` with that exact checker; it identified `8a891d49334c7fe7ec490a331a264ac0001ec13b` as the first bad commit.
- Re-ran `typos-cli 1.18.0` across the full repository after the correction: passed (exit 0).
- Ran Runic across the full repository with `--check`: passed (exit 0).
- Ran `git diff --check`: passed.

The focused validation is the repository's spelling workflow because this patch changes comments only.
