### PR TITLE
Error cleanly on complex EnsembleSummary; fix SplitFunction ODEProblem cache

### DIFF
--- a/src/ensemble/ensemble_analysis.jl
+++ b/src/ensemble/ensemble_analysis.jl
@@ -392,6 +392,13 @@ function SciMLBase.EnsembleSummary(
         sim::SciMLBase.AbstractEnsembleSolution{T, N},
         t = sim.u[1].t; quantiles = [0.05, 0.95]
     ) where {T, N}
+    # Medians/quantiles need a total order; complex states have none (DE #632).
+    sample = sim.u[1] isa SciMLBase.AbstractSciMLSolution ? sim.u[1].u[1] : sim.u[1]
+    et = RecursiveArrayTools.recursive_unitless_eltype(sample)
+    if et <: Complex
+        throw(SciMLBase.ComplexEnsembleSummaryError(et))
+    end
+
     if sim.u[1] isa SciMLBase.AbstractSciMLSolution
         m, v = timeseries_point_meanvar(sim, t)
         med = timeseries_point_median(sim, t)

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -129,6 +129,11 @@ a `(mean,var)` summary at each time point `t` in `ts`. This requires the ability
 to interpolate the solution. Quantile is used to determine the `qlow` and `qhigh`
 quantiles at each timepoint. It defaults to the 5% and 95% quantiles.
 
+Complex-valued trajectories are rejected with a
+`ComplexEnsembleSummaryError`: medians and quantiles require a total
+order, which complex numbers do not have. Summarize real/imaginary parts or
+magnitudes separately, or use mean/variance helpers that do not need ordering.
+
 ## Plot Recipe
 
 The `EnsembleSummary` comes with a plot recipe for visualizing the summary

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -395,6 +395,33 @@ function Base.showerror(io::IO, e::ComplexTspanError)
     return println(io, COMPLEX_TSPAN_ERROR_MESSAGE)
 end
 
