### PR TITLE
Make the AutoDePSpecialize docstring renderable downstream (v3.39.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.39.0"
+version = "3.39.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -172,7 +172,9 @@ struct FullSpecialize <: AbstractSpecialization end
 """
 $(TYPEDEF)
 
-`AutoDePSpecialize` extends [`AutoSpecialize`](@ref) by additionally
+`AutoDePSpecialize` extends
+[`AutoSpecialize`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+by additionally
 *de-specializing the parameter object*. Solver paths with a supported
 opaque-parameter strategy pack an `isbits`, non-`NullParameters` `p` into a
 fixed-type opaque container (e.g. `RespecializeParams.OpaqueParams`) and


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

The `AutoDePSpecialize` docstring opens with:

```julia
`AutoDePSpecialize` extends [`AutoSpecialize`](@ref) by additionally
```

`@ref` resolves against the *current* Documenter build, so it only works where
`AutoSpecialize` is itself rendered. `AutoDePSpecialize` is re-exported by
facade packages (OrdinaryDiffEq, DiffEqBase, OrdinaryDiffEqCore) whose manuals
render that one docstring without rendering `AutoSpecialize`. There the link
cannot resolve, and `:cross_references` is not in their `warnonly`, so the
build terminates:

```
┌ Error: Cannot resolve @ref for md"[`AutoSpecialize`](@ref)" in docs/src/api/diffeqbase.md.
...
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

This currently blocks OrdinaryDiffEq from rendering `AutoDePSpecialize` at all
(SciML/OrdinaryDiffEq.jl#4015), which its QA lane requires for every public name.

The chain is worse than one hop: `AutoSpecialize`'s own docstring `@ref`s
`FullSpecialize` and `unwrapped_f`, so "just render `AutoSpecialize` too"
pulls a solver-author hook into user-facing manuals.

## Fix

Link to the rendered section instead of using `@ref`:

```julia
`AutoDePSpecialize` extends
[`AutoSpecialize`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
by additionally
```

This is the convention already used elsewhere in these docstrings for exactly
this reason — e.g. `OverrideInitData` in `src/initialization.jl`,
`reeval_internals_due_to_modification!` in `src/integrator_interface.jl`.

The anchor is SciMLBase's own: `### [Specialization Levels](@id specialization_levels)`
in `docs/src/interfaces/Problems.md`, where `SciMLBase.AutoSpecialize` is
rendered in a `@docs` block. So the link works from SciMLBase's manual too, not
only downstream.

Patch bump to 3.39.1 — docstring text only, no behavior change.

## Verification

Built the full OrdinaryDiffEq.jl manual against this branch (`Pkg.develop`ed),
with a ` ```@docs ` block added for `OrdinaryDiffEq.AutoDePSpecialize`:

```
$ julia --project=docs docs/make.jl
...
DOCS EXIT=0
```

Against released SciMLBase 3.39.0 the same build fails with the
`:cross_references` error above. The docstring renders on the page with a
working link:

```html
<a href="https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels">
  <code>AutoSpecialize</code></a> by additionally <em>de-speci…
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC