### PR TITLE
Fix downstream rendering of integrator docstrings

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -933,8 +933,9 @@ end
 Return whether the preceding attempted solver step failed to converge.
 
 Concrete differential-equation integrators may specialize this hook when their
-step controller tracks a recoverable failed attempt. [`check_error`](@ref) uses
-it to convert a non-adaptive repeated failure into
+step controller tracks a recoverable failed attempt.
+[`check_error`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/#SciMLBase.check_error)
+uses it to convert a non-adaptive repeated failure into
 `ReturnCode.ConvergenceFailure`. The default is `false`.
 
 !!! warning "Developer API, not user API"
@@ -957,9 +958,10 @@ integration may continue.
 The common implementation preserves an existing terminal return code and checks
 for a NaN step size, iteration limits, a step size at or below `dtmin`, a
 user-supplied instability predicate, and failed nonlinear steps. It does not
-mutate `integrator.sol.retcode`; use [`check_error!`](@ref) when the solution
-must be updated. Concrete integrators may specialize the checks while preserving
-the return-code contract.
+mutate `integrator.sol.retcode`; use
+[`check_error!`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/#SciMLBase.check_error!)
+when the solution must be updated. Concrete integrators may specialize the
+checks while preserving the return-code contract.
 """
 function check_error(integrator::DEIntegrator)
     if integrator.sol.retcode ∉ (ReturnCode.Success, ReturnCode.Default)
@@ -1057,8 +1059,9 @@ function postamble! end
 """
     check_error!(integrator)
 
-Run [`check_error`](@ref), store the resulting code in
-`integrator.sol.retcode`, and return that code.
+Run
+[`check_error`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/#SciMLBase.check_error),
+store the resulting code in `integrator.sol.retcode`, and return that code.
 
 When the code is not `ReturnCode.Success`, the common implementation also calls
 the solver's `postamble!` hook so pending bookkeeping and finalization are

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -291,6 +291,20 @@ end
     @test occursin("SciMLBase.EnsembleAnalysis.EnsembleSummary", ensemble_docs)
 end
 
+@testset "Downstream-rendered integrator docstrings" begin
+    for doc in (
+            (@doc SciMLBase.last_step_failed),
+            (@doc SciMLBase.check_error),
+            (@doc SciMLBase.check_error!),
+        )
+        text = sprint(show, doc)
+        @test occursin(
+            "https://docs.sciml.ai/SciMLBase/stable/interfaces/Init_Solve/", text
+        )
+        @test !occursin("](@ref)", text)
+    end
+end
+
 if isdefined(Base, :ispublic)
     @testset "Extension hooks public API" begin
         for name in (


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- replace local `@ref` links in the `last_step_failed`, `check_error`, and `check_error!` docstrings with links to the owner package documentation
- add a regression test that checks these downstream-rendered docstrings contain owner-documentation links and no local `@ref` targets

## Why

OrdinaryDiffEq renders these SciMLBase docstrings in its own manual, but it does not render the corresponding SciMLBase bindings as local targets. Documenter therefore cannot resolve the local `check_error` reference and terminates during cross-reference validation.

The first failing OrdinaryDiffEq docs environment used SciMLBase 3.40.0; the preceding successful environment used 3.39.1. The link was introduced by SciMLBase #1472. This follows the same downstream-rendering pattern already fixed for another SciMLBase docstring in #1469.

Failing job: https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/30746151318/job/91491989362

## Local validation

- `Runic --check --diff .`
- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
- exact OrdinaryDiffEq documentation build at `a7080c6`, with this SciMLBase checkout developed into its docs environment

The first two commands passed, and the downstream OrdinaryDiffEq build completed with exit code 0. SciMLBase's own documentation passed cross-reference checks locally, then its full build was blocked by an unrelated `Problem_Traits` linkcheck returning HTTP 403; that same linkcheck failure reproduces on an untouched upstream-master worktree.
