### PR TITLE
Fix Moshi bare-singleton deprecation warning on v2-backport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.155.1"
+version = "2.155.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]
@@ -100,7 +100,7 @@ Markdown = "1.10"
 Measurements = "2"
 MonteCarloMeasurements = "1"
 Mooncake = "0.4, 0.5"
-Moshi = "0.3.6"
+Moshi = "0.3.11"
 PartialFunctions = "1.1"
 PreallocationTools = "0.4.31, 1.0"
 PrecompileTools = "1.2.1"

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -1,12 +1,12 @@
 abstract type AbstractClock end
 
 @data Clocks <: AbstractClock begin
-    ContinuousClock
+    ContinuousClock()
     struct PeriodicClock
         dt::Union{Nothing, Float64, Rational{Int}}
         phase::Float64 = 0.0
     end
-    SolverStepClock
+    SolverStepClock()
     struct EventClock
         id::Symbol
     end

--- a/test/clock.jl
+++ b/test/clock.jl
@@ -70,3 +70,17 @@ end
     @test clocktype(PeriodicClock(1 // 2, 3.14)) === (1 // 2, 3.14)
     @test clocktype(pi) === "other" broken = true
 end
+
+@testset "SciMLBase precompiles without deprecation warnings" begin
+    # Moshi's bare singleton variant syntax (`ContinuousClock` rather than
+    # `ContinuousClock()`) only warns while the `@data` block is macroexpanded, so a
+    # forced recompile is the only way to observe it from a test.
+    script = """Base.compilecache(Base.identify_package("SciMLBase"))"""
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+    buf = IOBuffer()
+    run(pipeline(ignorestatus(cmd), stdout = buf, stderr = buf))
+    output = String(take!(buf))
+    occursin("deprecated", output) &&
+        @info "SciMLBase precompilation output" output
+    @test !occursin("deprecated", output)
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Fixes the precompilation warning reported at https://discourse.julialang.org/t/warning-in-scimlbase-about-continousclock/138534:

```
┌ SciMLBase
│  ┌ Warning: the bare singleton variant syntax `ContinuousClock` is deprecated, write `ContinuousClock()` instead (near .../SciMLBase/hLfdZ/src/clock.jl:4)
│  │   caller = eval at boot.jl:430 [inlined]
│  └ @ Core ./boot.jl:430
└
```

### Root cause

Moshi v0.3.11 (Roger-luo/Moshi.jl#80, 2026-07-12) deprecated the bare singleton variant syntax inside `@data` and requires `Name()`. `src/clock.jl` on `v2-backport` declares `ContinuousClock` and `SolverStepClock` in the bare form, and the v2 compat entry `Moshi = "0.3.6"` resolves to v0.3.12, so every user on SciMLBase v2 now gets this warning on precompile. Only one warning shows because `Base.depwarn` dedupes on `(caller frame, funcsym)` — `SolverStepClock` has the same problem.

`master` (v3) is unaffected: Moshi was dropped entirely in 2837095 ("Replace Moshi with plain Julia structs for Clocks", v3.0.0). Verified — a fresh env with SciMLBase v3.40.0 precompiles clean.

Other Moshi users in the ecosystem (ModelingToolkitBase's `MissingGuessValue` / `StructuralHint`, SymbolicUtils' `BasicSymbolicImpl`) already use the explicit form, so this is the only offender.

### Fix

`ContinuousClock` → `ContinuousClock()`, `SolverStepClock` → `SolverStepClock()`. The explicit form throws `ArgumentError: missing fields in variant expression` on Moshi < 0.3.11, so the compat floor moves to `0.3.11` alongside the syntax. All `@match` patterns in `clock.jl` already used `Name()` and are unchanged.

### Test

Added a regression test that force-recompiles SciMLBase in a subprocess and asserts no deprecation output — the warning is emitted during macroexpansion, so it is invisible unless the package is actually recompiled.

Verified locally on Julia 1.11.9 with Moshi v0.3.12:

- Reproduced the warning on released v2.155.1.
- With the fix, `Base.compilecache` output is empty and clock behavior is identical (`iscontinuous`, `issolverstepclock`, `isclock`, `iseventclock`, `is_discrete_time_domain`, `first_clock_tick_time`, `==`, `hash`, `clock()` all as before).
- `GROUP=Core Pkg.test()` passes: `Clocks | 38 pass, 1 broken (pre-existing)`, `Remake | 4414 pass`, full group green.
- Confirmed the new test fails on the unpatched source: `Expression: !(occursin("deprecated", output))` → `Clocks | 37 pass, 1 fail, 1 broken`.
- Runic v1 `--check` clean on both changed files.

### Note

Version bumped to 2.155.2. This needs a release off `v2-backport` to actually reach the users hitting it; if v2 is no longer being registered, the alternative answer for them is to upgrade to SciMLBase v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwhhJmoj8GGx2i2vJ6Rnba