### PR TITLE
Run exit diagnostics on every failing check_error path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.40.1"
+version = "3.41.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -900,6 +900,24 @@ has_mtk_sys(integrator) = false
 
 diagnose_symbolic_instability(sys, u, uprev) = ""
 
+"""
+    log_error_estimate(integrator) -> String
+
+Return a diagnostic describing the adaptive error estimate of the last attempted
+step, or `""` when the integrator does not track one.
+
+Solver packages specialize this hook so [`check_error`](@ref) can report the
+scalar error estimate that drove the step controller and the state components
+that contributed most to it. That per-component breakdown is what distinguishes
+"the whole system is unstable" from "one equation is repeatedly forcing the step
+size down", which the scalar estimate alone cannot do.
+
+!!! warning "Developer API, not user API"
+    This is a versioned integrator implementation hook. Application code should
+    read the diagnostics from a solve's log output instead.
+"""
+log_error_estimate(integrator) = ""
+
 ### Display
 
 function Base.summary(io::IO, I::DEIntegrator)
@@ -948,6 +966,36 @@ SciMLBase.last_step_failed(integrator::MyIntegrator) = integrator.last_step_fail
 """
 last_step_failed(integrator::DEIntegrator) = false
 
+# `opts.verbose` is either a verbosity specifier with one toggle per message
+# category, or a plain `Bool` for integrators that predate the specifier.
+_diagnostic_enabled(verbose::Bool, toggle::Symbol) = verbose
+_diagnostic_enabled(verbose, toggle::Symbol) = verbosity_to_bool(getproperty(verbose, toggle))
+
+"""
+    exit_diagnostic(integrator, toggle::Symbol) -> String
+
+Build the extended diagnostic appended to every failing [`check_error`](@ref)
+exit, gated on the verbosity `toggle` for that exit.
+
+The diagnostic combines the error-estimate breakdown
+([`log_error_estimate`](@ref)), the numerical state/Jacobian analysis
+(`log_numerical_instability`), and, for symbolic models, the equations and
+variables those indices trace back to. Collecting a fresh Jacobian is expensive
+on large systems, so nothing is computed when the toggle is off.
+"""
+function exit_diagnostic(integrator, toggle::Symbol)
+    _diagnostic_enabled(integrator.opts.verbose, toggle) || return ""
+    verbose = integrator.opts.verbose
+    symbolic_on = has_mtk_sys(integrator) &&
+        _diagnostic_enabled(verbose, :symbolic_diagnostic)
+    symbolic_diagnostic = symbolic_on ?
+        diagnose_symbolic_instability(integrator.f.sys, integrator.u, integrator.uprev) : ""
+    numeric_diagnostic = log_numerical_instability(
+        integrator, jacobian_logging = symbolic_diagnostic == ""
+    )
+    return log_error_estimate(integrator) * numeric_diagnostic * symbolic_diagnostic
+end
+
 """
     check_error(integrator)
 
@@ -971,12 +1019,14 @@ function check_error(integrator::DEIntegrator)
     # SDEIntegrator.
 
     if isnan(integrator.dt)
-        @SciMLMessage("NaN dt detected. Likely a NaN value in the state, parameters, or derivative value caused this outcome.", verbose, :dt_NaN)
+        diagnostic = exit_diagnostic(integrator, :dt_NaN)
+        @SciMLMessage(lazy"NaN dt detected at t=$(integrator.t). Likely a NaN value in the state, parameters, or derivative value caused this outcome.$diagnostic", verbose, :dt_NaN)
         return ReturnCode.DtNaN
     end
     if integrator.iter > opts.maxiters
+        diagnostic = exit_diagnostic(integrator, :max_iters)
         @SciMLMessage(
-            "Interrupted. Larger maxiters is needed. If you are using an integrator for non-stiff ODEs or an automatic switching algorithm (the default), you may want to consider using a method for stiff equations. See the solver pages for more details (e.g. https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/#Stiff-Problems).",
+            lazy"Interrupted. Larger maxiters is needed. If you are using an integrator for non-stiff ODEs or an automatic switching algorithm (the default), you may want to consider using a method for stiff equations. See the solver pages for more details (e.g. https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/#Stiff-Problems). Reached t=$(integrator.t) with dt=$(integrator.dt).$diagnostic",
             verbose,
             :max_iters
         )
