### PR TITLE
Portable absolute URLs for docstring @refs that break DiffEqDocs (#879)

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -139,7 +139,7 @@ are:
   - `tspan`: the independent-variable interval for time-dependent problems.
   - `p`: parameters, defaulting to `NullParameters` when omitted.
   - `kwargs`: keyword arguments stored on the problem and forwarded to solves.
-  - construction-layout metadata available through [`problem_type`](@ref) when
+  - construction-layout metadata available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when
     several constructors share one concrete representation.
 
 Subtypes that expose state and parameters through symbolic indexing should
@@ -356,7 +356,7 @@ function mutation convention.
 ## Interface
 
 ODE problems should provide `f`, `u0`, `tspan`, `p`, and `kwargs`. A problem that
-preserves an alternate construction layout should extend [`problem_type`](@ref).
+preserves an alternate construction layout should extend [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/).
 The function should support either `f(u, p, t)` or
 `f(du, u, p, t)` according to [`isinplace`](@ref). Stored keyword arguments such
 as callbacks or tolerances are forwarded to solvers.
@@ -468,7 +468,7 @@ $(TYPEDEF)
 
 Base interface for second-order ODE problems. These problems are represented in
 the ODE hierarchy for solver interoperability, but their constructors preserve
-second-order structure through concrete fields or [`problem_type`](@ref) metadata.
+second-order structure through concrete fields or [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) metadata.
 """
 abstract type AbstractSecondOrderODEProblem{uType, tType, isinplace} <:
 AbstractODEProblem{uType, tType, isinplace} end
@@ -918,7 +918,7 @@ struct CheckInit <: DAEInitializationAlgorithm end
 An initialization algorithm that uses initialization metadata stored on a
 SciMLFunction to compute replacement state and parameter values.
 
-When `f` has non-`nothing` [`OverrideInitData`](@ref), `get_initial_values`
+When `f` has non-`nothing` [`OverrideInitData`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/), `get_initial_values`
 updates the stored initialization problem from the current value provider,
 solves it when it is nontrivial, and maps the initialization result back to the
 original problem's `u0` and `p`. If `f` has no initialization data,

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -109,7 +109,7 @@ Methods must return the initialized state object, the initialized parameter
 object, and a boolean indicating whether initialization succeeded. Keyword
 arguments are algorithm-specific: `CheckInit` requires an `abstol` for residual
 checks, while `OverrideInit` can require a NonlinearSolve algorithm and
-tolerances unless the stored [`OverrideInitData`](@ref) represents a trivial
+tolerances unless the stored [`OverrideInitData`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/) represents a trivial
 initialization problem.
 """
 function get_initial_values end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -648,7 +648,7 @@ the state should be interpolated to the new time.
     recompute `u` from the method's interpolation.
   - If changing time invalidates interpolation, error estimates, or dense output
     caches, the implementation must refresh them or require callers to follow
-    with [`reeval_internals_due_to_modification!`](@ref).
+    with [`reeval_internals_due_to_modification!`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/).
 """
 function set_t!(integrator::DEIntegrator, t)
     error("set_t!: method has not been implemented for the integrator")
@@ -677,7 +677,7 @@ parameter setters instead of `set_u!`.
     derivatives, interpolation data, and step controllers may no longer describe
     the current state.
   - Solvers that need additional work after a state change should implement
-    [`reeval_internals_due_to_modification!`](@ref) and document when callbacks
+    [`reeval_internals_due_to_modification!`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/) and document when callbacks
     or generic code must call it.
 """
 function set_u! end
@@ -940,7 +940,7 @@ last_step_failed(integrator::DEIntegrator) = false
 """
     check_error(integrator)
 
-Inspect `integrator` and return the [`ReturnCode`](@ref) that describes whether
+Inspect `integrator` and return the [`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes) that describes whether
 integration may continue.
 
 The common implementation preserves an existing terminal return code and checks

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -5,7 +5,7 @@ Marker for multi-point first-order BVP layouts.
 
 `StandardBVProblem()` identifies boundary value problems whose boundary
 condition is supplied as one residual function over the current solution values
-and mesh. It is returned by [`problem_type`](@ref) for a `BVProblem` that does
+and mesh. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) for a `BVProblem` that does
 not use separate endpoint boundary-condition functions.
 """
 struct StandardBVProblem end
@@ -123,7 +123,7 @@ every solve call.
 * `ub`: The upper bounds for the solution variables. Defaults to `nothing`.
 * `lcons`: The lower bounds for the constraint residuals. Defaults to `nothing`.
 * `ucons`: The upper bounds for the constraint residuals. Defaults to `nothing`.
-* Construction layout: Query [`problem_type`](@ref) to obtain either
+* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) to obtain either
   `StandardBVProblem` or `TwoPointBVProblem`.
 * `singular_term`: The singular term of the problem. Defaults to `nothing`.
 * `kwargs`: The keyword arguments passed onto the solves.
@@ -314,7 +314,7 @@ Marker for multi-point second-order BVP layouts.
 
 `StandardSecondOrderBVProblem()` identifies second-order BVPs whose boundary
 condition is supplied as one residual function over derivative values, state
-values, parameters, and mesh points. It is returned by [`problem_type`](@ref)
+values, parameters, and mesh points. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/)
 for a `SecondOrderBVProblem` when endpoint residual functions are not used.
 """
 struct StandardSecondOrderBVProblem end
@@ -434,7 +434,7 @@ every solve call.
 * `ub`: The upper bounds for the solution variables. Defaults to `nothing`.
 * `lcons`: The lower bounds for the constraint residuals. Defaults to `nothing`.
 * `ucons`: The upper bounds for the constraint residuals. Defaults to `nothing`.
-* Construction layout: Query [`problem_type`](@ref) to obtain either
+* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) to obtain either
   `StandardSecondOrderBVProblem` or `TwoPointSecondOrderBVProblem`.
 * `kwargs`: The keyword arguments passed onto the solves.
 """

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -307,7 +307,7 @@ Marker supertype for structured DDE problem layouts.
 
 Subtypes identify DDE problems constructed from partitioned first-order dynamics
 or from second-order dynamics. These markers are available through
-[`problem_type`](@ref) on the common `DDEProblem` representation so solvers can
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) on the common `DDEProblem` representation so solvers can
 preserve or recover the structured interpretation when needed.
 """
 abstract type AbstractDynamicalDDEProblem end
@@ -317,7 +317,7 @@ $(TYPEDEF)
 
 Marker for partitioned dynamical DDE problem layouts.
 
-`DynamicalDDEProblem{iip}` is returned by [`problem_type`](@ref) when a DDE is
+`DynamicalDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when a DDE is
 constructed from two coupled first-order components. The `iip` parameter records
 the in-place convention of the underlying `DynamicalDDEFunction`.
 """
@@ -381,7 +381,7 @@ $(TYPEDEF)
 
 Marker for second-order DDE problem layouts.
 
-`SecondOrderDDEProblem{iip}` is returned by [`problem_type`](@ref) when a
+`SecondOrderDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when a
 second-order delay equation is converted to the partitioned DDE form used by
 `DDEProblem`. The `iip` parameter records the in-place convention of the
 second-derivative function.

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -6,7 +6,7 @@ Marker for standard nonlinear problem layouts.
 `StandardNonlinearProblem()` is the default `problem_type` metadata for
 nonlinear problems represented directly by a residual function and either an
 initial guess or an interval. Solver code may inspect this marker through
-[`problem_type`](@ref) when it needs to distinguish the standard residual layout
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when it needs to distinguish the standard residual layout
 from specialized nonlinear problem encodings, while generic nonlinear code should rely on the
 `AbstractNonlinearProblem` fields and traits instead.
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -258,7 +258,7 @@ Marker supertype for structured ODE problem layouts.
 
 Subtypes identify ODE problems that are constructed from partitioned or
 second-order dynamics and then stored in the common `ODEProblem` representation.
-The concrete marker is available through [`problem_type`](@ref) so solvers can
+The concrete marker is available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) so solvers can
 preserve structure when they support specialized methods.
 """
 abstract type AbstractDynamicalODEProblem end
@@ -469,7 +469,7 @@ Marker supertype for split ODE problem layouts.
 
 Subtypes identify ODEs whose right-hand side is supplied as a split function,
 usually to expose additive, linear, stiff, or nonstiff structure to solvers.
-Split constructors expose this marker through [`problem_type`](@ref) while using
+Split constructors expose this marker through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) while using
 the ordinary `ODEProblem` storage layout.
 """
 abstract type AbstractSplitODEProblem end
@@ -576,7 +576,7 @@ Internal supertype for incrementing ODE constructor tags. Concrete tags record
 the in-place convention while [`IncrementingODEProblem`](@ref) converts the
 input into an `ODEProblem` with an [`IncrementingODEFunction`](@ref).
 
-These tags are available from [`problem_type`](@ref) on the resulting problem;
+These tags are available from [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) on the resulting problem;
 they are not standalone problem containers. Solvers that require incrementing
 evaluation may dispatch on the tag or the wrapped function, but ordinary ODE
 tooling should use the returned `ODEProblem` interface.
@@ -591,7 +591,7 @@ Construct an experimental ODE problem for a model function that can update an
 existing derivative buffer in an incrementing form.
 
 The constructor wraps `f` in an [`IncrementingODEFunction`](@ref), exposes an
-`IncrementingODEProblem{iip}` tag through [`problem_type`](@ref), and returns a
+`IncrementingODEProblem{iip}` tag through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/), and returns a
 standard `ODEProblem`. The result therefore follows the ordinary ODE problem
 field, symbolic-indexing, keyword-forwarding, and solve interfaces.
 

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -125,7 +125,7 @@ Construct the solution object returned by a SciML solver for `prob` solved with
 Solver packages extend `build_solution` for the problem and algorithm families
 they own so that direct solver implementations can share the same solution
 construction path. Methods should attach the original problem, algorithm,
-[`ReturnCode`](@ref), residual or error information, solver statistics, dense
+[`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes), residual or error information, solver statistics, dense
 interpolation data, and saved values expected by the corresponding
 [`AbstractSciMLSolution`](@ref) interface.
 
@@ -164,7 +164,7 @@ Construct the solution object returned by a SciML solver for `prob` solved with
 Solver packages extend `build_solution` for the problem and algorithm families
 they own so that direct solver implementations can share the same solution
 construction path. Methods should attach the original problem, algorithm,
-[`ReturnCode`](@ref), residual or error information, solver statistics, dense
+[`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes), residual or error information, solver statistics, dense
 interpolation data, and saved values expected by the corresponding
 [`AbstractSciMLSolution`](@ref) interface.
 
@@ -182,7 +182,7 @@ Return `sol` or wrap it in a higher-level SciML solution container.
 
 Solvers call `wrap_sol(sol)` after constructing a low-level solution. When
 `sol.prob` is an [`AbstractSciMLProblem`](@ref), the default implementation
-queries [`problem_type`](@ref) and dispatches to
+queries [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) and dispatches to
 `wrap_sol(sol, problem_type_or_metadata)` when the result is not `nothing`.
 Problem-family packages extend the two-argument form when a generated solver
 solution should be returned as a more specific public solution type.


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

Fixes the **source** of [DiffEqDocs.jl#879](https://github.com/SciML/DiffEqDocs.jl/issues/879): bare Documenter `@ref`s inside SciMLBase docstrings only resolve against the docs site that includes them. DiffEqDocs pulls those docstrings via `@docs` and then fails with `[:cross_references]`.

Replace bare refs for:

- `problem_type`
- `OverrideInitData`
- `ReturnCode`
- `reeval_internals_due_to_modification!`

with absolute `https://docs.sciml.ai/SciMLBase/stable/...` URLs, matching the portable-link style already used for Return Codes and specialization levels in this package.

## Why not fix in DiffEqDocs

A DiffEqDocs-side workaround (extra local `@docs` entries / rewrite scripts) papers over the problem. Every downstream docs site that splices these docstrings would need the same hack. Source absolute URLs work in SciMLBase docs and every re-export site.

Supersedes the approach in [DiffEqDocs#881](https://github.com/SciML/DiffEqDocs.jl/pull/881).

## Test plan

- [ ] SciMLBase docs build still green
- [ ] DiffEqDocs docs build green against this SciMLBase (with companion OrdinaryDiffEq PR for `Developer-Extension-API`)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>