### PR TITLE
Document solver concretization extension hooks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.40.1"
+version = "3.41.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -32,3 +32,21 @@ SciMLBase.unitfulvalue
 ```@docs
 SciMLBase.last_step_failed
 ```
+
+## Solver Preparation Hooks
+
+Solver packages use these hooks to derive the effective problem data for an individual
+solve call and to reject unsupported problem-algorithm pairings. They are not an
+application-facing replacement for `solve`, `init`, or `remake`.
+
+```@docs
+SciMLBase.get_concrete_p
+SciMLBase.get_concrete_u0
+SciMLBase.isconcreteu0
+SciMLBase.promote_u0
+SciMLBase.get_concrete_problem
+SciMLBase.check_prob_alg_pairing
+SciMLBase.KeywordArgError
+SciMLBase.keyword_arg_silent
+SciMLBase.@add_kwonly
+```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2105,6 +2105,11 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Core functions
 @public build_solution, numargs
 
+# Solver problem-concretization extension API
+@public get_concrete_p, get_concrete_u0, isconcreteu0, promote_u0,
+    get_concrete_problem, check_prob_alg_pairing, KeywordArgError, keyword_arg_silent,
+    @add_kwonly
+
 # SciMLFunction derivative traits
 @public has_jac, has_jvp, has_vjp, has_tgrad, has_analytic, has_reinit,
     has_initialization_data, has_stats

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -102,7 +102,7 @@ $allowedkeywords
 See <https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts> for more details.
 
 Set kwargshandle=KeywordArgError for an error message.
-Set kwargshandle=KeywordArgSilent to ignore this message.
+Set kwargshandle=keyword_arg_silent to ignore this message.
 """
 
 const KWARGERROR_MESSAGE = """
@@ -166,7 +166,36 @@ function Base.showerror(io::IO, e::CommonKwargError)
     return nothing
 end
 
+"""
+    KeywordArgError
+    KeywordArgWarn
+    KeywordArgSilent
+
+Controls how a solver handles keyword arguments outside its supported keyword set.
+
+## Values
+
+- `KeywordArgError`: throw `CommonKwargError` for unsupported keywords.
+- `KeywordArgWarn`: emit a warning and continue.
+- `KeywordArgSilent`: accept unsupported keywords without a warning.
+
+Solver packages can use these values as the `kwargshandle` passed to their keyword
+validation path. Application code should prefer solver-specific documented keywords
+instead of suppressing validation with `KeywordArgSilent`.
+"""
 @enum KeywordArgError KeywordArgWarn KeywordArgSilent
