### PR TITLE
Make has_sys public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.41.0"
+version = "3.42.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -133,6 +133,7 @@ SciMLBase.has_jvp
 SciMLBase.has_vjp
 SciMLBase.has_tgrad
 SciMLBase.has_initialization_data
+SciMLBase.has_sys
 ```
 
 ## AbstractSciMLFunction API

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2112,7 +2112,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # SciMLFunction derivative traits
 @public has_jac, has_jvp, has_vjp, has_tgrad, has_analytic, has_reinit,
-    has_initialization_data, has_stats
+    has_initialization_data, has_stats, has_sys
 
 # Function-argument validation errors
 @public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -5591,6 +5591,17 @@ has_Wfact(f::AbstractSciMLFunction) = __has_Wfact(f) && f.Wfact !== nothing
 has_Wfact_t(f::AbstractSciMLFunction) = __has_Wfact_t(f) && f.Wfact_t !== nothing
 has_paramjac(f::AbstractSciMLFunction) = __has_paramjac(f) && f.paramjac !== nothing
 has_vjp_p(f::AbstractSciMLFunction) = __has_vjp_p(f) && f.vjp_p !== nothing
+"""
+    has_sys(f::AbstractSciMLFunction)
+
+Return whether `f` carries a non-`nothing` symbolic system.
+
+The system is the symbolic description the function was generated from, such as
+a ModelingToolkit system or a `SymbolicIndexingInterface.SymbolCache`. It backs
+symbolic indexing and the initialization pipeline, so code that must keep a
+problem's `u0`/`p` in a form those paths can read should query this trait rather
+than inspecting `f.sys`, which is absent on function types that carry no system.
+"""
 has_sys(f::AbstractSciMLFunction) = __has_sys(f) && f.sys !== nothing
 """
     has_initializeprob(f::AbstractSciMLFunction) -> Bool

--- a/test/existence_functions.jl
+++ b/test/existence_functions.jl
@@ -2,8 +2,9 @@ using Test, SciMLBase
 using SciMLBase: __has_jac, __has_tgrad, __has_Wfact, __has_Wfact_t,
     __has_paramjac, __has_analytic, __has_colorvec, has_jac,
     has_tgrad,
-    has_Wfact, has_Wfact_t, has_paramjac, has_analytic, has_colorvec,
+    has_Wfact, has_Wfact_t, has_paramjac, has_analytic, has_colorvec, has_sys,
     AbstractDiffEqFunction
+using SymbolicIndexingInterface: SymbolCache
 
 struct Foo <: AbstractDiffEqFunction{false}
     jac::Any
@@ -57,3 +58,11 @@ f2 = Foo2(1, 1, nothing, nothing)
 @test !has_paramjac(f2)
 @test !has_analytic(f2)
 @test !has_colorvec(f2)
+
+@testset "has_sys" begin
+    fsys = NonlinearFunction((u, p) -> u; sys = SymbolCache([:x], [:a]))
+    @test has_sys(fsys)
+    @test !has_sys(NonlinearFunction((u, p) -> u))
+    # No `sys` field at all, so the field-existence branch has to short-circuit.
+    @test !has_sys(f)
+end


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

`has_sys` is the only member of the `AbstractSciMLFunction` field-existence trait family that is neither public nor documented. Its siblings — `has_jac`, `has_jvp`, `has_vjp`, `has_tgrad`, `has_analytic`, `has_initialization_data` — are all in the `@public` block and all render in `docs/src/interfaces/SciMLFunctions.md`.

Concretely, NonlinearSolveBase's `AutoDePSpecialize` path needs it: it declines parameter de-specialization for problems carrying symbolic metadata, since `p` must stay concrete for symbolic indexing and the initialization pipeline. Today that access trips `ExplicitImports`' non-public-qualified-access check.

This PR:

- adds a docstring to `has_sys` at its definition site
- adds it to the `@public` trait block
- renders it in the SciMLFunctions trait docs
- adds `has_sys` coverage to `test/existence_functions.jl`, including the no-`sys`-field short-circuit
- bumps to 3.42.0 (new public API is a minor bump)

## Rebase note

This PR originally also made `ImmutableNonlinearProblem` public. That half has been **dropped from this PR** because #1482 landed on master first and already does it — declares it `@public`, gives it a docstring, and adds the `@docs` entry next to `NonlinearProblem`. Nothing is lost; only the `has_sys` half remains here.

The version bump also moved: the original target 3.41.0 was taken by #1482 and is registered in General, so this is now 3.42.0.

## Validation

Run locally on the rebased branch (master @ 79ed05e):

```
$ julia --project=. test/existence_functions.jl
Test Summary: | Pass  Total  Time
has_sys       |    3      3  0.2s

$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   51     51  2m57.7s
     Testing SciMLBase tests passed
```

The QA group runs `api_docs_kwargs = (; rendered = true, ...)`, so it is what verifies the new public name actually carries a docstring and appears in the rendered docs.

Runic `--check` on the changed source files exits 0.

Follow-up: SciML/NonlinearSolve.jl will consume this to drop its internal `has_sys` access.
