### PR TITLE
Publish concrete solve AD developer API

### DIFF
--- a/docs/src/interfaces/Differentiation.md
+++ b/docs/src/interfaces/Differentiation.md
@@ -98,6 +98,30 @@ SciMLBase.AbstractSecondOrderSensitivityAlgorithm
 SciMLBase.AbstractShadowingSensitivityAlgorithm
 ```
 
+## Concrete Solve Developer Interface
+
+The following developer API is for packages that implement an AD integration or a
+sensitivity algorithm. Application code must select a documented `sensealg` through
+`solve`; it must not call these hooks or construct originator markers directly.
+
+An integration creates or uses an [`SciMLBase.ADOriginator`](@ref) that identifies its outer AD
+system, then adds a narrowly dispatched concrete-solve method for types it owns. The
+method receives the effective `prob`, `alg`, `sensealg`, `u0`, and `p` values in that
+order and must return the ordinary primal result together with the corresponding
+pullback or pushforward. It must preserve the primal solve semantics and may not mutate
+the problem or differentiated inputs.
+
+```@docs
+SciMLBase.ADOriginator
+SciMLBase.ChainRulesOriginator
+SciMLBase.EnzymeOriginator
+SciMLBase.ReverseDiffOriginator
+SciMLBase.TrackerOriginator
+SciMLBase.MooncakeOriginator
+SciMLBase._concrete_solve_adjoint
+SciMLBase._concrete_solve_forward
+```
+
 ## SensitivityADPassThrough
 
 The special sensitivity algorithm `SensitivityADPassThrough` ignores the

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1595,9 +1595,26 @@ depend on a reaction-network package.
 abstract type AbstractReactionNetwork end
 
 """
-$(TYPEDEF)
+    ADOriginator
 
-Internal. Used for signifying which AD context a derivative calculation is in.
+Developer interface marker for the automatic-differentiation system that initiated a
+solve derivative.
+
+`ADOriginator` values are passed to [`_concrete_solve_adjoint`](@ref) and
+[`_concrete_solve_forward`](@ref) so a sensitivity implementation can choose a rule
+compatible with the outer AD system.
+
+# Extension Rules
+
+Packages that integrate a new AD system may define a zero-field subtype and pass an
+instance only from their own solve-derivative rule. They must also provide concrete-solve
+hook methods specialized on a problem, sensitivity algorithm, or originator type they
+own. Do not dispatch a broad fallback on `ADOriginator`, redefine another package's
+originator marker, or expose an originator value as an application-facing solver option.
+
+The built-in markers identify ChainRules, Enzyme, ReverseDiff, Tracker, and Mooncake
+contexts. They are developer API; application code should select a documented
+`sensealg` and let the loaded AD integration choose the originator.
 """
 abstract type ADOriginator end
 
@@ -1630,37 +1647,72 @@ when every stored field can share the same policy.
 abstract type AbstractAliasSpecifier end
 
 """
-$(TYPEDEF)
+    ChainRulesOriginator()
 
-Internal. Used for signifying the AD context comes from a ChainRules.jl definition.
+Zero-field [`ADOriginator`](@ref) marking a derivative initiated by a
+ChainRulesCore rule.
+
+# Developer Interface
+
+Pass this marker to a concrete-solve hook only from a ChainRules-backed solve rule.
+Sensitivity packages may specialize hook methods on it to return a ChainRules pullback.
+Application code must not construct this marker to select a sensitivity algorithm.
 """
 struct ChainRulesOriginator <: ADOriginator end
 
 """
-$(TYPEDEF)
+    EnzymeOriginator()
 
-Internal. Used for signifying the AD context comes from an Enzyme.jl definition.
+Zero-field [`ADOriginator`](@ref) marking a derivative initiated by Enzyme.
+
+# Developer Interface
+
+Pass this marker to a concrete-solve hook only from an Enzyme-backed solve rule.
+Sensitivity packages may specialize hook methods on it when the primal or derivative
+values require Enzyme-specific handling. Application code must not construct this
+marker to select a sensitivity algorithm.
 """
 struct EnzymeOriginator <: ADOriginator end
 
 """
-$(TYPEDEF)
+    ReverseDiffOriginator()
 
-Internal. Used for signifying the AD context comes from a ReverseDiff.jl context.
+Zero-field [`ADOriginator`](@ref) marking a derivative initiated by ReverseDiff.
+
+# Developer Interface
+
+Pass this marker to a concrete-solve hook only from a ReverseDiff-backed solve rule.
+Sensitivity packages may specialize hook methods on it to preserve ReverseDiff tape
+semantics. Application code must not construct this marker to select a sensitivity
+algorithm.
 """
 struct ReverseDiffOriginator <: ADOriginator end
 
 """
-$(TYPEDEF)
+    TrackerOriginator()
 
-Internal. Used for signifying the AD context comes from a Tracker.jl context.
+Zero-field [`ADOriginator`](@ref) marking a derivative initiated by Tracker.
+
+# Developer Interface
+
+Pass this marker to a concrete-solve hook only from a Tracker-backed solve rule.
+Sensitivity packages may specialize hook methods on it to preserve Tracker value and
+gradient handling. Application code must not construct this marker to select a
+sensitivity algorithm.
 """
 struct TrackerOriginator <: ADOriginator end
 
 """
-$(TYPEDEF)
+    MooncakeOriginator()
 
-Internal. Used for signifying the AD context comes from a Mooncake.jl context.
+Zero-field [`ADOriginator`](@ref) marking a derivative initiated by Mooncake.
+
+# Developer Interface
+
+Pass this marker to a concrete-solve hook only from a Mooncake-backed solve rule.
+Sensitivity packages may specialize hook methods on it to return Mooncake-compatible
+derivative data. Application code must not construct this marker to select a
+sensitivity algorithm.
 """
 struct MooncakeOriginator <: ADOriginator end
 
@@ -2207,6 +2259,11 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Automatic differentiation markers
 @public NoAD
+
+# Versioned automatic-differentiation concrete-solve extension API. These names are
+# deliberately not exported: application code selects a documented `sensealg` instead.
+@public ADOriginator, ChainRulesOriginator, EnzymeOriginator, ReverseDiffOriginator,
+    TrackerOriginator, MooncakeOriginator, _concrete_solve_adjoint, _concrete_solve_forward
 
 # Function-wrapper / solution interface helpers
 @public unwrapped_f, specialization, solution_new_retcode

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -527,6 +527,43 @@ function Base.showerror(io::IO, e::AdjointNotFoundError)
     return print(io, ADJOINT_NOT_FOUND_MESSAGE)
 end
 
+"""
+    _concrete_solve_adjoint(prob, alg, sensealg, u0, p, originator, args...; kwargs...)
+
+Construct the reverse-mode derivative result for a solver call.
+
+# Arguments
+
+  - `prob`: The problem being solved.
+  - `alg`: The selected solver algorithm, which may be `nothing` when the caller uses
+    a problem-stored default.
+  - `sensealg`: The selected sensitivity algorithm or `nothing` for a package-defined
+    default.
+  - `u0`: The effective initial state passed to the primal solve.
+  - `p`: The effective parameter value passed to the primal solve.
+  - `originator`: An [`ADOriginator`](@ref) identifying the outer AD system.
+  - `args...`: Remaining positional solve arguments.
+
+# Keyword Arguments
+
+`kwargs...` are the solve keywords forwarded by the caller. Implementations must honor
+the applicable common solve keywords and preserve any values that affect the primal
+solution or derivative result.
+
+# Returns
+
+A pair `(primal, pullback)`. `primal` is the ordinary solve result and `pullback` is a
+callable compatible with the AD system identified by `originator`.
+
+# Developer Interface
+
+Sensitivity packages extend this hook to implement reverse-mode solve derivatives.
+Methods must specialize on at least one problem type, solver/sensitivity algorithm, or
+originator type that the extending package owns. They must not mutate `prob`, `u0`, or
+`p`, must compute the same primal result as the corresponding `solve` call, and must
+return cotangents in the positional order expected by the originating AD rule. The
+fallback throws an informative error until a compatible sensitivity package has loaded.
+"""
 function _concrete_solve_adjoint(args...; kwargs...)
     throw(AdjointNotFoundError())
 end
@@ -543,6 +580,43 @@ function Base.showerror(io::IO, e::ForwardSensitivityNotFoundError)
     return print(io, FORWARD_SENSITIVITY_NOT_FOUND_MESSAGE)
 end
 
+"""
+    _concrete_solve_forward(prob, alg, sensealg, u0, p, originator, args...; kwargs...)
+
+Construct the forward-mode derivative result for a solver call.
+
+# Arguments
+
+  - `prob`: The problem being solved.
+  - `alg`: The selected solver algorithm, which may be `nothing` when the caller uses
+    a problem-stored default.
+  - `sensealg`: The selected sensitivity algorithm or `nothing` for a package-defined
+    default.
+  - `u0`: The effective initial state passed to the primal solve.
+  - `p`: The effective parameter value passed to the primal solve.
+  - `originator`: An [`ADOriginator`](@ref) identifying the outer AD system.
+  - `args...`: Remaining positional solve arguments.
+
+# Keyword Arguments
+
+`kwargs...` are the solve keywords forwarded by the caller. Implementations must honor
+the applicable common solve keywords and preserve any values that affect the primal
+solution or tangent result.
+
+# Returns
+
+A pair `(primal, pushforward)`. `primal` is the ordinary solve result and `pushforward`
+is a callable compatible with the AD system identified by `originator`.
+
+# Developer Interface
+
+Sensitivity packages extend this hook to implement forward-mode solve derivatives.
+Methods must specialize on at least one problem type, solver/sensitivity algorithm, or
+originator type that the extending package owns. They must not mutate `prob`, `u0`, or
+`p`, must compute the same primal result as the corresponding `solve` call, and must
+accept tangents in the positional order expected by the originating AD rule. The
+fallback throws an informative error until a compatible sensitivity package has loaded.
+"""
 function _concrete_solve_forward(args...; kwargs...)
     throw(ForwardSensitivityNotFoundError())
 end

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -23,6 +23,27 @@ SciMLBase.get_concrete_problem(
 SciMLBase.check_prob_alg_pairing(::ConcretizationHookProblem, ::ConcretizationHookAlgorithm) =
     nothing
 
+struct ConcreteSolveContractProblem end
+struct ConcreteSolveContractAlgorithm end
+struct ConcreteSolveContractSenseAlg end
+struct ConcreteSolveContractOriginator <: SciMLBase.ADOriginator end
+
+function SciMLBase._concrete_solve_adjoint(
+        ::ConcreteSolveContractProblem, ::ConcreteSolveContractAlgorithm,
+        ::ConcreteSolveContractSenseAlg, u0, p, ::ConcreteSolveContractOriginator,
+        args...; kwargs...
+    )
+    return (; u0, p, args, kwargs = (; kwargs...)), Δ -> (:adjoint, Δ)
+end
+
+function SciMLBase._concrete_solve_forward(
+        ::ConcreteSolveContractProblem, ::ConcreteSolveContractAlgorithm,
+        ::ConcreteSolveContractSenseAlg, u0, p, ::ConcreteSolveContractOriginator,
+        args...; kwargs...
+    )
+    return (; u0, p, args, kwargs = (; kwargs...)), Δ -> (:forward, Δ)
+end
+
 @testset "Common keyword interface documentation" begin
     common_keywords = read(
         joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Common_Keywords.md"),
@@ -144,6 +165,25 @@ end
     end
     @test concretization_kwonly(2) == 3
     @test concretization_kwonly(; x = 2, offset = 4) == 6
+end
+
+@testset "Concrete solve AD developer interface" begin
+    prob = ConcreteSolveContractProblem()
+    alg = ConcreteSolveContractAlgorithm()
+    sensealg = ConcreteSolveContractSenseAlg()
+    originator = ConcreteSolveContractOriginator()
+
+    primal, pullback = SciMLBase._concrete_solve_adjoint(
+        prob, alg, sensealg, :u0, :p, originator, :extra; saveat = :saved
+    )
+    @test primal == (; u0 = :u0, p = :p, args = (:extra,), kwargs = (; saveat = :saved))
+    @test pullback(:cotangent) == (:adjoint, :cotangent)
+
+    primal, pushforward = SciMLBase._concrete_solve_forward(
+        prob, alg, sensealg, :u0, :p, originator, :extra; saveat = :saved
+    )
+    @test primal == (; u0 = :u0, p = :p, args = (:extra,), kwargs = (; saveat = :saved))
+    @test pushforward(:tangent) == (:forward, :tangent)
 end
 
 @testset "Concrete interface reference documentation" begin
@@ -301,6 +341,9 @@ if isdefined(Base, :ispublic)
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,
                 :keyword_arg_silent, Symbol("@add_kwonly"),
+                :ADOriginator, :ChainRulesOriginator, :EnzymeOriginator,
+                :ReverseDiffOriginator, :TrackerOriginator, :MooncakeOriginator,
+                :_concrete_solve_adjoint, :_concrete_solve_forward,
             )
             @test Base.ispublic(SciMLBase, name)
             @test Base.Docs.hasdoc(SciMLBase, name)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -106,7 +106,7 @@ end
 # None of these cross a package boundary, and an extension is exactly where a package
 # is expected to wire its internals to an optional dependency.
 const _ei_own_internals = (
-    :ADOriginator, :MooncakeOriginator, :set_mooncakeoriginator_if_mooncake,
+    :set_mooncakeoriginator_if_mooncake,
     :DualEltypeChecker, :ODENLStepData,
     :_reshape, :add_labels!, :anyeltypedual, :build_linear_solution, :checkkwargs,
     :diffeq_to_arrays, :getobserved, :handle_distribution_u0, :interpret_vars,


### PR DESCRIPTION
## Summary
- make the concrete-solve AD originator markers and forward/reverse hooks definition-site public developer API
- render the documented developer contract in the differentiation interface
- add a generic external extension contract test and remove the now-stale internal-only QA exceptions

## Verification
- focused public-interface contract test
- `Pkg.test()`
- rendered local documentation build with cross-references
- Runic and `git diff --check`

The normal docs build still fails only during link checking because the pre-existing `https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/` URL returns HTTP 403. This PR does not change link-check configuration or ignore that failure.

Ignore until reviewed by @ChrisRackauckas.