### PR TITLE
Allow step_limiter and stage_limiter solve kwargs

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -96,6 +96,9 @@ const allowedkeywords = (
     :tune_parameters,
     # Optimizer kwargs passed via BVP solvers
     :optimize_kwargs,
+    # Solve-level stage/step limiters (OrdinaryDiffEq solver kwargs)
+    :step_limiter,
+    :stage_limiter,
 )
 
 

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -1025,3 +1025,15 @@ BatchIntegralFunction(biip, Float64[], max_batch = 20)
 @test_throws SciMLBase.TooFewArgumentsError BatchIntegralFunction(bi1)
 @test_throws SciMLBase.TooManyArgumentsError BatchIntegralFunction(bitoo)
 @test_throws SciMLBase.TooManyArgumentsError BatchIntegralFunction(bitoo, Float64[])
+
+@testset "solve-level limiter kwargs are allowed" begin
+    # OrdinaryDiffEq solve-level step/stage limiters must pass keyword validation.
+    SciMLBase.checkkwargs(SciMLBase.KeywordArgError; step_limiter = identity)
+    SciMLBase.checkkwargs(SciMLBase.KeywordArgError; stage_limiter = identity)
+    SciMLBase.checkkwargs(
+        SciMLBase.KeywordArgError; step_limiter = identity, stage_limiter = identity
+    )
+    @test_throws SciMLBase.CommonKwargError SciMLBase.checkkwargs(
+        SciMLBase.KeywordArgError; not_a_real_kwarg = 1
+    )
+end


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Master / PR IntegrationTest `OrdinaryDiffEq.jl/Integrators` fails because
`solve(...; step_limiter=...)` is rejected by SciMLBase keyword validation:

```
Unrecognized keyword arguments: [:step_limiter]
```

OrdinaryDiffEq exposes solve-level stage/step limiters; those names were never
added to `allowedkeywords`.

## Changes

- Add `:step_limiter` and `:stage_limiter` to `allowedkeywords` in `src/errors.jl`.
- Unit test that validation accepts them and still rejects unknown kwargs.

## Related

Seen on SciMLBase draft PRs #1462/#1463/#1464 Integrators downstream jobs;
not caused by those PRs (fails the same way against current master).