@@ -999,34 +1049,24 @@ function check_error(integrator::DEIntegrator)
                         true
                 )
             )
-            sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
-            symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
-            numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
-            diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
-            EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
-            @SciMLMessage(lazy"dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable.$diagnostic", verbose, :dt_min_unstable)
+            diagnostic = exit_diagnostic(integrator, :dt_min_unstable)
+            @SciMLMessage(lazy"dt($(integrator.dt)) <= dtmin($(opts.dtmin)) at t=$(integrator.t). Aborting. There is either an error in your model specification or the true solution is unstable.$diagnostic", verbose, :dt_min_unstable)
             return ReturnCode.DtLessThanMin
         elseif !step_accepted && integrator.t isa AbstractFloat && abs(integrator.dt) <= abs(eps(integrator.t))
-            sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
-            symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
-            numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
-            diagnostic = verbosity_to_bool(verbose.dt_min_unstable) ? numeric_diagnostic * symbolic_diagnostic : ""
-            EEst = isdefined(integrator, :EEst) ? lazy", step error estimate = $(integrator.EEst)" : ""
-            @SciMLMessage(lazy"At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt)$EEst. Aborting. There is either an error in your model specification or the true solution is unstable (or it cannot be represented in $(eltype(integrator.u)) precision).$diagnostic", verbose, :dt_epsilon)
+            diagnostic = exit_diagnostic(integrator, :dt_epsilon)
+            @SciMLMessage(lazy"At t=$(integrator.t), dt was forced below floating point epsilon $(integrator.dt). Aborting. There is either an error in your model specification or the true solution is unstable (or it cannot be represented in $(eltype(integrator.u)) precision).$diagnostic", verbose, :dt_epsilon)
             return ReturnCode.Unstable
         end
     end
     if step_accepted &&
             opts.unstable_check(integrator.dt, integrator.u, integrator.p, integrator.t)
-        sys = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? integrator.f.sys : nothing
-        symbolic_diagnostic = (has_mtk_sys(integrator) && verbosity_to_bool(verbose.symbolic_diagnostic)) ? diagnose_symbolic_instability(sys, integrator.u, integrator.uprev) : ""
-        numeric_diagnostic = log_numerical_instability(integrator, jacobian_logging = symbolic_diagnostic == "")
-        diagnostic = verbosity_to_bool(verbose.instability) ? numeric_diagnostic * symbolic_diagnostic : ""
-        @SciMLMessage("Instability detected. Aborting.$diagnostic", verbose, :instability)
+        diagnostic = exit_diagnostic(integrator, :instability)
+        @SciMLMessage(lazy"Instability detected at t=$(integrator.t). Aborting.$diagnostic", verbose, :instability)
         return ReturnCode.Unstable
     end
     if last_step_failed(integrator)
-        @SciMLMessage("Newton steps could not converge and algorithm is not adaptive. Use a lower dt.", verbose, :newton_convergence)
+        diagnostic = exit_diagnostic(integrator, :newton_convergence)
+        @SciMLMessage(lazy"Newton steps could not converge and algorithm is not adaptive. Use a lower dt.$diagnostic", verbose, :newton_convergence)
         return ReturnCode.ConvergenceFailure
     end
     return ReturnCode.Success

