### PR TITLE
Publicize extension hooks used by solver packages

### DIFF
--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -114,6 +114,8 @@ of the mathematical structure used to create it.
 
 ```@docs
 SciMLBase.remake
+SciMLBase.updated_u0_p
+SciMLBase.parameterless_type
 ```
 
 For problems that are created from a system (e.g. created through ModelingToolkit.jl) or

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -80,6 +80,8 @@ SciMLBase.ReturnCode
 
 ```@docs
 SciMLBase.successful_retcode
+SciMLBase.isdenseplot
+SciMLBase.plottable_indices
 ```
 
 ### Specific Return Codes

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2205,6 +2205,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Function-wrapper / solution interface helpers
 @public unwrapped_f, specialization, solution_new_retcode
+@public parameterless_type, updated_u0_p, isdenseplot, plottable_indices
 @public isfunctionwrapper, wrapfun_oop, wrapfun_iip, unwrap_fw
 
 # Low-level solver-author extension entry points

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -1497,6 +1497,15 @@ function _updated_u0_p_symmap(prob, u0, ::Val{true}, p, ::Val{true}, t0)
         remake_buffer(prob, parameter_values(prob), keys(p), values(p))
 end
 
+"""
+    updated_u0_p(prob, u0, p, t0 = nothing; interpret_symbolicmap = true,
+        use_defaults = false)
+
+Resolve replacement initial conditions and parameters for a SciML problem.
+
+Package authors implementing a `remake` method for a wrapper problem can use this to
+preserve the symbolic-map and default-value behavior of [`remake`](@ref).
+"""
 function updated_u0_p(
         prob, u0, p, t0 = nothing; interpret_symbolicmap = true,
         use_defaults = false

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -243,6 +243,13 @@ end
 DEFAULT_PLOT_FUNC(x, y) = (x, y)
 DEFAULT_PLOT_FUNC(x, y, z) = (x, y, z) # For v0.5.2 bug
 
+"""
+    isdenseplot(sol)
+
+Return whether plotting `sol` should evaluate its interpolation densely.
+
+Solution packages may extend this for a concrete solution type.
+"""
 function isdenseplot(sol)
     return (sol.dense || sol.prob isa AbstractDiscreteProblem) &&
         !(sol isa AbstractRODESolution) &&

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -424,6 +424,14 @@ end
 
 using Base: typename
 
+"""
+    parameterless_type(x)
+
+Return the parameterless type constructor associated with `x` or a concrete type.
+
+This is intended for package authors implementing `remake`-style reconstruction of
+parametric SciML objects.
+"""
 Base.@pure __parameterless_type(T) = typename(T).wrapper
 parameterless_type(x) = __parameterless_type(typeof(x))
 parameterless_type(::Type{T}) where {T} = __parameterless_type(T)

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -254,6 +254,12 @@ end
 end
 
 if isdefined(Base, :ispublic)
+    @testset "Extension hooks public API" begin
+        for name in (:parameterless_type, :updated_u0_p, :isdenseplot, :plottable_indices)
+            @test Base.ispublic(SciMLBase, name)
+        end
+    end
+
     @testset "Clocks manual public API" begin
         for name in (
                 :AbstractClock,


### PR DESCRIPTION
Makes `parameterless_type`, `updated_u0_p`, `isdenseplot`, and `plottable_indices` public extension APIs with definition-site documentation and rendered interface entries. Adds public-interface coverage.

Ignore until reviewed by @ChrisRackauckas.