### PR TITLE
Add AutoDePSpecialize specialization level

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.36.1"
+version = "3.37.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -55,6 +55,7 @@ Note that `iip` choice is required for specialization choices to be made.
 ```@docs
 SciMLBase.AbstractSpecialization
 SciMLBase.AutoSpecialize
+SciMLBase.AutoDePSpecialize
 SciMLBase.NoSpecialize
 SciMLBase.FunctionWrapperSpecialize
 SciMLBase.FullSpecialize

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2230,7 +2230,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public DECache
 
 # Specialization markers
-@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize
+@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize
 
 # SDE interpretation trait
 @public AlgorithmInterpretation, alg_interpretation

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -169,10 +169,52 @@ ODEProblem{true, SciMLBase.FullSpecialize}(f, [1.0], (0.0, 1.0))
 """
 struct FullSpecialize <: AbstractSpecialization end
 
+"""
+$(TYPEDEF)
+
+`AutoDePSpecialize` extends [`AutoSpecialize`](@ref) by additionally
+*de-specializing the parameter object*. Solver paths with a supported
+opaque-parameter strategy pack an `isbits`, non-`NullParameters` `p` into a
+fixed-type opaque container (e.g. `RespecializeParams.OpaqueParams`) and
+install callable wrappers whose signatures carry the opaque container type in
+the `p` slot instead of `typeof(p)`. The concretized problem type — and with
+it the solver's compilation — then becomes independent of the user's
+parameter struct type, so a single compiled (and precompiled) solve is shared
+across all `isbits` parameter types. Inside the user's `f`, `p` is recovered
+at its original concrete type via a type-stable, allocation-free unpack, so
+the model function itself remains fully specialized.
+
+`AutoDePSpecialize` is the recommended choice for latency-sensitive workflows
+that construct many problems with differently-typed parameter structs
+(parameter studies over configuration structs, package test suites,
+teaching setups).
+
+Support is solver-specific, like all specialization levels. Where a solver
+path has no opaque-parameter strategy — or where `p` is not `isbits` or is
+`NullParameters` — behavior falls back to plain `AutoSpecialize`. Solvers
+that apply the packing keep the opaque container in the concretized problem
+(e.g. `sol.prob.p`), since installed wrappers may be re-invoked with it;
+consult the solver's documentation for how to recover the original value.
+
+## Example
+
+```julia
+struct MyParams
+    k::Float64
+end
+f(du, u, p, t) = (du .= p.k .* u)
+ODEProblem{true, SciMLBase.AutoDePSpecialize}(f, [1.0], (0.0, 1.0), MyParams(2.0))
+```
+"""
+struct AutoDePSpecialize <: AbstractSpecialization end
+
 specstring = Preferences.@load_preference("SpecializationLevel", "AutoSpecialize")
 if specstring ∉
-        ("NoSpecialize", "FullSpecialize", "AutoSpecialize", "FunctionWrapperSpecialize")
-    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize).")
+        (
+        "NoSpecialize", "FullSpecialize", "AutoSpecialize", "FunctionWrapperSpecialize",
+        "AutoDePSpecialize",
+    )
+    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize).")
 end
 
 const DEFAULT_SPECIALIZATION = getproperty(SciMLBase, Symbol(specstring))

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -245,3 +245,34 @@ end
     @test sccprob2 isa SCCNonlinearProblem{SVector{3, Float64}}
     @test state_values(sccprob2) isa SVector{3, Float64}
 end
+
+@testset "AutoDePSpecialize specialization marker" begin
+    struct DePParams
+        k::Float64
+    end
+    f_dep!(du, u, p, t) = (du[1] = -p.k * u[1]; nothing)
+
+    prob = ODEProblem{true, SciMLBase.AutoDePSpecialize}(
+        f_dep!, [1.0], (0.0, 1.0), DePParams(0.5)
+    )
+    @test prob isa ODEProblem
+    @test prob.f isa ODEFunction{true, SciMLBase.AutoDePSpecialize}
+    @test SciMLBase.specialization(prob.f) === SciMLBase.AutoDePSpecialize
+    # The marker alone performs no wrapping or packing in SciMLBase: fields stay
+    # concretely typed like FullSpecialize/AutoSpecialize construction, and p is
+    # the user's struct until a solver path installs an opaque-parameter wrapper.
+    @test prob.f.f === f_dep!
+    @test prob.p === DePParams(0.5)
+    du = [0.0]
+    prob.f(du, [2.0], prob.p, 0.0)
+    @test du[1] ≈ -1.0
+
+    # Available for other function families, e.g. nonlinear problems.
+    f_nl!(res, u, p) = (res[1] = u[1] - p.k; nothing)
+    nlfun = NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(f_nl!)
+    @test SciMLBase.specialization(nlfun) === SciMLBase.AutoDePSpecialize
+
+    # unwrapped_f reconstruction keeps the marker
+    uf = SciMLBase.unwrapped_f(prob.f)
+    @test SciMLBase.specialization(uf) === SciMLBase.AutoDePSpecialize
+end


### PR DESCRIPTION
> [!NOTE]
> Draft PR — please ignore until reviewed by @ChrisRackauckas.

Adds `AutoDePSpecialize <: AbstractSpecialization`, a specialization level that extends `AutoSpecialize` by also **de-specializing the parameter object**: solver paths with an opaque-parameter strategy pack an isbits, non-`NullParameters` `p` into a fixed-type opaque container (e.g. `RespecializeParams.OpaqueParams`) and install wrappers whose signatures carry the container type in the `p` slot. The concretized problem type — and the solver compilation — becomes independent of the user's parameter struct type, so one precompiled solve covers all isbits parameter types, while the user's `f` still receives `p` fully typed via an allocation-free unpack.

SciMLBase only defines the **marker**: type + docstring, `@public`, `@docs` entry in the Specialization Levels section of `interfaces/Problems.md`, and `"AutoDePSpecialize"` added to the `SpecializationLevel` preference allowlist. No new dependencies — the wrapping is solver-owned, so any function family (ODE, nonlinear, …) can implement its own strategy.

Placing the level here (rather than in DiffEqBase, where an earlier revision defined it) is per @ChrisRackauckas's direction so that **NonlinearSolve.jl can implement the same level** for its residual wrappers. The ODE-stack implementation and benchmarks live in SciML/OrdinaryDiffEq.jl#3692 (measured there: first-solve TTFX for a never-seen parameter struct 12.1 s → 0.43 s for `DefaultODEAlgorithm`, runtime within ~2% of `AutoSpecialize`).

Construction through the generic `AbstractSciMLFunction` constructor branches already works for arbitrary specialization types, so no constructor changes are needed; the marker alone performs no wrapping in SciMLBase (fields stay concretely typed, `p` untouched), which the new tests in `test/problem_building_test.jl` assert, along with `specialization()` round-tripping and `unwrapped_f` preserving the marker.

**Version**: 3.36.1 → 3.37.0 (new public API).

**Tests run locally**: `test/problem_building_test.jl` with dev'd SciMLBase — all pass including the 8 new assertions (`AutoDePSpecialize specialization marker | 8 pass`). Runic applied to changed .jl files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAbA8hSnrirMrJjFqxwn5