+const COMPLEX_ENSEMBLE_SUMMARY_ERROR_MESSAGE = """
+Complex-valued ensemble trajectories detected when building an
+`EnsembleSummary`.
+
+`EnsembleSummary` computes componentwise medians and quantiles, which
+require a total order (`isless`). Complex numbers have no natural
+ordering, so quantiles (and medians) are undefined on ℂ.
+
+Supported options:
+  - Summarize real and imaginary parts separately (e.g. map each
+    trajectory to `real.(u)` / `imag.(u)` before summarizing).
+  - Summarize magnitudes with `abs.(u)` if a polar summary is enough.
+  - Use only mean/variance helpers such as `timeseries_point_meanvar`,
+    which do not require ordering.
+
+See https://github.com/SciML/DifferentialEquations.jl/issues/632.
+"""
+
+struct ComplexEnsembleSummaryError <: Exception
+    eltype::Any
+end
+
+function Base.showerror(io::IO, e::ComplexEnsembleSummaryError)
+    println(io, COMPLEX_ENSEMBLE_SUMMARY_ERROR_MESSAGE)
+    return println(io, "Detected element type: $(e.eltype)")
+end
+
 const TUPLE_STATE_ERROR_MESSAGE = """
 Tuple type used as a state. Since a tuple does not have vector
 properties, it will not work as a state type in equation solvers.

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -231,6 +231,18 @@ function ODEProblem(f::AbstractODEFunction, u0, tspan, args...; kwargs...)
     return ODEProblem{isinplace(f)}(f, u0, tspan, args...; kwargs...)
 end
 
+# In-place `SplitFunction` evaluation needs a temporary buffer (`_func_cache`).
+# `SplitODEProblem` always allocates it from `u0`; bare `ODEProblem(sf, u0, tspan)`
+# must do the same so `f(du,u,p,t)` does not call `get_tmp(nothing, du)`.
+function ODEProblem(f::SplitFunction, u0, tspan, args...; kwargs...)
+    iip = isinplace(f)
+    if iip && f._func_cache === nothing
+        _func_cache = typeof(u0) <: AbstractArray{<:Number} ? DiffCache(u0) : u0
+        f = remake(f; _func_cache)
+    end
+    return ODEProblem{iip}(f, u0, tspan, args...; kwargs...)
+end
+
 function ODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     iip = isinplace(f, 4)
     _u0 = prepare_initial_state(u0)

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2868,6 +2868,18 @@ end
 
 (f::SplitFunction)(u, p, t) = f.f1(u, p, t) + f.f2(u, p, t)
 function (f::SplitFunction)(du, u, p, t)
+    if f._func_cache === nothing
+        throw(
+            ArgumentError(
+                string(
+                    "In-place SplitFunction evaluation requires `_func_cache`. ",
+                    "Build the problem with `SplitODEProblem(f1, f2, u0, tspan)` or ",
+                    "`ODEProblem(split_function, u0, tspan)` so the cache is allocated ",
+                    "from `u0`. A bare `SplitFunction(f1, f2)` has no buffer until then."
+                )
+            )
+        )
+    end
     tmp = get_tmp(f._func_cache, du)
     f.f1(tmp, u, p, t)
     f.f2(du, u, p, t)

--- a/test/ensemble_tests.jl
+++ b/test/ensemble_tests.jl
@@ -55,3 +55,32 @@ mx, my,
         )
     )
 end
+
+# https://github.com/SciML/DifferentialEquations.jl/issues/632
+@testset "EnsembleSummary rejects complex-valued trajectories" begin
+    prob = ODEProblem((u, p, t) -> u, 1.0 + 0.0im, (0.0, 1.0))
+    ts = [0.0, 0.5, 1.0]
+    vals = [
+        [1.0 + 0.0im, 1.5 + 0.2im, 2.0 + 0.4im],
+        [0.5 + 0.1im, 1.0 + 0.3im, 1.5 + 0.5im],
+        [1.2 - 0.1im, 1.4 + 0.0im, 1.8 + 0.2im],
+    ]
+    sols = [
+        SciMLBase.build_solution(
+                prob, :NoAlgorithm, ts, u; retcode = SciMLBase.ReturnCode.Success
+            )
+            for u in vals
+    ]
+    sim = EnsembleSolution(sols, 0.0, true)
+    err = try
+        EnsembleSummary(sim, ts)
+        nothing
+    catch e
+        e
+    end
+    @test err isa SciMLBase.ComplexEnsembleSummaryError
+    @test occursin("Complex-valued ensemble", sprint(showerror, err))
+    # mean/var path remains available without ordering
+    m, v = EA.timeseries_point_meanvar(sim, ts)
+    @test length(m.u) == length(ts)
+end

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -38,6 +38,39 @@ prob_bvp = BVProblem(simplependulum!, bc!, [pi / 2, pi / 2], (0, 1.0))
     @test SciMLBase.specialization(specialized_incrementing_f) === SciMLBase.NoSpecialize
 end
 
+# Bare ODEProblem(SplitFunction, u0, tspan) must allocate `_func_cache` for iip,
+# matching SplitODEProblem (otherwise f(du,u,p,t) hits ndims(::Type{Nothing})).
+@testset "ODEProblem(SplitFunction) allocates _func_cache" begin
+    f1! = (du, u, p, t) -> (du .= u)
+    f2! = (du, u, p, t) -> (du .= -u)
+    u0 = [1.0, 2.0]
+    sf = SplitFunction(f1!, f2!)
+    @test sf._func_cache === nothing
+    @test_throws ArgumentError sf(similar(u0), u0, nothing, 0.0)
+
+    prob = ODEProblem(sf, u0, (0.0, 1.0))
+    @test prob.f._func_cache !== nothing
+    du = zeros(2)
+    # combined rhs is f1 + f2 = u + (-u) = 0
+    prob.f(du, u0, nothing, 0.0)
+    @test du ≈ zeros(2)
+
+    # SplitODEProblem path still works and keeps a cache
+    prob_split = SplitODEProblem(f1!, f2!, u0, (0.0, 1.0))
+    @test prob_split.f._func_cache !== nothing
+    du2 = zeros(2)
+    prob_split.f(du2, u0, nothing, 0.0)
+    @test du2 ≈ zeros(2)
+
+    # out-of-place SplitFunction needs no cache
+    f1 = (u, p, t) -> u
+    f2 = (u, p, t) -> -u
+    sf_oop = SplitFunction(f1, f2)
+    @test sf_oop._func_cache === nothing
+    prob_oop = ODEProblem(sf_oop, 1.0, (0.0, 1.0))
+    @test prob_oop.f(1.0, nothing, 0.0) == 0.0
+end
+
 @testset "`constructorof` tests" begin
     probs = []
 


### PR DESCRIPTION
## Summary

Two small, independent fixes for long-standing footguns:

1. **`EnsembleSummary` on complex data** ([SciML/DifferentialEquations.jl#632](https://github.com/SciML/DifferentialEquations.jl/issues/632)): quantiles/medians need `isless`, which is undefined on `Complex`. Previously this failed deep inside `Statistics.quantile` with `MethodError: no method matching isless(::ComplexF64, ::ComplexF64)`. Now detects complex eltypes up front and throws `ComplexEnsembleSummaryError` with workarounds (real/imag separately, magnitudes, or mean/var helpers). Semantics of "quantile on ℂ" are deliberately *not* invented — clean error matches SciML style (`ComplexSupportError`, etc.).

2. **`ODEProblem(SplitFunction(f1!, f2!), u0, tspan)` for iip**: `SplitODEProblem` allocates `_func_cache` from `u0`, but bare `ODEProblem(sf, u0, tspan)` did not, so `f(du,u,p,t)` called `get_tmp(nothing, du)` → `ndims(::Type{Nothing})`. Mirror the `SplitODEProblem` cache allocation on the bare `ODEProblem` path, and throw a clear `ArgumentError` if an iip `SplitFunction` is evaluated without a cache.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Tests

- `test/ensemble_tests.jl`: complex ensemble rejects with `ComplexEnsembleSummaryError`; mean/var still works
- `test/problem_building_test.jl`: bare iip `ODEProblem(SplitFunction, …)` allocates cache and evaluates; bare call without cache errors; oop path unchanged
- Local e2e with OrdinaryDiffEq: `solve(ODEProblem(SplitFunction(f1!,f2!), u0, tspan), Tsit5())` → Success; complex `EnsembleSummary` throws the new error

## Recommendation notes (not in this PR)

- Observed-variable `save_idxs` (DE #1036): feature request only; `SavedSubsystem` already rejects observed symbols by design
- ComponentArrays SII (DE #957): needs a real SII extension, not a one-liner (partial `getsyms` exists for plotting only)
- DE v8 re-exports / Rodas5: intentional scope reduction; documented in OrdinaryDiffEq NEWS
- Matrix{SVector} (DE #939): intended `NonNumberEltypeError`; closed

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>