### PR TITLE
Declare OptimizationStats, DefaultOptimizationCache, ImmutableNonlinearProblem public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.40.0"
+version = "3.41.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Algebraic_Problem_Types.md
+++ b/docs/src/interfaces/Algebraic_Problem_Types.md
@@ -23,6 +23,7 @@ SciMLBase.EigenvalueTarget.SmallestImaginaryPart
 
 ```@docs
 SciMLBase.NonlinearProblem
+SciMLBase.ImmutableNonlinearProblem
 SciMLBase.StandardNonlinearProblem
 SciMLBase.IntervalNonlinearProblem
 SciMLBase.NonlinearLeastSquaresProblem

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -212,6 +212,7 @@ SciMLBase.AbstractSteadyStateProblem
 
 ```@docs
 SciMLBase.AbstractOptimizationCache
+SciMLBase.DefaultOptimizationCache
 ```
 
 ## Concrete Problem Reference

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -208,6 +208,7 @@ with their respective interfaces.
 ```@docs
 SciMLBase.DEStats
 SciMLBase.NLStats
+SciMLBase.OptimizationStats
 ```
 
 ### Solution Construction and Errors

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2100,7 +2100,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Solution / problem support types
 @public NLStats, NullParameters, AbstractSpecialization, AutoSpecialize,
-    AbstractOptimizationCache
+    AbstractOptimizationCache, DefaultOptimizationCache, OptimizationStats
 
 # Core functions
 @public build_solution, numargs
@@ -2179,7 +2179,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
     late_binding_update_u0_p, strip_interpolation, unitfulvalue, value, last_step_failed
 
 # Problem types and alias specifiers
-@public ImmutableODEProblem, NonlinearAliasSpecifier
+@public ImmutableODEProblem, ImmutableNonlinearProblem, NonlinearAliasSpecifier
 @public AbstractAliasSpecifier, AnalyticalAliasSpecifier, SteadyStateAliasSpecifier,
     ImplicitDiscreteAliasSpecifier, DAEAliasSpecifier, DDEAliasSpecifier,
     SDDEAliasSpecifier, BVPAliasSpecifier, OptimizationAliasSpecifier,

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -665,6 +665,21 @@ struct NonlinearAliasSpecifier <: AbstractAliasSpecifier
     end
 end
 
+"""
+$(TYPEDEF)
+
+An immutable counterpart to [`NonlinearProblem`](@ref SciMLBase.NonlinearProblem) that
+carries the same `f`, `u0`, `p`, `problem_type`, and `kwargs` data.
+
+Because the struct and its fields are immutable, an `ImmutableNonlinearProblem` built
+from `isbits` components is itself `isbits`. That makes it usable from contexts which
+cannot allocate or mutate — most importantly inside GPU kernels, where solver packages
+construct one per thread and hand it to a non-allocating nonlinear solver. Use
+`NonlinearProblem` for ordinary host-side solves; reach for this type when the problem
+must cross into a kernel or otherwise stay allocation-free.
+
+Constructors mirror `NonlinearProblem`, and `remake` is supported.
+"""
 struct ImmutableNonlinearProblem{uType, iip, P, F, K, PT} <:
     AbstractNonlinearProblem{uType, iip}
     f::F


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Motivation

These three names are already part of the de facto solver-author API, but none of them is declared `public`:

| Name | Who needs it | Why |
|---|---|---|
| `OptimizationStats` | every optimization solver | it is what you pass to `build_solution(...; stats = ...)` to populate `sol.stats` |
| `DefaultOptimizationCache` | optimization solvers without a reusable cache | it is the cache you hand to `build_solution` |
| `ImmutableNonlinearProblem` | GPU kernel solvers | the mutable `NonlinearProblem` is not `isbits` and cannot cross into a kernel |

Because they are reachable only as non-public names, downstream packages get an ExplicitImports failure and are pushed toward the wrong fix. A concrete example: a strict-QA pass on ParallelParticleSwarms.jl "resolved" these findings by dropping `OptimizationStats` from every returned solution and swapping `ImmutableNonlinearProblem` for `NonlinearProblem` inside a GPU kernel — silently removing `sol.stats` and breaking the allocation-free kernel path. That is the predictable outcome when working code depends on a name the owner will not promise.

## Changes

- `@public OptimizationStats, DefaultOptimizationCache` (added to the existing solution/problem support-types block).
- `@public ImmutableNonlinearProblem` (added to the problem-types block, next to `ImmutableODEProblem`).
- `ImmutableNonlinearProblem` had no docstring, so one is added explaining what it is for and when to reach for it over `NonlinearProblem`, plus its `@docs` entry in `Algebraic_Problem_Types.md`.
- `OptimizationStats` and `DefaultOptimizationCache` were already documented and only needed rendered-docs entries (`Solutions.md` and `Problems.md` respectively).
- Version `3.40.0` → `3.41.0` (adding public API is a minor bump).

Public and documented move together, per the SciML convention: every name declared public here has a docstring and a rendered `@docs` entry in the same PR.

## Verification

Loaded locally against the branch:

```
DefaultOptimizationCache       ispublic=true isdefined=true
OptimizationStats              ispublic=true isdefined=true
ImmutableNonlinearProblem      ispublic=true isdefined=true
__solve                        ispublic=true isdefined=true
```

and confirmed the new `ImmutableNonlinearProblem` docstring attaches (1069 chars via `@doc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1VkEmNsLeQTkYmc9pvEL3