### PR TITLE
Fix CheckInit MethodError when abstol is a vector (ODE #1214)

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -219,6 +219,20 @@ _vec(v::Number) = v
 _vec(v::SciMLOperators.AbstractSciMLScalarOperator) = v
 _vec(v::AbstractVector) = v
 
+# Check residual against abstol. Scalar abstol uses the usual scalar residual
+# norm; array abstol uses a weighted residual (componentwise / abstol) so vector
+# tolerances do not MethodError on `normresid > abstol` (OrdinaryDiffEq #1214).
+@inline function exceeds_checkinit_abstol(resid, abstol::Number, integrator, t)
+    normresid = isdefined(integrator.opts, :internalnorm) ?
+        integrator.opts.internalnorm(resid, t) : norm(resid)
+    return normresid > abstol
+end
+@inline function exceeds_checkinit_abstol(resid, abstol, integrator, t)
+    weighted = isdefined(integrator.opts, :internalnorm) ?
+        integrator.opts.internalnorm(resid ./ abstol, t) : norm(resid ./ abstol)
+    return weighted > 1
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -249,9 +263,9 @@ function get_initial_values(
     tmp = evaluate_f(integrator, prob, f, isinplace, u0, p, t)
     tmp .= ArrayInterface.restructure(tmp, algebraic_eqs .* _vec(tmp))
 
-    normresid = isdefined(integrator.opts, :internalnorm) ?
-        integrator.opts.internalnorm(tmp, t) : norm(tmp)
-    if normresid > abstol
+    if exceeds_checkinit_abstol(tmp, abstol, integrator, t)
+        normresid = isdefined(integrator.opts, :internalnorm) ?
+            integrator.opts.internalnorm(tmp, t) : norm(tmp)
         throw(CheckInitFailureError(normresid, abstol, true))
     end
     return u0, p, true
@@ -266,10 +280,10 @@ function get_initial_values(
     t = current_time(integrator)
 
     resid = evaluate_f(integrator, prob, f, isinplace, u0, p, t)
-    normresid = isdefined(integrator.opts, :internalnorm) ?
-        integrator.opts.internalnorm(resid, t) : norm(resid)
 
-    if normresid > abstol
+    if exceeds_checkinit_abstol(resid, abstol, integrator, t)
+        normresid = isdefined(integrator.opts, :internalnorm) ?
+            integrator.opts.internalnorm(resid, t) : norm(resid)
         throw(CheckInitFailureError(normresid, abstol, false))
     end
     return u0, p, true

--- a/test/downstream/initialization.jl
+++ b/test/downstream/initialization.jl
@@ -173,6 +173,27 @@ end
                 Val(SciMLBase.isinplace(f)); abstol = 1.0e-10
             )
         end
+
+        # Vector abstol must not MethodError on `normresid > abstol`
+        # (OrdinaryDiffEq.jl #1214 / DifferentialEquations path via CheckInit).
+        @testset "Vector abstol" begin
+            f = iipfn
+            prob = DAEProblem(f, [1.0, 0.0], [1.0, 1.0], (0.0, 1.0), 1.0)
+            integ = init(prob, DImplicitEuler(); abstol = [1.0e-6, 1.0e-6])
+            u0, _,
+                success = SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(true); abstol = [1.0e-6, 1.0e-6]
+            )
+            @test success
+            @test u0 == prob.u0
+
+            integ.u[2] = 2.0
+            @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(true); abstol = [1.0e-6, 1.0e-6]
+            )
+        end
     end
 
     @testset "SDEProblem" begin

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -84,6 +84,27 @@ using StochasticDiffEq, OrdinaryDiffEq, NonlinearSolve, SymbolicIndexingInterfac
                 Val(SciMLBase.isinplace(f)); abstol = 1.0e-10
             )
         end
+
+        # Vector abstol must not MethodError on `normresid > abstol`
+        # (OrdinaryDiffEq.jl #1214 / DifferentialEquations path via CheckInit).
+        @testset "Vector abstol" begin
+            f = iipfn
+            prob = DAEProblem(f, [1.0, 0.0], [1.0, 1.0], (0.0, 1.0), 1.0)
+            integ = init(prob, DImplicitEuler(); abstol = [1.0e-6, 1.0e-6])
+            u0, _,
+                success = SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(true); abstol = [1.0e-6, 1.0e-6]
+            )
+            @test success
+            @test u0 == prob.u0
+
+            integ.u[2] = 2.0
+            @test_throws SciMLBase.CheckInitFailureError SciMLBase.get_initial_values(
+                prob, integ, f, SciMLBase.CheckInit(),
+                Val(true); abstol = [1.0e-6, 1.0e-6]
+            )
+        end
     end
 
     @testset "SDEProblem" begin


### PR DESCRIPTION
## Summary

- Fixes `MethodError: no method matching isless(::Vector{Float64}, ::Float64)` in `CheckInit` when `abstol` is a vector.
- Root cause: `normresid > abstol` is invalid when `abstol` is an array (default DAE path uses `CheckInit` via `DefaultInit`).
- Fix: weighted residual check for array `abstol` (`internalnorm(resid ./ abstol, t) > 1`), matching `check_dae_tolerance` in OrdinaryDiffEqNonlinearSolve.
- Adds regression test for vector `abstol` on `DAEProblem`.

Fixes SciML/OrdinaryDiffEq.jl#1214 (default initialization path).

This PR should be ignored until reviewed by @ChrisRackauckas.

## Test plan

- [x] Local: vector abstol + consistent `DAEProblem` with DABDF2/DFBDF/DImplicitEuler succeeds
- [x] Local: vector abstol still throws `CheckInitFailureError` when residual is large
- [ ] CI: `test/initialization.jl`