### PR TITLE
Fix symbolic save_idxs skipping translation when selecting all state variables

### DIFF
--- a/src/solutions/save_idxs.jl
+++ b/src/solutions/save_idxs.jl
@@ -482,7 +482,55 @@ function get_save_idxs_and_saved_subsystem(prob, save_idxs)
         else
             save_idxs = _save_idxs
         end
+    else
+        # `SavedSubsystem` also returns `nothing` when the selection saves every
+        # state variable (and every time-series parameter), in which case
+        # symbolic `save_idxs` must still be translated to integer state indexes,
+        # preserving the requested order, so raw symbols never leak into integer
+        # indexing. Non-symbolic `save_idxs` (e.g. `Colon`) pass through untouched.
+        save_idxs = translate_symbolic_save_idxs(prob, save_idxs)
     end
 
     return save_idxs, saved_subsystem
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Translate symbolic `save_idxs` into integer state indexes, preserving the
+requested order and scalarizing symbolic arrays. Non-symbolic `save_idxs` (an
+integer, `Colon`, etc.) are returned unchanged. A single symbolic entry that
+resolves to one state is returned as a scalar so it is saved as a scalar
+timeseries rather than a single-element array.
+"""
+function translate_symbolic_save_idxs(indp, save_idxs)
+    if save_idxs isa AbstractArray && symbolic_type(save_idxs) == NotSymbolic()
+        translated = Int[]
+        for sym in save_idxs
+            _append_state_indices!(translated, indp, sym)
+        end
+        return translated
+    elseif symbolic_type(save_idxs) == NotSymbolic()
+        return save_idxs
+    else
+        translated = Int[]
+        _append_state_indices!(translated, indp, save_idxs)
+        return length(translated) == 1 ? only(translated) : translated
+    end
+end
+
+function _append_state_indices!(translated, indp, sym)
+    if symbolic_type(sym) == NotSymbolic()
+        push!(translated, sym)
+    elseif sym isa AbstractArray && is_variable(indp, sym)
+        for s in collect(sym)
+            push!(translated, variable_index(indp, s))
+        end
+    else
+        idx = variable_index(indp, sym)
+        idx === nothing &&
+            throw(ArgumentError("Can only save variables. Got $sym."))
+        push!(translated, idx)
+    end
+    return translated
 end

--- a/test/downstream/solution_interface.jl
+++ b/test/downstream/solution_interface.jl
@@ -414,6 +414,58 @@ end
         @test _idxs == Int[]
         @test _ss isa SciMLBase.SavedSubsystem
     end
+
+    # https://github.com/SciML/SciMLBase.jl/issues/1454
+    @testset "symbolic save_idxs selecting all states" begin
+        @variables x(t) = 1.0 y(t) = 1.0 z(t) = 1.0
+        @parameters a = 1.5 b = 1.0 c = 3.0 d = 1.0
+        @mtkcompile sys = System(
+            [D(x) ~ a * x - b * x * y, D(y) ~ -c * y + d * x * z, D(z) ~ x - z], t
+        )
+        prob = ODEProblem(sys, [], (0.0, 1.0))
+        xidx = variable_index(sys, x)
+        yidx = variable_index(sys, y)
+        zidx = variable_index(sys, z)
+
+        # `SavedSubsystem` returns `nothing` for a save-everything request, but
+        # `get_save_idxs_and_saved_subsystem` must still translate the symbols to
+        # integer state indexes preserving the requested order.
+        for (si, expected) in (
+                ([:x, :y, :z], [xidx, yidx, zidx]),
+                ([:z, :y, :x], [zidx, yidx, xidx]),
+                ([x, y, z], [xidx, yidx, zidx]),
+                ([z, y, x], [zidx, yidx, xidx]),
+            )
+            _idxs, _ss = SciMLBase.get_save_idxs_and_saved_subsystem(prob, si)
+            @test _idxs == expected
+            @test eltype(_idxs) == Int
+            @test _ss === nothing
+        end
+
+        full = solve(prob, Tsit5(); saveat = 0.1)
+        # all states, natural order
+        sol = solve(prob, Tsit5(); saveat = 0.1, save_idxs = [:x, :y, :z])
+        @test sol.u[end] == [full[x][end], full[y][end], full[z][end]]
+        # all states, permuted order must be preserved
+        solr = solve(prob, Tsit5(); saveat = 0.1, save_idxs = [:z, :y, :x])
+        @test solr.u[end] == [full[z][end], full[y][end], full[x][end]]
+        # `Num` selection of all states
+        soln = solve(prob, Tsit5(); saveat = 0.1, save_idxs = [x, y, z])
+        @test soln.u[end] == [full[x][end], full[y][end], full[z][end]]
+
+        # regressions: subset, single symbol, and integer selections still work
+        subset = solve(prob, Tsit5(); saveat = 0.1, save_idxs = [:x, :z])
+        @test subset.u[end] == [full[x][end], full[z][end]]
+        single = solve(prob, Tsit5(); saveat = 0.1, save_idxs = :x)
+        @test single.u[end] == full[x][end]
+        ints = solve(prob, Tsit5(); saveat = 0.1, save_idxs = [1, 2, 3])
+        @test ints.u[end] == full.u[end]
+
+        # non-state expression is still rejected
+        @test_throws Exception SciMLBase.get_save_idxs_and_saved_subsystem(
+            prob, [x + y]
+        )
+    end
 end
 
 @testset "Interpolation after final discrete save" begin


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes #1454.

## Problem

Symbolic `save_idxs` silently skipped index translation when the selection named **all** state variables, leaking raw `Symbol`/`Num` into the integer indexing path.

With a 3-variable MTK Lotka-Volterra system:

| `save_idxs` | before |
| --- | --- |
| `[:x, :z]` (subset) | OK → `[1, 3]` |
| `[:x, :y, :z]` (ALL) | **FAIL** `ArgumentError: unable to check bounds for indices of type Symbol` |
| `[:z, :y, :x]` (ALL, permuted) | **FAIL** (same) |

Reproduced with `Vector{Symbol}` and `Vector{Num}` (the latter: `TypeError: non-boolean (Num) used in boolean context`).

## Root cause

`SavedSubsystem` deliberately returns `nothing` for a save-everything request (its docstring: "returns `nothing` when no metadata is needed, including ... requests that save all state variables"). The `get_save_idxs_and_saved_subsystem` generic method's `if saved_subsystem !== nothing` guard misread that `nothing` as "no translation needed" and returned the raw symbolic `save_idxs` unchanged.

## Fix

In the `saved_subsystem === nothing` branch, translate symbolic `save_idxs` to integer state indexes via `variable_index`, **preserving the requested order** (so permutations like `[:z, :y, :x]` reorder correctly rather than collapsing to a sorted/identity shortcut) and scalarizing symbolic arrays. Non-symbolic `save_idxs` (integers, `Colon`) pass through untouched; observed / non-state expressions are still rejected by `SavedSubsystem` as before.

## Verification (run locally, Julia 1.11)

`save_idxs = [:x, :y, :z]` and `[:z, :y, :x]` (and their `Num` equivalents) now succeed, and the saved solution matches a full solve in the requested order:

```
[:x,:y,:z] order/value matches full [x,y,z]: true
[:z,:y,:x] order/value matches full [z,y,x]: true
[:x,:z]    order/value matches full [x,z]:   true
:x scalar  matches full x:                   true
```

Subset, single-symbol, integer, permuted-integer, and `nothing` cases all still work; `[x + y]` (non-state expression) still errors.

## Tests

Added a regression test to `test/downstream/solution_interface.jl` in the "Saved subsystem" testset covering: symbolic all-vars (natural + permuted), `Num` all-vars, the `get_save_idxs_and_saved_subsystem` translation output, subset/single/integer regressions, and non-state rejection.

Full `solution_interface.jl` (Solution Indexing) suite passes locally: **260 passed, 0 failed, 0 errored**.