### PR TITLE
Label ncondition as callback condition calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.40.0"
+version = "3.40.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -60,7 +60,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::DEStats)
     @printf io "%-50s %-d\n" "Number of nonlinear solver convergence failures:" s.nnonlinconvfail
     @printf io "%-50s %-d\n" "Number of fixed-point solver iterations:" s.nfpiter
     @printf io "%-50s %-d\n" "Number of fixed-point solver convergence failures:" s.nfpconvfail
-    @printf io "%-50s %-d\n" "Number of rootfind condition calls:" s.ncondition
+    @printf io "%-50s %-d\n" "Number of callback condition calls:" s.ncondition
     @printf io "%-50s %-d\n" "Number of accepted steps:" s.naccept
     @printf io "%-50s %-d" "Number of rejected steps:" s.nreject
     return iszero(s.maxeig) || @printf io "\n%-50s %-e" "Maximum eigenvalue recorded:" s.maxeig


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Motivation

From a Slack thread with @MasonProtter, debugging an ODE that suddenly starts hitting `maxiters`:

```
julia> trace.this_trial[].sol.stats
SciMLBase.DEStats
[...]
Number of rootfind condition calls:                2999367
Number of accepted steps:                          999789
```

The problem has no continuous callbacks at all, so this reads as a serious bug — roughly three rootfinds per step that should not exist. @oscardssmith tracked it down: the counter increments on discrete callbacks too, which it has done deliberately since DiffEqBase's "Corrects condition call count" commit.

So the counter is right and the label is wrong. `DEStats`' own docstring already says `ncondition` is the "Number of callback condition-function calls". Only the printed label claims rootfinding.

## What this does

Renames the printed line to "Number of callback condition calls:". Display only — the field, its value, and its documented meaning are unchanged.

The matching label in DiffEqBase's fallback `Stats` show method and in DiffEqDevTools' work-precision plot recipe is fixed in SciML/OrdinaryDiffEq.jl#4058.

If separating continuous-rootfind calls from discrete-condition calls is wanted, that needs a new `DEStats` field and a breaking release; happy to open that separately.

## Checklist

- [x] Appropriate tests were added — n/a, display-string change with no behavior change
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC)
- [x] Any new documentation only uses public API

## Additional context

Version bumped to 3.40.1; if #1478 (3.41.0) merges first this needs a trivial rebase of the version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKB6v14nZHZPYtKiLsPLDT
