### PR TITLE
Export the CommonSolve verbs again, and drop the undocumented reexports

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -8,7 +7,6 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
-CommonSolve = "0.2"
 Documenter = "1"
 ModelingToolkit = "10, 11.0"
 OrdinaryDiffEq = "6, 7.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using CommonSolve, Documenter, SciMLBase
+using Documenter, SciMLBase
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)

--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -41,10 +41,10 @@ which is designed for caching efficiency with reusing factorizations.
 
 While `init` and `solve` are the common entry point for users, solver packages will
 mostly define dispatches on `SciMLBase.__init` and `SciMLBase.__solve`. The reason is
-because this allows `CommonSolve.init` and `CommonSolve.solve` to have common
+because this allows `SciMLBase.init` and `SciMLBase.solve` to have common
 implementations across all solvers for doing things such as checking for common
 errors and throwing high level messages. Solvers can opt out of the high-level
-error handling by directly defining `CommonSolve.init` and `CommonSolve.solve`
+error handling by directly defining `SciMLBase.init` and `SciMLBase.solve`
 instead, though this is not recommended because it loses the uniform error messages.
 
 ```@docs
@@ -90,7 +90,7 @@ SciMLBase.AbstractDDEIntegrator
 SciMLBase.AbstractDAEIntegrator
 SciMLBase.AbstractSDDEIntegrator
 SciMLBase.DECache
-CommonSolve.step!
+SciMLBase.step!
 Base.resize!(::SciMLBase.DEIntegrator, ::Int)
 Base.deleteat!(::SciMLBase.DEIntegrator, ::Any)
 SciMLBase.addat!

--- a/docs/src/interfaces/Symbolic_SaveIdxs.md
+++ b/docs/src/interfaces/Symbolic_SaveIdxs.md
@@ -1,9 +1,5 @@
 # [Symbolic `save_idxs` and Saved Subsystems](@id symbolic_save_idxs)
 
-```@docs
-SciMLBase.AllObserved
-```
-
 When a symbolic problem is solved with `save_idxs`, a solution may contain only a
 subset of the original state variables or time-series parameters. The solution
 interface still needs symbolic indexing to behave as if the original system were

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -47,7 +47,7 @@ import Logging, ArrayInterface, Random
 using LoggingExtras: ActiveFilteredLogger
 import IteratorInterfaceExtensions
 import CommonSolve
-import CommonSolve: solve, init, step!
+import CommonSolve: solve, init, step!, solve!
 import FunctionWrappersWrappers
 import RuntimeGeneratedFunctions
 import EnumX
@@ -63,9 +63,8 @@ using SciMLOperators:
 import SciMLOperators:
     update_coefficients, update_coefficients!, islinear
 
-# Compatibility bindings for released solver packages. New code must access these
-# names through CommonSolve and SciMLOperators, which own their public contracts.
-const solve! = CommonSolve.solve!
+# Compatibility binding for released solver packages. New code must access this
+# name through SciMLOperators, which owns its public contract.
 const isconstant = SciMLOperators.isconstant
 
 using SciMLPublic: @public
@@ -2016,12 +2015,9 @@ function unwrap_fw end
 
 export ReturnCode
 
-# Exports
-export AllObserved
-
 export isinplace
 
-export discretize, symbolic_discretize
+export solve, solve!, init, step!, discretize, symbolic_discretize
 
 export LinearProblem, LinearSolution, IntervalNonlinearProblem,
     IntegralProblem, IntegralSolution, SampledIntegralProblem,

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -1,14 +1,3 @@
-### Abstract Interface
-"""
-    AllObserved
-
-Selector requesting every observed variable available through a solution's
-symbolic indexing interface. `AllObserved` is reexported from
-RecursiveArrayTools so SciML solution code can use the same selector without
-depending on its storage location.
-"""
-const AllObserved = RecursiveArrayTools.AllObserved
-
 # No Time Solution : Forward to `A.u`
 Base.getindex(A::AbstractNoTimeSolution) = A.u[]
 Base.getindex(A::AbstractNoTimeSolution, i::Int) = A.u[i]

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -208,7 +208,6 @@ end
     end
 
     for binding in (
-            "SciMLBase.AllObserved",
             "SciMLBase.Clocks",
             "SciMLBase.EnsembleAnalysis",
             "SciMLBase.NullParameters",

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -67,12 +67,16 @@ const _ei_nonpublic_qualified_accesses = (
     :StaticArray,                          # StaticArraysCore
 )
 
-# `AllObserved` is the RecursiveArrayTools symbolic-indexing selector, reexported so
-# solution indexing code shares one selector rather than depending on its storage
-# location.
+# The CommonSolve verbs. SciMLBase does not own them, but they are the SciML solve
+# interface as users and solver packages write it, and they are documented here, so
+# they stay exported and are allow-listed rather than dropped. They are documented at
+# CommonSolve as well, so the rendered-docs check skips them.
+const _reexports_allow = (:init, :solve, :solve!, :step!)
+
 run_qa(
     SciMLBase;
-    reexports_allow = (:AllObserved,),
+    reexports_allow = _reexports_allow,
+    api_docs_kwargs = (; rendered_ignore = _reexports_allow),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = _ei_nonpublic_qualified_accesses),
     ),


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Stacked on https://github.com/SciML/SciMLBase.jl/pull/1475 — review that one first; this branch contains its commit.

## What this keeps

#1472 removed `solve`, `solve!`, `init`, and `step!` from the export surface. Those four are the SciML solve interface as users and solver packages write it, and they are documented here, so this exports them again and allow-lists them in QA rather than dropping them.

## What stays removed

Everything else #1472 dropped stays dropped, because none of it is documented by SciMLBase. Checked rather than assumed:

- **The SciMLOperators reexport** (`MatrixOperator`, `FunctionOperator`, `ScalarOperator`, `IdentityOperator`, `NullOperator`, `AffineOperator`, `DiagonalOperator`, `TensorProductOperator`, `WOperator`, `AddVector`, `BlockDiagonalOperator`, `InvertibleOperator`, `StaticWOperator`, `TensorSumOperator`, `cache_operator`, `concretize`, `isconstant`, `iscached`, `islinear`, `issquare`, `isconvertible`, `kronsum`, `has_adjoint`, `has_concretization`, `has_exp`, `has_expmv`(`!`), `has_ldiv`(`!`), `has_mul`(`!`), `update_coefficients`(`!`), `SciMLOperators`) — zero `@docs` entries anywhere in `docs/src`. These are documented at SciMLOperators, which owns them.

- **`deleteat!`** — documented only as a method on the Base function, `Base.deleteat!(::SciMLBase.DEIntegrator, ::Any)` in `Init_Solve.md`. The export was redundant: `deleteat!` resolves through Base in any scope, so dropping it changes nothing for callers. Verified both halves — in a `using SciMLBase` module `deleteat!` still resolves to `Base.deleteat!`, and SciMLBase still contributes its `DEIntegrator` method.

- **`AllObserved`** — this one *was* documented, at `Symbolic_SaveIdxs.md`. But it is a const alias for the RecursiveArrayTools selector, so the docstring and rendered entry were documenting a name SciMLBase does not own. The const, its docstring, the `@docs` entry, and the export all go.

## Net effect on the export surface

Measured with `names(SciMLBase)` against both baselines:

- vs. current master: `init`, `solve`, `solve!`, `step!` restored; `AllObserved` removed.
- vs. pre-#1472 (3.40.0): 36 names still removed, being the 34 SciMLOperators names plus `AllObserved` and `deleteat!`.

So this is still a reduction in the export surface relative to 3.40.0, and `AllObserved` is the one name that genuinely leaves user scope. Worth a deliberate call on whether 3.41.0 is the right version number for that, since the removals now stand on "not documented here" rather than on SemVer.

## Verification

- `GROUP=QA` on Julia 1.12: 35/35.
- Runic clean.
- Full `Pkg.test()` running.

Also carries the `SciMLTesting` compat move to `"2.6"` from the parent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFVmGLPUsWbRgkLJckxUGy
