### PR TITLE
Remove the migrated controller kwargs from allowedkeywords

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.39.1"
+version = "3.40.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -20,14 +20,6 @@ const allowedkeywords = (
     :force_dtmin,
     :internalnorm,
     :controller,
-    :gamma,
-    :beta1,
-    :beta2,
-    :qmax,
-    :qmin,
-    :qsteady_min,
-    :qsteady_max,
-    :qoldinit,
     :failfactor,
     :calck,
     :alias_u0,
@@ -121,6 +113,41 @@ $allowedkeywords
 See <https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts> for more details.
 """
 
+"""
+    controller_kwargs
+
+Step size controller keyword arguments that were moved onto the controller objects
+(`PIController`, `PIDController`, `IController`, `PredictiveController`). They are no
+longer accepted by `solve`/`init`; passing one produces a `CommonKwargError` carrying
+[`CONTROLLER_KWARG_MESSAGE`](@ref) rather than the generic unrecognized-keyword text.
+"""
+const controller_kwargs = (
+    :gamma,
+    :beta1,
+    :beta2,
+    :qmax,
+    :qmin,
+    :qsteady_min,
+    :qsteady_max,
+    :qoldinit,
+)
+
+const CONTROLLER_KWARG_MESSAGE = """
+
+These are step size controller options, which are no longer set as keyword arguments to
+`solve`. They are now fields of the controller object, passed via the `controller` keyword:
+
+    # old
+    solve(prob, alg; gamma = 0.9, beta1 = 0.7, beta2 = -0.4)
+
+    # new
+    using OrdinaryDiffEqCore: PIController
+    solve(prob, alg; controller = PIController(0.7, -0.4))
+
+`PIController`, `PIDController`, `IController`, and `PredictiveController` all live in
+OrdinaryDiffEqCore. Omit `controller` entirely to use the algorithm's default.
+"""
+
 struct CommonKwargError <: Exception
     kwargs::Any
 end
@@ -130,7 +157,13 @@ function Base.showerror(io::IO, e::CommonKwargError)
     notin = collect(map(x -> x ∉ allowedkeywords, keys(e.kwargs)))
     unrecognized = collect(keys(e.kwargs))[notin]
     print(io, "Unrecognized keyword arguments: ")
-    return printstyled(io, unrecognized; bold = true, color = :red)
+    printstyled(io, unrecognized; bold = true, color = :red)
+    controller_passed = filter(in(controller_kwargs), unrecognized)
+    if !isempty(controller_passed)
+        print(io, "\n")
+        printstyled(io, CONTROLLER_KWARG_MESSAGE; color = :cyan)
+    end
+    return nothing
 end
 
 @enum KeywordArgError KeywordArgWarn KeywordArgSilent

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -93,6 +93,13 @@ function get_concrete_u0(prob::BVProblem, isadapt, t0, kwargs)
     return _u0
 end
 
+function warn_controller_kwargs(unrecognized)
+    return if any(in(controller_kwargs), unrecognized)
+        printstyled(CONTROLLER_KWARG_MESSAGE; color = :cyan)
+        print("\n")
+    end
+end
+
 function checkkwargs(kwargshandle; kwargs...)
     return if any(x -> x ∉ allowedkeywords, keys(kwargs))
         if kwargshandle == KeywordArgError
@@ -103,6 +110,7 @@ function checkkwargs(kwargshandle; kwargs...)
             print("Unrecognized keyword arguments: ")
             printstyled(unrecognized; bold = true, color = :red)
             print("\n\n")
+            warn_controller_kwargs(unrecognized)
         else
             @assert kwargshandle == KeywordArgSilent
         end
@@ -119,6 +127,7 @@ function checkkwargs(kwargshandle, allowed; kwargs...)
             print("Unrecognized keyword arguments: ")
             printstyled(unrecognized; bold = true, color = :red)
             print("\n\n")
+            warn_controller_kwargs(unrecognized)
         else
             @assert kwargshandle == KeywordArgSilent
         end

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -1037,3 +1037,46 @@ BatchIntegralFunction(biip, Float64[], max_batch = 20)
         SciMLBase.KeywordArgError; not_a_real_kwarg = 1
     )
 end
+
+@testset "controller kwargs are rejected" begin
+    # These moved onto the controller objects (PIController/PIDController/IController/
+    # PredictiveController). They were left in `allowedkeywords` after the controller
+    # refactor, so `solve` accepted them and silently dropped them -- see
+    # SciML/OrdinaryDiffEq.jl#4027. They must now be rejected.
+    for kw in SciMLBase.controller_kwargs
+        @test kw ∉ SciMLBase.allowedkeywords
+        @test_throws SciMLBase.CommonKwargError SciMLBase.checkkwargs(
+            SciMLBase.KeywordArgError; (kw => 0.9,)...
+        )
+    end
+
+    # `controller` itself is the replacement and stays allowed.
+    @test :controller ∈ SciMLBase.allowedkeywords
+    SciMLBase.checkkwargs(SciMLBase.KeywordArgError; controller = nothing)
+
+    # `failfactor` sat directly after the removed block; guard against over-deletion.
+    @test :failfactor ∈ SciMLBase.allowedkeywords
+    SciMLBase.checkkwargs(SciMLBase.KeywordArgError; failfactor = 2)
+
+    # The error must point at the migration, not just list every allowed keyword.
+    err = try
+        SciMLBase.checkkwargs(SciMLBase.KeywordArgError; gamma = 0.9)
+        nothing
+    catch e
+        e
+    end
+    @test err isa SciMLBase.CommonKwargError
+    msg = sprint(showerror, err)
+    @test occursin("controller", msg)
+    @test occursin("PIController", msg)
+    @test occursin("gamma", msg)
+
+    # A plain unknown keyword must NOT get the controller advice.
+    err2 = try
+        SciMLBase.checkkwargs(SciMLBase.KeywordArgError; not_a_real_kwarg = 1)
+        nothing
+    catch e
+        e
+    end
+    @test !occursin("PIController", sprint(showerror, err2))
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/4027.

`gamma`, `beta1`, `beta2`, `qmax`, `qmin`, `qsteady_min`, `qsteady_max`, and `qoldinit` moved onto the controller objects in the v7 controller refactor, but were never taken out of `allowedkeywords`. `solve` therefore accepted them and silently dropped them — the worst possible migration outcome, since code that tuned a controller kept running and quietly reverted to defaults.

Measured before the fix (OrdinaryDiffEq v7.1.3, SciMLBase v3.39.1), Lorenz at `abstol=reltol=1e-8`:

```
gamma=0.1  -> nsteps=5597
gamma=0.5  -> nsteps=5597
gamma=0.9  -> nsteps=5597
gamma=0.99 -> nsteps=5597
```

`:controller` and `:failfactor` are untouched.

### Verified there is no remaining consumer

This is a global list shared by every SciML solver, so I checked each consumer rather than assuming:

- **OrdinaryDiffEqCore** — `__init` no longer takes any of them; only `controller = nothing` remains. Fully migrated. The `qsteady_min`/`qmax` hits in that package are controller struct fields and `*_default(alg)` traits, not solve kwargs.
- **StochasticDiffEqCore** — `_sde_init` still lists all eight in its keyword signature with real defaults (`solve.jl:132-141`), which looked alarming, but they are **never read again in the file**; only `controller` is threaded through to the options. Confirmed empirically: sweeping `gamma`/`qmax`/`qoldinit` on an adaptive `SRIW1` solve at a fixed seed gives byte-identical step counts and endpoints. So they are dead defaults on the SDE side too. Removing them from that signature is worth a follow-up but is not needed for this fix.
- **Sundials** — has its own `warnkeywords` tuple listing these as explicitly unsupported-and-ignored. Those now become a hard error at the SciMLBase keyword check instead of a warning, which is the intended behavior.
- **BoundaryValueDiffEq / JumpProcesses / DelayDiffEq** — no references.

### Better error than a keyword-list dump

A bare `CommonKwargError` prints the whole allowed-keyword list and gives no migration hint, which is not much help to someone with `gamma = 0.9` in their code. Added a `controller_kwargs` tuple and a targeted message appended only when one of them was actually passed:

```
Unrecognized keyword arguments: [:gamma]

These are step size controller options, which are no longer set as keyword arguments to
`solve`. They are now fields of the controller object, passed via the `controller` keyword:

    # old
    solve(prob, alg; gamma = 0.9, beta1 = 0.7, beta2 = -0.4)

    # new
    using OrdinaryDiffEqCore: PIController
    solve(prob, alg; controller = PIController(0.7, -0.4))
```

This matches how v7 handles the other migrated keywords (`autodiff`, `verbose`, `alias` all error with an actionable message). Wired into both the error and warn paths of `checkkwargs`. A plain unknown keyword does not get the controller advice — there is a test for that.

### Tests

Added `"controller kwargs are rejected"` to `test/function_building_error_messages.jl`: each of the eight is absent from `allowedkeywords` and throws; `:controller` and `:failfactor` still pass (the latter guards against over-deletion, since it sat immediately after the removed block); the message contains the migration hint; an unrelated bad keyword does not.

Run locally on Julia 1.11.9:

- `GROUP=Core` — **passed** (`Function Building Error Messages`: 289/289; new testset 23/23)
- `GROUP=QA` — **passed** (24/24)
- End-to-end against a dev'd SciMLBase with real `OrdinaryDiffEq` + `StochasticDiffEq` solves: all eight rejected on both ODE and SDE paths, while plain solves, `controller = PIController(...)`, `controller = nothing`, `failfactor`, and `abstol`/`reltol`/`dtmax` all still return `Success`.

Runic-clean (all three touched files were already formatted).

### Versioning

Bumped to **v3.40.0** (minor). Per your call this is a bugfix restoring intended behavior rather than a break, so a patch bump is defensible too — but since previously-accepted input now errors, minor seemed like the more honest signal. Happy to change it to 3.39.2 if you prefer.