### PR TITLE
Document solver termination hooks

### DIFF
--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -138,6 +138,18 @@ SciMLBase.get_rng
 SciMLBase.set_rng!
 ```
 
+### Solver author termination hooks
+
+!!! warning "Developer API, not user API"
+    `done` and `postamble!` are versioned extension hooks for differential
+    equation solver packages. Application code should use the iterator and
+    solve interfaces above instead of calling either hook.
+
+```@docs
+SciMLBase.done
+SciMLBase.postamble!
+```
+
 ## Initialization Interface
 
 ```@docs

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2171,7 +2171,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public OverrideInitData
 
 # Solution / integrator interface
-@public DEStats, check_error!, promote_tspan, set_ut!, get_sol
+@public DEStats, check_error!, promote_tspan, set_ut!, get_sol, done, postamble!
 
 # Problem types and alias specifiers
 @public ImmutableODEProblem, NonlinearAliasSpecifier

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1021,6 +1021,26 @@ function check_error(integrator::DEIntegrator)
     return ReturnCode.Success
 end
 
+"""
+    postamble!(integrator)
+
+Finalize a differential-equation integrator after its solve loop terminates.
+Solver packages specialize this hook to perform final bookkeeping that must run
+on normal completion and on an error return. The default generic function has no
+method; an integrator implementation that requires finalization must provide one.
+
+!!! warning "Developer API, not user API"
+    Application code must not call this hook. Use `solve!`, `step!`, or
+    `terminate!` to control an integrator lifecycle.
+
+# Example
+```julia
+function SciMLBase.postamble!(integrator::MyIntegrator)
+    flush_pending_save!(integrator)
+    return nothing
+end
+```
+"""
 function postamble! end
 
 """
@@ -1044,6 +1064,28 @@ function check_error!(integrator::DEIntegrator)
 end
 
 ### Default Iterator Interface
+"""
+    done(integrator) -> Bool
+
+Return whether a differential-equation integrator has finished iteration.
+Solver packages may specialize this hook for their `DEIntegrator` subtype when
+their termination protocol differs from the common return-code and time-stop
+logic. A specialization must ensure [`postamble!`](@ref) has finalized the
+integrator before it reports a completed solve.
+
+!!! warning "Developer API, not user API"
+    Application code should iterate an integrator or call `solve!`; it should
+    not drive a solver by calling `done` directly.
+
+# Example
+```julia
+function SciMLBase.done(integrator::MyIntegrator)
+    integrator.finished || return false
+    SciMLBase.postamble!(integrator)
+    return true
+end
+```
+"""
 function done(integrator::DEIntegrator)
     if !(integrator.sol.retcode in (ReturnCode.Default, ReturnCode.Success))
         return true

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -255,7 +255,10 @@ end
 
 if isdefined(Base, :ispublic)
     @testset "Extension hooks public API" begin
-        for name in (:parameterless_type, :updated_u0_p, :isdenseplot, :plottable_indices)
+        for name in (
+                :parameterless_type, :updated_u0_p, :isdenseplot, :plottable_indices,
+                :done, :postamble!,
+            )
             @test Base.ispublic(SciMLBase, name)
         end
     end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Makes `done` and `postamble!` documented developer-public hooks, adds rendered interface docs, and locks their public status with tests.

Validation:
- Julia 1.12 `Pkg.test()` passed.
- Direct public/doc assertions passed for both names.
- Runic and `git diff --check` passed.
- Docs build resolved the new entries, then hit the existing remote linkcheck 403 for `https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/`; no linkcheck policy was changed.