### PR TITLE
Bump SciMLBase to v3.38.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.37.0"
+version = "3.38.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLBase` **v3.37.0 → v3.38.0** (minor) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** @public parameterless_type/updated_u0_p/isdenseplot/plottable_indices (publicized extension hooks)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)