### PR TITLE
Publish linear and eigenvalue solution construction hooks

### DIFF
--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -27,6 +27,17 @@ SciMLBase.value
 SciMLBase.unitfulvalue
 ```
 
+## Solution Construction Hooks
+
+Solver packages use these hooks after finishing a linear or eigenvalue solve. They preserve
+the common no-time-solution representation without making application code depend on a
+concrete solution constructor.
+
+```@docs
+SciMLBase.build_linear_solution
+SciMLBase.build_eigenvalue_solution
+```
+
 ## Integrator Hook
 
 ```@docs

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2103,7 +2103,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
     AbstractOptimizationCache, DefaultOptimizationCache, OptimizationStats
 
 # Core functions
-@public build_solution, numargs
+@public build_solution, build_linear_solution, build_eigenvalue_solution, numargs
 
 # Solver problem-concretization extension API
 @public get_concrete_p, get_concrete_u0, isconcreteu0, promote_u0,

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -30,6 +30,46 @@ struct LinearSolution{T, N, uType, R, A, C, S} <: AbstractLinearSolution{T, N}
     stats::S
 end
 
+"""
+    build_linear_solution(alg, u, resid, cache; retcode = ReturnCode.Default, iters = 0,
+        stats = nothing) -> LinearSolution
+
+Construct the `LinearSolution` returned by a solver for a linear system.
+
+!!! warning "Developer API, not user API"
+    Solver packages use this versioned construction hook after implementing a linear solve.
+    Application code should obtain solutions through `solve` or `solve!` rather than call it
+    directly.
+
+# Arguments
+
+- `alg`: The linear algorithm that produced the result.
+- `u`: The computed solution state. It is retained without copying.
+- `resid`: The residual reported by the algorithm, or `nothing` when it is unavailable.
+- `cache`: The cache associated with this solve, or `nothing` when no cache should be
+  exposed.
+
+# Keywords
+
+- `retcode::ReturnCode.T = ReturnCode.Default`: The completion status of the solve.
+- `iters::Integer = 0`: Number of iterations performed by an iterative method.
+- `stats = nothing`: Solver-specific statistics, or `nothing` when none are available.
+
+# Returns
+
+- `LinearSolution`: A no-time solution whose `u`, `resid`, `alg`, `retcode`, `iters`,
+  `cache`, and `stats` fields are the corresponding supplied values.
+
+# Example
+
+```julia
+julia> alg = :direct;
+
+julia> build_linear_solution(alg, [2.0], nothing, nothing;
+                              retcode = ReturnCode.Success)
+retcode: Success
+```
+"""
 function build_linear_solution(
         alg, u, resid, cache;
         retcode = ReturnCode.Default,
@@ -78,6 +118,44 @@ struct EigenvalueSolution{T, N, U, V, P, A, R, S} <: AbstractEigenvalueSolution{
     stats::S
 end
 
+"""
+    build_eigenvalue_solution(prob, alg, values, vectors; retcode = ReturnCode.Success,
+        resid = nothing, stats = nothing) -> EigenvalueSolution
+
+Construct the `EigenvalueSolution` returned by a solver for an eigenvalue problem.
+
+!!! warning "Developer API, not user API"
+    Solver packages use this versioned construction hook after computing eigenpairs.
+    Application code should obtain solutions through `solve` rather than call it directly.
+
+# Arguments
+
+- `prob`: The `EigenvalueProblem` that was solved.
+- `alg`: The eigenvalue algorithm that produced the result.
+- `values`: Computed eigenvalues. They are retained without copying as the solution's `u`
+  field.
+- `vectors`: Eigenvectors corresponding to `values`, conventionally stored column-wise.
+
+# Keywords
+
+- `retcode::ReturnCode.T = ReturnCode.Success`: The completion status of the solve.
+- `resid = nothing`: Residual information for the computed eigenpairs, when available.
+- `stats = nothing`: Solver-specific statistics, or `nothing` when none are available.
+
+# Returns
+
+- `EigenvalueSolution`: A no-time solution whose `u`, `vectors`, `prob`, `alg`, `retcode`,
+  `resid`, and `stats` fields are the corresponding supplied values.
+
+# Example
+
+```julia
+julia> prob = EigenvalueProblem([2.0 0.0; 0.0 3.0]);
+
+julia> build_eigenvalue_solution(prob, :dense, [2.0, 3.0], [1.0 0.0; 0.0 1.0]).retcode
+Success
+```
+"""
 function build_eigenvalue_solution(
         prob, alg, values, vectors;
         retcode = ReturnCode.Success, resid = nothing, stats = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,9 @@ run_tests(;
         @time @safetestset "Solution interface" begin
             include("solution_interface.jl")
         end
+        @time @safetestset "Public solution builder interface" begin
+            include("solution_builder_interface.jl")
+        end
         @time @safetestset "Interpolation types" begin
             include("interpolation_tests.jl")
         end

--- a/test/solution_builder_interface.jl
+++ b/test/solution_builder_interface.jl
@@ -1,0 +1,46 @@
+using SciMLBase
+using Test
+
+module ExternalSolutionBuilderContract
+    using SciMLBase:
+        AbstractLinearAlgorithm, EigenvalueProblem, ReturnCode, build_eigenvalue_solution,
+        build_linear_solution
+
+    struct ExternalLinearAlgorithm <: AbstractLinearAlgorithm end
+
+    const LINEAR_RESULT = build_linear_solution(
+        ExternalLinearAlgorithm(), [1.0, 2.0], Ref(0.0), nothing;
+        retcode = ReturnCode.Success, iters = 3, stats = (matvecs = 4,)
+    )
+
+    const EIGEN_PROBLEM = EigenvalueProblem([2.0 0.0; 0.0 3.0])
+    const EIGEN_RESULT = build_eigenvalue_solution(
+        EIGEN_PROBLEM, ExternalLinearAlgorithm(), [2.0, 3.0], [1.0 0.0; 0.0 1.0];
+        resid = [0.0, 0.0], stats = (factorizations = 1,)
+    )
+end
+
+@testset "Public solution builder interface" begin
+    if VERSION >= v"1.11"
+        @test Base.ispublic(SciMLBase, :build_linear_solution)
+        @test Base.ispublic(SciMLBase, :build_eigenvalue_solution)
+    end
+
+    linear = ExternalSolutionBuilderContract.LINEAR_RESULT
+    @test linear.u == [1.0, 2.0]
+    @test linear.resid[] == 0.0
+    @test linear.alg isa ExternalSolutionBuilderContract.ExternalLinearAlgorithm
+    @test linear.retcode === SciMLBase.ReturnCode.Success
+    @test linear.iters == 3
+    @test linear.cache === nothing
+    @test linear.stats == (matvecs = 4,)
+
+    eigen = ExternalSolutionBuilderContract.EIGEN_RESULT
+    @test eigen.u == [2.0, 3.0]
+    @test eigen.vectors == [1.0 0.0; 0.0 1.0]
+    @test eigen.prob === ExternalSolutionBuilderContract.EIGEN_PROBLEM
+    @test eigen.alg isa ExternalSolutionBuilderContract.ExternalLinearAlgorithm
+    @test eigen.retcode === SciMLBase.ReturnCode.Success
+    @test eigen.resid == [0.0, 0.0]
+    @test eigen.stats == (factorizations = 1,)
+end


### PR DESCRIPTION
## Summary
- mark `build_linear_solution` and `build_eigenvalue_solution` as versioned SciMLBase developer APIs
- document both hooks at their definition sites with SciMLStyle arguments, keywords, returns, and doctested examples
- render the hooks in the Developer API and verify a downstream-style module imports only the public construction surface

## Verification
- `Pkg.test()`
- docs build with doctests
- Runic and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.