+
+"""
+    keyword_arg_silent
+
+The documented solver-author value for accepting unsupported keyword arguments without
+emitting a warning. Pass it as `kwargshandle` to a keyword-validation path when the
+caller has intentionally delegated keyword handling to another layer.
+
+Application code should not use this value to suppress unsupported solver keywords;
+use the solver's documented keyword interface instead.
+"""
+const keyword_arg_silent = KeywordArgSilent
 
 const INCOMPATIBLE_U0_MESSAGE = """
 Initial condition incompatible with functional form.

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -66,6 +66,28 @@ handle_distribution_u0(_u0) = _u0
 eval_u0(u0::Function) = true
 eval_u0(u0) = false
 
+"""
+    get_concrete_p(prob, kwargs)
+
+Return the parameter value a solver should use for a single solve call.
+
+# Arguments
+
+- `prob`: A SciML problem with a `p` field.
+- `kwargs`: Keyword arguments from the solve call, represented by a `NamedTuple` or
+  another key-addressable keyword container.
+
+# Returns
+
+The `p` keyword override when present; otherwise `prob.p`.
+
+# Developer Interface
+
+Solver packages call this before constructing their cache or concretizing a problem so
+that `solve(prob; p = new_p)` and `solve(remake(prob; p = new_p))` use the same
+parameter value. Extensions should preserve that override rule and must not mutate
+`prob` or the supplied keyword container.
+"""
 function get_concrete_p(prob, kwargs)
     return if haskey(kwargs, :p)
         p = kwargs[:p]
@@ -74,6 +96,32 @@ function get_concrete_p(prob, kwargs)
     end
 end
 
+"""
+    get_concrete_u0(prob, isadapt, t0, kwargs)
+
+Return the initial state a solver should use for a single solve call.
+
+# Arguments
+
+- `prob`: A SciML problem with a `u0` field.
+- `isadapt`: Whether the solver will adapt its time step or mesh. Integer initial
+  states are converted to floating-point values when this is `true`.
+- `t0`: The initial independent-variable value.
+- `kwargs`: Keyword arguments from the solve call. A `u0` entry overrides `prob.u0`.
+
+# Returns
+
+The effective initial state after applying the `u0` override, evaluating supported
+problem-specific initial-state representations, and enforcing the common in-place and
+tuple-state constraints.
+
+# Developer Interface
+
+Solver packages use this hook while concretizing a problem. Extensions must honor the
+`u0` keyword override, return a state compatible with the problem's in-place trait,
+and throw the appropriate SciMLBase initial-condition error instead of silently
+changing an invalid state representation.
+"""
 function get_concrete_u0(prob::BVProblem, isadapt, t0, kwargs)
     if haskey(kwargs, :u0)
         u0 = kwargs[:u0]
@@ -156,6 +204,29 @@ function get_updated_symbolic_problem(indp, prob; kw...)
     return prob
 end
 
+"""
+    isconcreteu0(prob, t0, kwargs) -> Bool
+
+Return whether `prob.u0` is already a concrete initial state that can be reused without
+evaluation.
+
+# Arguments
+
+- `prob`: A SciML problem with a `u0` field.
+- `t0`: The initial independent-variable value for the proposed solve.
+- `kwargs`: Keyword arguments for the proposed solve.
+
+# Returns
+
+`true` when the problem's stored `u0` is neither deferred nor distribution-valued, and
+`false` otherwise.
+
+# Developer Interface
+
+`get_concrete_problem` implementations use this predicate to decide whether they may
+return the original problem object. Extensions must return `false` whenever evaluating
+or replacing `u0` is required, including for solve-call overrides.
+"""
 function isconcreteu0(prob, t0, kwargs)
     return !eval_u0(prob.u0) && prob.u0 !== nothing && !isdistribution(prob.u0)
 end
@@ -215,6 +286,29 @@ function get_concrete_du0(prob, isadapt, t0, kwargs)
     return _du0
 end
 
+"""
+    promote_u0(u0, p, t0)
+
+Promote an initial state to preserve automatic-differentiation element types carried by
+parameters or the initial independent variable.
+
+# Arguments
+
+- `u0`: Initial state to prepare for a solve.
+- `p`: Effective parameter value for the solve.
+- `t0`: Effective initial independent-variable value.
+
+# Returns
+
+`u0` unchanged when no dual element type is present; otherwise a state with the common
+dual-compatible element type.
+
+# Developer Interface
+
+Solver packages call this after `get_concrete_u0` and before constructing caches or
+testing whether a problem can be reused. Extensions must retain the value semantics of
+`u0` and only change its element type when promotion is required by `p` or `t0`.
+"""
 function promote_u0(u0, p, t0)
     if SciMLStructures.isscimlstructure(p)
         _p = SciMLStructures.canonicalize(SciMLStructures.Tunable(), p)[1]
@@ -315,6 +409,58 @@ SciMLBase.unitfulvalue(x::MyDualQuantity) = x.primal
 unitfulvalue(x) = x
 isdistribution(u0) = false
 sse(x::Number) = abs2(x)
+
+"""
+    get_concrete_problem(prob, isadapt; alg = nothing, kwargs...)
+
+Return the problem object a solver should use for a specific solve call.
+
+# Arguments
+
+- `prob`: The problem supplied to `solve` or `init`.
+- `isadapt`: Whether the selected algorithm adapts time steps or a mesh.
+- `alg`: Selected algorithm, when algorithm-dependent promotion or function
+  specialization is required.
+- `kwargs`: Solve-call keyword arguments, including possible `u0`, `p`, and time-span
+  overrides.
+
+# Returns
+
+Either `prob` when its stored data already matches the requested solve, or a replacement
+problem carrying the effective values for that solve.
+
+# Developer Interface
+
+Solver packages extend this hook for problem families that require solver-time
+concretization. Implementations should use `get_concrete_p`, `get_concrete_u0`,
+`promote_u0`, and `remake` as appropriate; they must not mutate `prob`, must preserve
+the problem family and user-visible metadata, and may return `prob` only when the
+effective values and their relevant types are unchanged.
+"""
+function get_concrete_problem end
+
+"""
+    check_prob_alg_pairing(prob, alg)
+
+Validate that `alg` is applicable to `prob` before a solver allocates its cache.
+
+# Arguments
+
+- `prob`: Problem selected for the solve.
+- `alg`: Algorithm selected for the solve.
+
+# Returns
+
+`nothing` when the pairing is supported.
+
+# Developer Interface
+
+Solver packages extend this hook for problem families with algorithm restrictions.
+Implementations should throw a descriptive SciMLBase error for unsupported pairings and
+must not mutate `prob` or `alg`. A no-op method is appropriate when every algorithm in
+the package's documented algorithm family supports the problem type.
+"""
+function check_prob_alg_pairing end
 
 struct DualEltypeChecker{T, T2}
     x::T

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -9,6 +9,20 @@ end
 SciMLBase.problem_type(::ProblemTypeTestProblem) = ProblemTypeTestMarker()
 SciMLBase.wrap_sol(::ProblemTypeTestSolution, ::ProblemTypeTestMarker) = :wrapped
 
+struct ConcretizationHookProblem{F, U, P} <: SciMLBase.AbstractSciMLProblem
+    f::F
+    u0::U
+    p::P
+end
+struct ConcretizationHookAlgorithm end
+
+SciMLBase.isinplace(::ConcretizationHookProblem) = false
+SciMLBase.get_concrete_problem(
+    prob::ConcretizationHookProblem, isadapt; alg = nothing, kwargs...
+) = (; prob, isadapt, alg, kwargs)
+SciMLBase.check_prob_alg_pairing(::ConcretizationHookProblem, ::ConcretizationHookAlgorithm) =
+    nothing
+
 @testset "Common keyword interface documentation" begin
     common_keywords = read(
         joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Common_Keywords.md"),
@@ -105,6 +119,31 @@ end
     @test occursin("SciMLBase.problem_type", problem_trait_docs)
     @test occursin("Delay, Boundary, and Noise Problem Types", problem_docs)
     @test occursin("Algebraic Problem Types", problem_docs)
+end
+
+@testset "Solver concretization developer interface" begin
+    prob = ConcretizationHookProblem(nothing, [1.0], :default_parameter)
+    alg = ConcretizationHookAlgorithm()
+
+    @test SciMLBase.get_concrete_p(prob, (;)) === :default_parameter
+    @test SciMLBase.get_concrete_p(prob, (; p = :override_parameter)) === :override_parameter
+    @test SciMLBase.get_concrete_u0(prob, false, 0.0, (;)) === prob.u0
+    @test SciMLBase.get_concrete_u0(prob, false, 0.0, (; u0 = [2.0])) == [2.0]
+    @test SciMLBase.isconcreteu0(prob, 0.0, (;))
+    @test SciMLBase.promote_u0([1.0], prob.p, 0.0) == [1.0]
+
+    concrete = SciMLBase.get_concrete_problem(prob, true; alg, p = :override_parameter)
+    @test concrete.prob === prob
+    @test concrete.isadapt
+    @test concrete.alg === alg
+    @test concrete.kwargs[:p] === :override_parameter
+    @test SciMLBase.check_prob_alg_pairing(prob, alg) === nothing
+
+    SciMLBase.@add_kwonly function concretization_kwonly(x; offset = 1)
+        return x + offset
+    end
+    @test concretization_kwonly(2) == 3
+    @test concretization_kwonly(; x = 2, offset = 4) == 6
 end
 
 @testset "Concrete interface reference documentation" begin
@@ -259,6 +298,9 @@ if isdefined(Base, :ispublic)
                 :done, :postamble!, :enable_interpolation_sensitivitymode,
                 :get_root_indp, :has_initializeprob, :late_binding_update_u0_p,
                 :strip_interpolation, :unitfulvalue, :value, :last_step_failed,
+                :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
+                :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,
+                :keyword_arg_silent, Symbol("@add_kwonly"),
             )
             @test Base.ispublic(SciMLBase, name)
             @test Base.Docs.hasdoc(SciMLBase, name)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Adds the public, rendered developer contract for problem-concretization hooks now owned by SciMLBase, with direct contract tests.

Validation:
- focused `test/public_interface.jl`
- `GROUP=QA Pkg.test()` (35/35)
- rendered Documenter build (network link checking disabled only for local validation; the normal build reaches rendering but the existing stable Problem_Traits link returns HTTP 403)
- Runic check