### PR TITLE
Fix master QA: parameterless_type docstring + reexport allowlist

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -424,6 +424,8 @@ end
 
 using Base: typename
 
+Base.@pure __parameterless_type(T) = typename(T).wrapper
+
 """
     parameterless_type(x)
 
@@ -432,7 +434,6 @@ Return the parameterless type constructor associated with `x` or a concrete type
 This is intended for package authors implementing `remake`-style reconstruction of
 parametric SciML objects.
 """
-Base.@pure __parameterless_type(T) = typename(T).wrapper
 parameterless_type(x) = __parameterless_type(typeof(x))
 parameterless_type(::Type{T}) where {T} = __parameterless_type(T)
 

--- a/test/downstream/solution_interface.jl
+++ b/test/downstream/solution_interface.jl
@@ -465,6 +465,16 @@ end
         @test_throws Exception SciMLBase.get_save_idxs_and_saved_subsystem(
             prob, [x + y]
         )
+
+        # Mixed integer + symbol selection of all states must still translate,
+        # preserving order (adjacent path to pure-symbolic all-vars; #1454).
+        mixed = [:x, yidx, :z]
+        _idxs, _ss = SciMLBase.get_save_idxs_and_saved_subsystem(prob, mixed)
+        @test _idxs == [xidx, yidx, zidx]
+        @test eltype(_idxs) == Int
+        @test _ss === nothing
+        solm = solve(prob, Tsit5(); saveat = 0.1, save_idxs = mixed)
+        @test solm.u[end] == [full[x][end], full[y][end], full[z][end]]
     end
 end
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -121,8 +121,16 @@ const _api_docs_rendered_ignore = (
     :has_expmv!, :has_ldiv, :has_ldiv!, :has_mul, :has_mul!, :iscached,
     :isconstant, :isconvertible, :islinear, :issquare, :kronsum,
     :update_coefficients, :update_coefficients!,
-    :init, :solve, :solve!,
+    :init, :solve, :solve!, :step!,
+    # RecursiveArrayTools symbolic-indexing sentinel reexported for solution UI.
+    :AllObserved,
+    # Base name reexported as the DEIntegrator resizing verb (methods live on Base).
+    :deleteat!,
 )
+
+# Intentional public reexports: SciMLOperators via `@reexport`, CommonSolve verbs
+# reexported for the SciML solve interface, and `AllObserved` from RecursiveArrayTools.
+const _reexports_allow = _api_docs_rendered_ignore
 
 run_qa(
     SciMLBase;
@@ -140,6 +148,7 @@ run_qa(
         rendered = true,
         rendered_ignore = _api_docs_rendered_ignore,
     ),
+    reexports_allow = _reexports_allow,
 )
 
 include("alloccheck.jl")


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Master `Run Tests` / QA fails with two SciMLTesting checks:

1. **`public API has docstrings`** — `parameterless_type` was `@public` and listed in docs, but the docstring was attached to the internal `Base.@pure __parameterless_type` helper instead of the public methods.
2. **`No unapproved public reexports`** — intentional reexports (`@reexport using SciMLOperators`, CommonSolve verbs, `AllObserved`, Base `deleteat!` as the DEIntegrator verb) were not listed in `reexports_allow`.

## Changes

- Move the `parameterless_type` docstring onto the public methods in `src/utils.jl`.
- Pass `reexports_allow = _reexports_allow` in `test/qa/qa.jl` (shared with `rendered_ignore`, plus `:step!`, `:AllObserved`, `:deleteat!`).
- Add a mixed `Symbol`/`Int` all-states `save_idxs` regression next to the #1454 coverage (adjacent path to pure-symbolic all-vars).

## Local verification

```
GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
# QA | 24 passed / 24 total
# Testing SciMLBase tests passed
```

## Related master CI notes

IntegrationTest / ReleaseTest failures on master are largely **downstream** of this package (not fixed here):

- OrdinaryDiffEq `DEVerbosity` resize MethodError → tracked by SciML/OrdinaryDiffEq.jl#3971
- Catalyst `UndefKeywordError: parent_sys` on ReleaseTest → Catalyst-side