### PR TITLE
Clarify observed save_idxs rejection (DE #1036)

### DIFF
--- a/docs/src/interfaces/Common_Keywords.md
+++ b/docs/src/interfaces/Common_Keywords.md
@@ -60,9 +60,11 @@ smaller subset.
     Providing `saveat` alone changes the usual defaults of `save_everystep` and
     `dense` to `false`. The default is an empty collection.
   - `save_idxs`: Save only selected state components. It may be an integer,
-    collection of indices, or supported symbolic state/parameter selection.
-    Symbolically subsetted solutions must preserve the
-    [saved-subsystem interface](@ref symbolic_save_idxs).
+    collection of indices, or supported symbolic state/time-series-parameter
+    selection. Observed variables are not supported (see
+    [symbolic save_idxs](@ref symbolic_save_idxs) and
+    SciML/DifferentialEquations.jl#1036). Symbolically subsetted solutions must
+    preserve the [saved-subsystem interface](@ref symbolic_save_idxs).
   - `tstops`: Require the integrator to stop at additional values. This is used
     for discontinuities, singularities, and externally scheduled events. A
     scalar or collection is known at initialization; a callable such as

--- a/docs/src/interfaces/Symbolic_SaveIdxs.md
+++ b/docs/src/interfaces/Symbolic_SaveIdxs.md
@@ -23,6 +23,12 @@ breaking symbolic queries.
   time-series parameters only when that parameter's time series was saved.
 - Saving only time-series parameters is valid; the state `save_idxs` passed to a
   low-level solver is then `Int[]`.
+- **Observed variables are not supported in `save_idxs`.** Selecting an observed
+  quantity raises an `ArgumentError` that names the limitation and lists
+  workarounds (full-state solve + `sol[obs]`, `DiffEqCallbacks.SavingCallback`,
+  or saving the dependent states). Supporting observed `save_idxs` requires
+  evaluating observed functions at save points and extending `SavedSubsystem`
+  with an observed-column map; see SciML/DifferentialEquations.jl#1036.
 
 ## Solver-Author Flow
 

--- a/src/solutions/save_idxs.jl
+++ b/src/solutions/save_idxs.jl
@@ -99,7 +99,10 @@ parameter object `pobj`. `saved_idxs` may contain integer state indexes,
 symbolic state variables, symbolic arrays of state variables, or symbolic
 time-series parameters. Every symbolic entry must resolve to either a state
 variable or a time-series parameter of `indp`; other symbolic entries are
-rejected.
+rejected. Observed variables (quantities computed from the full state via
+`observed`, not stored in `u`) are **not** supported in `save_idxs` yet and
+raise a dedicated `ArgumentError` pointing at workarounds and
+DifferentialEquations.jl#1036.
 
 The object is stored on solution types when `save_idxs` omits part of the
 symbolic state or time-series parameter set. It lets `sol[x]`, `state_values`,
@@ -224,7 +227,7 @@ function SavedSubsystem(indp, pobj, saved_idxs::Union{AbstractArray, Tuple})
             cnt = get(ts_idx_to_count, idx.timeseries_idx, 0)
             ts_idx_to_count[idx.timeseries_idx] = cnt + 1
         else
-            throw(ArgumentError("Can only save variables and timeseries parameters. Got $var."))
+            throw(_invalid_save_idxs_symbol_error(indp, var))
         end
     end
 
@@ -528,9 +531,39 @@ function _append_state_indices!(translated, indp, sym)
         end
     else
         idx = variable_index(indp, sym)
-        idx === nothing &&
-            throw(ArgumentError("Can only save variables. Got $sym."))
+        if idx === nothing
+            throw(_invalid_save_idxs_symbol_error(indp, sym; allow_timeseries_params = false))
+        end
         push!(translated, idx)
     end
     return translated
+end
+
+"""
+    _invalid_save_idxs_symbol_error(indp, var; allow_timeseries_params=true)
+
+Build the `ArgumentError` for a symbolic entry that cannot be used in
+`save_idxs`. Observed quantities get a dedicated message (DifferentialEquations.jl#1036);
+other non-state / non-timeseries-parameter symbols keep a generic rejection.
+"""
+function _invalid_save_idxs_symbol_error(indp, var; allow_timeseries_params::Bool = true)
+    if is_observed(indp, var)
+        return ArgumentError(
+            string(
+                "Saving observed variables via `save_idxs` is not yet supported (got $var). ",
+                "Observed quantities are computed from the full state and are not stored in `u`, ",
+                "so the solver cannot select them with integer state indices. ",
+                "Workarounds: (1) omit `save_idxs` and index the full solution with `sol[$var]`; ",
+                "(2) use `DiffEqCallbacks.SavingCallback` to record observed values at save times; ",
+                "(3) pass the state variables the observed quantity depends on in `save_idxs`. ",
+                "See SciML/DifferentialEquations.jl#1036."
+            )
+        )
+    elseif allow_timeseries_params
+        return ArgumentError(
+            "Can only save variables and timeseries parameters. Got $var."
+        )
+    else
+        return ArgumentError("Can only save variables. Got $var.")
+    end
 end

--- a/test/downstream/solution_interface.jl
+++ b/test/downstream/solution_interface.jl
@@ -466,6 +466,58 @@ end
             prob, [x + y]
         )
     end
+
+    # https://github.com/SciML/DifferentialEquations.jl/issues/1036
+    @testset "observed save_idxs is rejected with a dedicated error" begin
+        @variables x(t) = 1.0 y(t) = 1.0 obs(t)
+        @parameters p = 0.5
+        @mtkcompile sys = System(
+            [D(x) ~ x + p * y, D(y) ~ 2p + x, obs ~ x + y], t
+        )
+        @test is_observed(sys, obs)
+        @test !is_variable(sys, obs)
+        prob = ODEProblem(sys, [], (0.0, 1.0))
+        @test is_observed(prob, obs)
+
+        err = try
+            SciMLBase.get_save_idxs_and_saved_subsystem(prob, [obs])
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        @test occursin("observed", msg)
+        @test occursin("1036", msg)
+        @test occursin("SavingCallback", msg)
+
+        err_solve = try
+            solve(prob, Tsit5(); save_idxs = [obs], saveat = 0.1)
+            nothing
+        catch e
+            e
+        end
+        @test err_solve isa ArgumentError
+        @test occursin("observed", sprint(showerror, err_solve))
+
+        # Mixed observed + state is also rejected (no silent partial save).
+        err_mixed = try
+            SciMLBase.get_save_idxs_and_saved_subsystem(prob, [x, obs])
+            nothing
+        catch e
+            e
+        end
+        @test err_mixed isa ArgumentError
+        @test occursin("observed", sprint(showerror, err_mixed))
+
+        # Full-state solve still exposes observed via solution indexing.
+        full = solve(prob, Tsit5(); saveat = 0.1)
+        @test full[obs] ≈ full[x] .+ full[y]
+
+        # Symbolic state save_idxs still works.
+        sol = solve(prob, Tsit5(); save_idxs = [x], saveat = 0.1)
+        @test sol[x] ≈ full[x]
+    end
 end
 
 @testset "Interpolation after final discrete save" begin

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -1,6 +1,7 @@
 using Test, SciMLBase
 using LinearAlgebra
 using StaticArrays
+using SymbolicIndexingInterface
 
 @testset "getindex" begin
     u = rand(1)
@@ -199,4 +200,49 @@ end
     # And when the concrete nlsol type is known at the call site, inference
     # must produce a fully concrete ODESolution type.
     @inferred bvde_like(odesol, nlsol)
+end
+
+@testset "save_idxs rejects observed quantities" begin
+    # SymbolCache treats Expr as observed (SII). Full MTK observed coverage is
+    # in test/downstream/solution_interface.jl.
+    sc = SymbolCache([:x, :y], [:p], :t)
+    p = [0.5]
+    obs = :(x + y)
+    @test is_observed(sc, obs)
+    @test !is_variable(sc, obs)
+
+    err = try
+        SciMLBase.SavedSubsystem(sc, p, [obs])
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    msg = sprint(showerror, err)
+    @test occursin("observed", msg)
+    @test occursin("1036", msg)
+    @test occursin("SavingCallback", msg)
+
+    # Direct helper used by both SavedSubsystem and translate_symbolic_save_idxs.
+    err_helper = SciMLBase._invalid_save_idxs_symbol_error(sc, obs)
+    @test err_helper isa ArgumentError
+    @test occursin("observed", sprint(showerror, err_helper))
+
+    # Non-observed garbage still uses the generic rejection path.
+    err3 = try
+        SciMLBase.SavedSubsystem(sc, p, [:not_a_state])
+        nothing
+    catch e
+        e
+    end
+    @test err3 isa ArgumentError
+    @test occursin(
+        "Can only save variables and timeseries parameters", sprint(showerror, err3)
+    )
+    @test !occursin("observed variables via `save_idxs`", sprint(showerror, err3))
+
+    # State selection still works.
+    ss = SciMLBase.SavedSubsystem(sc, p, [:x])
+    @test ss isa SciMLBase.SavedSubsystem
+    @test SciMLBase.get_saved_state_idxs(ss) == [1]
 end


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Related: SciML/DifferentialEquations.jl#1036 (observed variables in `save_idxs`).

## What this is (and is not)

This is the **smallest correct slice** for DE #1036: a dedicated error + docs when observed symbols appear in `save_idxs`. It does **not** implement observed save columns.

Full support is intentionally out of scope for this PR. Solver save paths (e.g. OrdinaryDiffEqCore) hard-code `u[save_idxs]` integer indexing. Eval-at-save observed storage needs a multi-package design (`SavedSubsystem` observed map + save-path evaluation + interpolation policy). Silently expanding observed to full-state save would look like support but would not meet the memory goal and would be a wrong answer.

## Change

When `is_observed(indp, var)` holds for a rejected `save_idxs` entry, throw:

```
ArgumentError: Saving observed variables via `save_idxs` is not yet supported (got …).
… workarounds: full sol[obs]; DiffEqCallbacks.SavingCallback; save dependent states.
See SciML/DifferentialEquations.jl#1036.
```

Generic non-state / non-timeseries-parameter rejection is unchanged.

Docs updated:
- `docs/src/interfaces/Symbolic_SaveIdxs.md` — explicit observed limitation
- `docs/src/interfaces/Common_Keywords.md` — `save_idxs` keyword note

## Tests (run locally)

Unit (`SymbolCache` Expr as observed):

```
save_idxs rejects observed quantities | 13 passed
POST_RUNIC_OK
```

Downstream MTK + regression:

```
Saved subsystem subset incl observed rejection | 19 passed
REGRESSION_OK
```

Including: observed-only and mixed `[x, obs]` rejection, full-solve `sol[obs]` still works, symbolic state `save_idxs` still works, all-states symbolic translation regression from #1460 still works.

## Follow-up design (not in this PR)

1. Extend `SavedSubsystem` with `observed_map` (saved column → observed symbolic + callable).
2. Change integrator save path to evaluate observed at save points when requested.
3. v1 policy: require `saveat` / non-dense for observed-only; refuse dense interp unless parent states also saved.
4. Clear errors if indexing an unsaved, non-reconstructible symbol.