### PR TITLE
Make LinearProblem inferrable for AbstractSciMLOperator inputs

### DIFF
--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -162,6 +162,12 @@ function LinearProblem(A, b, args...; kwargs...)
         LinearProblem{true}(A, b, args...; kwargs...)
     elseif A isa Number
         LinearProblem{false}(A, b, args...; kwargs...)
+    elseif A isa AbstractSciMLOperator
+        # `isinplace` reflects on the operator's call methods, which infers as
+        # `Union{Missing, Bool}` and makes the whole constructor infer to `Any`.
+        # Every `AbstractSciMLOperator` defines the 4-arg in-place call, so this
+        # is the value the reflection already computes -- just statically.
+        LinearProblem{true}(A, b, args...; kwargs...)
     else
         LinearProblem{isinplace(A, 4)}(A, b, args...; kwargs...)
     end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`LinearProblem(A, b, args...)` (`src/problems/linear_problems.jl:160`) falls through to `LinearProblem{isinplace(A, 4)}` for anything that is neither an `AbstractArray` nor a `Number`. `isinplace` is runtime method reflection (via `numargs`) and infers as `Union{Missing, Bool}`, so the `iip` type parameter is never a compile-time constant and the whole constructor infers to `Any`:

```julia
julia> Base.infer_return_type(LinearProblem, Tuple{Matrix{Float64}, Vector{Float64}})
LinearProblem{Nothing, true, Matrix{Float64}, ...}   # concrete

julia> Base.infer_return_type(LinearProblem, Tuple{MatrixOperator{...}, Vector{Float64}})
Any                                                  # before this PR
```

This was latent until something started passing operators. SciML/OrdinaryDiffEq.jl#3885 made `reuse_jac_prototype` wrap a dense `W` in a `MatrixOperator`, which sends NonlinearSolveBase's `construct_linear_solver` down the `A isa AbstractSciMLOperator` branch (`NonlinearSolveBase/src/linear_solve.jl:93-97`). The `Any` then propagates outward as `where` bounds through `LinearSolveJLCache` → `NewtonDescentCache` → `DoglegCache` → `GeneralizedFirstOrderAlgorithmCache` → `NonlinearSolveCache` → `NLSolver`, which is currently breaking `@inferred` on `build_nlsolver` in `OrdinaryDiffEqBDF`'s inference tests on master (`lib/OrdinaryDiffEqBDF/test/inference_tests.jl:19`).

I bisected that failure to OrdinaryDiffEq `9a2f7e7b7` (#3885), but the fix belongs here — #3885's operator wrapping is architecturally intentional, and unwrapping it would revert the matrix-free Krylov path that PR was written to enable.

## Change

Dispatch `AbstractSciMLOperator` to `LinearProblem{true}` statically.

## Why this is behavior-preserving

`true` is the value the reflection already computes at runtime. I checked the case most likely to differ — an operator whose `iip` trait is `false`:

```julia
julia> A = MatrixOperator(rand(3,3));
julia> SciMLBase.isinplace(A, 4)
true

julia> F = FunctionOperator((u,p,t) -> 2u, rand(3); isinplace=false, outofplace=true);
julia> typeof(F).parameters[1:2]   # (iip, oop)
(false, true)
julia> SciMLBase.isinplace(F, 4)
true
```

Even an out-of-place-only `FunctionOperator` reports `true`, because `isinplace`/`numargs` reflects on the operator struct's call methods (which always include the 4-arg in-place form) rather than on its `iip` trait. So no `AbstractSciMLOperator` currently reaches the `false` branch.

The one behavior change worth flagging for review: a *custom* `AbstractSciMLOperator` defined outside SciMLOperators that deliberately omits the 4-arg in-place call would previously have gotten `iip = false` and now gets `true`. I could not construct such a type from the SciMLOperators types, but it is not structurally impossible, so please sanity-check that assumption.

## Tests

- `GROUP=Core` SciMLBase test suite: **passes**.
- Direct repro of the downstream inference failure, with and without this patch (`build_nlsolver` with `NonlinearSolveAlg(TrustRegion(autodiff=AutoFiniteDiff()))`):

| | result |
|---|---|
| registry SciMLBase v3.36.0 | 1 passed, **1 errored** |
| this branch | **2 passed** |

- `LinearProblem(MatrixOperator, b)` now infers concretely as `LinearProblem{Nothing, true, MatrixOperator{Float64, Matrix{Float64}, ...}, Vector{Float64}, NullParameters, Nothing, ...}`.

Runic-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)