### PR TITLE
Handle null-state ODESolution property updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.41.0"
+version = "3.41.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -140,12 +140,17 @@ function ConstructionBase.constructorof(::Type{O}) where {T, N, O <: ODESolution
     return ODESolution{T, N}
 end
 
-function ConstructionBase.setproperties(sol::ODESolution, patch::NamedTuple)
+function ConstructionBase.setproperties(
+        sol::ODESolution{T, N}, patch::NamedTuple
+    ) where {T, N}
     u = get(patch, :u, sol.u)
-    N = u === nothing ? 2 : ndims(eltype(u)) + 1
-    T = eltype(eltype(u))
+    new_T, new_N = if haskey(patch, :u)
+        eltype(eltype(u)), u === nothing || eltype(u) === Nothing ? 2 : ndims(eltype(u)) + 1
+    else
+        T, N
+    end
     patch = merge(getproperties(sol), patch)
-    return ODESolution{T, N}(
+    return ODESolution{new_T, new_N}(
         patch.u, patch.u_analytic, patch.errors, patch.t, patch.k,
         patch.discretes, patch.prob, patch.alg, patch.interp, patch.dense, patch.tslocation, patch.stats,
         patch.alg_choice, patch.retcode, patch.resid, patch.original, patch.saved_subsystem

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -1,4 +1,5 @@
 using Test, SciMLBase
+using ConstructionBase: setproperties
 using LinearAlgebra
 using RecursiveArrayTools: DiffEqArray
 using StaticArrays
@@ -50,6 +51,45 @@ SymbolicIndexingInterface.get_parameter_timeseries_collection(
     SciMLBase.save_discretes!(sol, 1.0, [2.0], 1)
     @test discrete.t == [0.0, 1.0]
     @test discrete.u == [[1.0], [2.0]]
+end
+
+@testset "ODESolution property replacement preserves state metadata" begin
+    f = (u, p, t) -> nothing
+
+    null_prob = ODEProblem(f, nothing, (0.0, 1.0))
+    null_sol = SciMLBase.build_solution(
+        null_prob, :NoAlgorithm, [0.0, 1.0], [nothing, nothing]; interp = nothing
+    )
+    @test null_sol isa ODESolution{Any, 2}
+
+    for updated in (
+            setproperties(null_sol, (retcode = ReturnCode.Success,)),
+            SciMLBase.solution_new_retcode(null_sol, ReturnCode.Success),
+        )
+        @test typeof(updated) === typeof(null_sol)
+        @test updated.u === null_sol.u
+        @test updated.retcode == ReturnCode.Success
+    end
+    @test typeof(setproperties(null_sol, (u = copy(null_sol.u),))) === typeof(null_sol)
+    no_saved_states = setproperties(null_sol, (u = nothing,))
+    @test no_saved_states isa ODESolution{Any, 2}
+    @test no_saved_states.u === nothing
+
+    for u0 in (1.0, [1.0, 2.0])
+        prob = ODEProblem(f, u0, (0.0, 1.0))
+        sol = SciMLBase.build_solution(
+            prob, :NoAlgorithm, [0.0], [deepcopy(u0)]; interp = nothing
+        )
+        for updated in (
+                setproperties(sol, (retcode = ReturnCode.Success,)),
+                SciMLBase.solution_new_retcode(sol, ReturnCode.Success),
+            )
+            @test typeof(updated) === typeof(sol)
+            @test updated.u === sol.u
+            @test updated.retcode == ReturnCode.Success
+        end
+        @test typeof(setproperties(sol, (u = copy(sol.u),))) === typeof(sol)
+    end
 end
 
 @testset "A * sol for AbstractNoTimeSolution" begin


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Summary

- preserve an `ODESolution`'s existing element type and dimensionality parameters when `ConstructionBase.setproperties` patches fields other than `u`
- support rebuilding with both `Vector{Nothing}` and `u = nothing`
- add direct `setproperties` and public `solution_new_retcode` regressions for null, scalar, and vector states
- bump SciMLBase from 3.41.0 to 3.41.1

## Root cause

`solution_new_retcode` uses Accessors, which dispatches to SciMLBase's `ConstructionBase.setproperties(::ODESolution, ...)`. Commit `55d81af15d274d094a4c50f3e6ae82e6321d5d13` made that method unconditionally recompute `N` as `ndims(eltype(u)) + 1`, even when the patch only changes `retcode`. A null-state ODE solution stores `u::Vector{Nothing}`, so retcode replacement throws `MethodError: no method matching ndims(::Type{Nothing})`.

An adjacent-commit bisect/reproduction confirmed `0c72de24f730ab139b9cd130f46190e2aa07f1e2` succeeds and `55d81af15d274d094a4c50f3e6ae82e6321d5d13` fails; `git bisect` reports `55d81af15` as the first bad commit.

This is fixed in SciMLBase because `solution_new_retcode` and the `ODESolution` ConstructionBase implementation are owned here. No OrdinaryDiffEq-specific workaround is needed.

## Validation

- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  - `Solution interface`: 72/72
  - `Remake`: 4430/4430
  - final result: `Testing SciMLBase tests passed`
- `GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
  - `Solution interface`: 72/72
  - `Remake`: 4430/4430
  - final result: `Testing SciMLBase tests passed`
- direct Julia 1.12 reproduction verified retcode replacement, `Vector{Nothing}` replacement, and `u = nothing` replacement preserve the expected solution metadata
- `julia +1.12 --project=../.runic_env -m Runic --check .`
- `git diff --check`

The clean OrdinaryDiffEq `ImplicitDiscreteSolve` Core group was also run at `fd8861edd500f8bba76a4f2a865e304d10881fe8` with registered SciMLBase 3.39.1 and passed all existing testsets. The IDS reinitialization work exposes this latent SciMLBase bug by taking the public retcode-replacement path.