--- a/test/check_error_diagnostics.jl
+++ b/test/check_error_diagnostics.jl
@@ -1,0 +1,103 @@
+using Test, SciMLBase, Logging
+
+# A minimal integrator that goes through the generic `SciMLBase.check_error`
+# rather than specializing it, so every exit branch can be driven directly.
+struct DiagSolution
+    retcode::SciMLBase.ReturnCode.T
+end
+SciMLBase.solution_new_retcode(::DiagSolution, code) = DiagSolution(code)
+
+mutable struct DiagOpts
+    verbose::Bool
+    maxiters::Int
+    dtmin::Float64
+    adaptive::Bool
+    force_dtmin::Bool
+    unstable_check::Any
+end
+
+mutable struct DiagIntegrator{Alg, IIP, U, T} <: SciMLBase.DEIntegrator{Alg, IIP, U, T}
+    u::U
+    uprev::U
+    t::T
+    dt::T
+    p::Any
+    f::Any
+    iter::Int
+    accept_step::Bool
+    step_failed::Bool
+    sol::DiagSolution
+    opts::DiagOpts
+
+    function DiagIntegrator(; kwargs...)
+        opts = DiagOpts(true, 100, 1.0e-10, true, false, (dt, u, p, t) -> false)
+        integ = new{Bool, true, Vector{Float64}, Float64}(
+            [1.0], [1.0], 0.5, 0.1, nothing, nothing, 1, true, false,
+            DiagSolution(ReturnCode.Default), opts
+        )
+        for (k, v) in kwargs
+            k in fieldnames(DiagOpts) ? setfield!(opts, k, v) : setfield!(integ, k, v)
+        end
+        return integ
+    end
+end
+
+SciMLBase.last_step_failed(integrator::DiagIntegrator) = integrator.step_failed
+SciMLBase.postamble!(::DiagIntegrator) = nothing
+
+const NUMERIC_MARK = " <numeric>"
+const ESTIMATE_MARK = " <estimate>"
+SciMLBase.log_numerical_instability(::DiagIntegrator; jacobian_logging = true) = NUMERIC_MARK
+SciMLBase.log_error_estimate(::DiagIntegrator) = ESTIMATE_MARK
+
+function logged_check_error(integrator)
+    io = IOBuffer()
+    code = with_logger(SimpleLogger(io)) do
+        SciMLBase.check_error(integrator)
+    end
+    return code, String(take!(io))
+end
+
+# Every non-Success exit reports the extended diagnostics, not just the dtmin and
+# instability branches that carried them historically.
+@testset "diagnostics on $(name)" for (name, integrator, expected) in (
+        ("dt NaN", DiagIntegrator(dt = NaN), ReturnCode.DtNaN),
+        ("maxiters", DiagIntegrator(iter = 101), ReturnCode.MaxIters),
+        (
+            "dt below dtmin", DiagIntegrator(dt = 1.0e-14, accept_step = false),
+            ReturnCode.DtLessThanMin,
+        ),
+        (
+            "dt below eps", DiagIntegrator(dt = 1.0e-30, dtmin = 0.0, accept_step = false),
+            ReturnCode.Unstable,
+        ),
+        (
+            "unstable check", DiagIntegrator(unstable_check = (dt, u, p, t) -> true),
+            ReturnCode.Unstable,
+        ),
+        ("newton failure", DiagIntegrator(step_failed = true), ReturnCode.ConvergenceFailure),
+    )
+    code, logs = logged_check_error(integrator)
+    @test code == expected
+    @test occursin(NUMERIC_MARK, logs)
+    @test occursin(ESTIMATE_MARK, logs)
+end
+
+@testset "successful check reports nothing" begin
+    code, logs = logged_check_error(DiagIntegrator())
+    @test code == ReturnCode.Success
+    @test isempty(logs)
+end
+
+@testset "silent verbosity skips diagnostic work" begin
+    integrator = DiagIntegrator(iter = 101, verbose = false)
+    code, logs = logged_check_error(integrator)
+    @test code == ReturnCode.MaxIters
+    @test isempty(logs)
+    @test SciMLBase.exit_diagnostic(integrator, :max_iters) == ""
+end
+
+@testset "default hooks are empty" begin
+    @test SciMLBase.log_error_estimate(nothing) == ""
+    @test SciMLBase.log_numerical_instability(nothing) == ""
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,9 @@ run_tests(;
         @time @safetestset "Integrator interface" begin
             include("integrator_tests.jl")
         end
+        @time @safetestset "check_error diagnostics" begin
+            include("check_error_diagnostics.jl")
+        end
         @time @safetestset "Ensemble functionality" begin
             include("ensemble_tests.jl")
         end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Motivation

From a Slack thread with @MasonProtter: a large ODE solved in a loop suddenly starts hitting `maxiters`. Saving every step to inspect what happened OOMs a 256GB machine, and `save_everystep=false` leaves almost nothing to look at:

```
julia> trace.this_trial[].sol.t
10-element Vector{Float64}:
   0.0
   ...
 122.40941475068085
```

No NaNs, no large values, no obvious culprit. The solver knew exactly which equation was forcing the step size down — it just never said so.

The extended diagnostics added in #1379 do report that kind of information, but only on the `dtmin`, sub-epsilon, and unstable-check exits. As @oscardssmith put it in the thread, "shreyas's pr won't help if we aren't exiting with a dt<dtmin or unstable". A `maxiters` exit got the generic "larger maxiters is needed" string and nothing else.

## What this does

The high level, quoting the thread: *"should I exit?" -> "if logging is on, diagnose more information about why I exited" -> "exit"*.

- Every non-`Success` exit from `check_error` now runs the same diagnostic — `MaxIters` and `DtNaN` and `ConvergenceFailure` included, not just the two instability branches. The shared construction moved into `SciMLBase.exit_diagnostic`.
- New `SciMLBase.log_error_estimate(integrator)` hook, defaulting to `""`. Solver packages specialize it to report the adaptive error estimate and, more usefully, the state components contributing most to it. `EEst = ||atmp||` only says the step was rejected; `atmp` says *which equation* rejected it. Implemented for `ODEIntegrator` in SciML/OrdinaryDiffEq.jl#4057.
- The `maxiters` and `dt_NaN` messages now report the `t` (and `dt`) they gave up at.

Two incidental fixes in the same code:

- The diagnostics were computed and then thrown away when the verbosity toggle was off. They are now gated *before* the work happens, which matters because the numeric diagnostic can build a fresh Jacobian on a large system.
- The dt-below-epsilon branch gated its diagnostic on `dt_min_unstable` while emitting the message under `dt_epsilon`, so setting `dt_epsilon` alone got a message with no diagnostic. Both now use `dt_epsilon`.

Also drops the `isdefined(integrator, :EEst) ? ... : ""` interpolation from the dtmin messages. `ODEIntegrator` moved `EEst` onto the controller cache, so `isdefined` has been permanently `false` and that text never printed. `log_error_estimate` reports the estimate through a hook the solver actually implements.

## What it looks like

With SciML/OrdinaryDiffEq.jl#4057 providing the hook, on a 10-equation system where only component 7 is stiff:

```
┌ Warning: Verbosity toggle: max_iters
│  Interrupted. Larger maxiters is needed. [...] Reached t=0.01712924006064487 with dt=3.5068470420252215e-5.
│
│ Error estimate diagnostics:
│ step error estimate EEst = 0.1727 (a step is accepted when EEst <= 1) after 498 accepted and 2 rejected steps
│
│ largest contributors to EEst = internalnorm(atmp), where atmp is the tolerance-weighted local error per state component:
│   atmp[7] = -0.5463, u[7] = 8.311e-07, uprev[7] = 8.311e-07
│   atmp[1] = 2.141e-19, u[1] = 0.9983, uprev[1] = 0.9983
│   atmp[2] = 2.141e-19, u[2] = 0.9983, uprev[2] = 0.9983
└
```

## Tests

`test/check_error_diagnostics.jl` drives a mock integrator through the generic `check_error` and asserts that all six exit branches (`DtNaN`, `MaxIters`, `DtLessThanMin`, sub-epsilon `Unstable`, unstable-check `Unstable`, `ConvergenceFailure`) emit both hooks' output, that a successful check emits nothing, and that a silent toggle skips the diagnostic entirely.

Run locally on Julia 1.11:

```
$ GROUP=Core julia --project -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total  Time
check_error diagnostics |   25     25  1.2s
[...]
     Testing SciMLBase tests passed

$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   35     35  1m33.6s
     Testing SciMLBase tests passed
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC)
- [x] Any new documentation only uses public API

## Additional context

Supports SciML/OrdinaryDiffEq.jl#4057 (implements `log_error_estimate`) and composes with SciML/OrdinaryDiffEq.jl#3731, whose `log_numerical_instability` now also fires on `maxiters` exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKB6v14nZHZPYtKiLsPLDT
