### PR TITLE
Publish sensitivity function developer API

### DIFF
--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -132,6 +132,9 @@ SciMLBase.has_jac
 SciMLBase.has_jvp
 SciMLBase.has_vjp
 SciMLBase.has_tgrad
+SciMLBase.has_paramjac
+SciMLBase.has_vjp_p
+SciMLBase.has_observed
 SciMLBase.has_initialization_data
 SciMLBase.has_sys
 ```
@@ -182,4 +185,6 @@ SciMLBase.TimeDerivativeWrapper
 SciMLBase.TimeGradientWrapper
 SciMLBase.UDerivativeWrapper
 SciMLBase.UJacobianWrapper
+SciMLBase.ParamJacobianWrapper
+SciMLBase.Void
 ```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2112,7 +2112,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # SciMLFunction derivative traits
 @public has_jac, has_jvp, has_vjp, has_tgrad, has_analytic, has_reinit,
-    has_initialization_data, has_stats, has_sys
+    has_initialization_data, has_stats, has_sys, has_paramjac, has_vjp_p, has_observed
 
 # Function-argument validation errors
 @public FunctionArgumentsError, TooFewArgumentsError, TooManyArgumentsError
@@ -2257,7 +2257,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
     generate_sim_seeds, default_rng_func, WeightedEnsembleSolution
 
 # AD / sensitivity function wrappers
-@public TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper
+@public TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper,
+    ParamJacobianWrapper, Void
 
 # Problem alias specifiers
 @public RODEAliasSpecifier, SDEAliasSpecifier

--- a/src/function_wrappers.jl
+++ b/src/function_wrappers.jl
@@ -150,24 +150,45 @@ UDerivativeWrapper(f::F, t, p) where {F} = UDerivativeWrapper{isinplace(f, 4)}(f
 (ff::UDerivativeWrapper{true})(u) = (du1 = similar(u); ff.f(du1, u, ff.p, ff.t); du1)
 
 """
-    ParamJacobianWrapper{iip, fType, tType, uType} <: AbstractWrappedFunction{iip}
+    ParamJacobianWrapper(f, t, u)
+    ParamJacobianWrapper{iip}(f, t, u)
 
-Wraps functions to compute Jacobians with respect to parameters `p`. This wrapper is essential for 
-parameter estimation, inverse problems, and sensitivity analysis with respect to model parameters.
+Wrap an ODE-style function as a function of parameters alone.
+
+# Arguments
+
+  - `f`: An in-place `f(du, u, p, t)` or out-of-place `f(u, p, t)` model function.
+  - `t`: The fixed independent-variable value.
+  - `u`: The fixed state value.
+  - `iip`: Whether `f` follows the in-place convention. The unparameterized constructor
+    infers it from `f`.
 
 # Fields
-- `f`: The function to wrap
-- `t`: Time value
-- `u`: State variables
+
+  - `f`: The wrapped model function.
+  - `t`: The fixed independent-variable value.
+  - `u`: The fixed state value.
 
 # Type Parameters
-- `iip`: Boolean indicating if the function is in-place (`true`) or out-of-place (`false`)
-- `fType`: Type of the wrapped function
-- `tType`: Type of the time variable
-- `uType`: Type of the state variables
 
-This wrapper enables efficient computation of `∂f/∂p` for parameter sensitivity analysis and
-optimization algorithms.
+  - `iip`: Whether the wrapped function is in-place.
+  - `fType`: Type of the wrapped function.
+  - `tType`: Type of the fixed independent-variable value.
+  - `uType`: Type of the fixed state value.
+
+# Usage
+
+```julia
+pf = ParamJacobianWrapper((u, p, t) -> p .* u, 0.0, [2.0])
+pf([3.0]) # [6.0]
+```
+
+# Developer Interface
+
+Sensitivity and solver packages use this wrapper when differentiating a model with
+respect to `p`. Call `pf(p)` to allocate an output or `pf(out, p)` to fill a provided
+output buffer. The fixed `u` and `t` values must be valid inputs for `f`; downstream
+code must use the callable interface rather than depending on the mutable field layout.
 """
 mutable struct ParamJacobianWrapper{iip, fType, tType, uType} <: AbstractWrappedFunction{iip}
     f::fType

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -5589,7 +5589,27 @@ It is only meaningful for function types with an explicit independent variable.
 has_tgrad(f::AbstractSciMLFunction) = __has_tgrad(f) && f.tgrad !== nothing
 has_Wfact(f::AbstractSciMLFunction) = __has_Wfact(f) && f.Wfact !== nothing
 has_Wfact_t(f::AbstractSciMLFunction) = __has_Wfact_t(f) && f.Wfact_t !== nothing
+"""
+    has_paramjac(f::AbstractSciMLFunction) -> Bool
+
+Return whether `f` carries a non-`nothing` parameter-Jacobian callback.
+
+When this returns `true`, sensitivity or solver code may use `f.paramjac` to evaluate
+the derivative of the model function with respect to parameters without selecting an
+automatic-differentiation fallback. The callback must follow the in-place or
+out-of-place convention of `f`.
+"""
 has_paramjac(f::AbstractSciMLFunction) = __has_paramjac(f) && f.paramjac !== nothing
+
+"""
+    has_vjp_p(f::AbstractSciMLFunction) -> Bool
+
+Return whether `f` carries a non-`nothing` parameter vector-Jacobian-product callback.
+
+When this returns `true`, sensitivity or solver code may use `f.vjp_p` to apply the
+adjoint derivative with respect to parameters without materializing a parameter
+Jacobian. The callback must follow the in-place or out-of-place convention of `f`.
+"""
 has_vjp_p(f::AbstractSciMLFunction) = __has_vjp_p(f) && f.vjp_p !== nothing
 """
     has_sys(f::AbstractSciMLFunction)
@@ -5732,6 +5752,15 @@ function has_paramsyms(f::AbstractSciMLFunction)
         !isempty(parameter_symbols(f))
     end
 end
+"""
+    has_observed(f::AbstractSciMLFunction) -> Bool
+
+Return whether `f` carries a non-default observed-quantity callback.
+
+Observed callbacks define derived quantities evaluated from a problem state, parameters,
+and independent variable. A `true` result means downstream code may use the documented
+observed-function interface; a `false` result means it must not inspect `f.observed`.
+"""
 function has_observed(f::AbstractSciMLFunction)
     return __has_observed(f) && f.observed !== DEFAULT_OBSERVED && f.observed !== nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -594,6 +594,36 @@ end
 # Overloaded in other repositories
 function unwrap_cache end
 
+"""
+    Void(f)
+
+Wrap `f` so every call returns `nothing` after evaluating `f`.
+
+# Arguments
+
+  - `f`: A callable whose side effects should be preserved while its return value is
+    discarded.
+
+# Returns
+
+A callable wrapper with the same positional arguments as `f` that always returns
+`nothing`.
+
+# Usage
+
+```julia
+values = Int[]
+push_nothing = Void(x -> push!(values, x))
+push_nothing(1) # nothing
+```
+
+# Developer Interface
+
+Use this wrapper when an in-place SciML callback must have `nothing` return semantics,
+including AD integration code that distinguishes mutation from an out-of-place return.
+`f` is still evaluated exactly once. Do not use `Void` to hide exceptions or to change
+the calling convention of `f`.
+"""
 struct Void{F}
     f::F
 end

--- a/test/existence_functions.jl
+++ b/test/existence_functions.jl
@@ -2,7 +2,8 @@ using Test, SciMLBase
 using SciMLBase: __has_jac, __has_tgrad, __has_Wfact, __has_Wfact_t,
     __has_paramjac, __has_analytic, __has_colorvec, has_jac,
     has_tgrad,
-    has_Wfact, has_Wfact_t, has_paramjac, has_analytic, has_colorvec, has_sys,
+    has_Wfact, has_Wfact_t, has_paramjac, has_vjp_p, has_observed, has_analytic,
+    has_colorvec, has_sys,
     AbstractDiffEqFunction
 using SymbolicIndexingInterface: SymbolCache
 
@@ -14,6 +15,37 @@ struct Foo <: AbstractDiffEqFunction{false}
     paramjac::Any
     analytic::Any
     colorvec::Any
+end
+
+struct SensitivityTraitFunction <: AbstractDiffEqFunction{false}
+    paramjac::Any
+    vjp_p::Any
+    observed::Any
+end
+
+@testset "Sensitivity function trait interface" begin
+    f = SensitivityTraitFunction(:paramjac, :vjp_p, :observed)
+    @test has_paramjac(f)
+    @test has_vjp_p(f)
+    @test has_observed(f)
+
+    missing = SensitivityTraitFunction(nothing, nothing, nothing)
+    @test !has_paramjac(missing)
+    @test !has_vjp_p(missing)
+    @test !has_observed(missing)
+end
+
+@testset "Sensitivity function wrapper interface" begin
+    pf = SciMLBase.ParamJacobianWrapper((u, p, t) -> p .* u, 0.0, [2.0])
+    @test pf([3.0]) == [6.0]
+    out = zeros(1)
+    @test pf(out, [4.0]) === out
+    @test out == [8.0]
+
+    values = Int[]
+    wrapped = SciMLBase.Void(x -> push!(values, x))
+    @test wrapped(1) === nothing
+    @test values == [1]
 end
 
 f = Foo(1, 1, 1, 1, 1, 1, 1)

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -301,6 +301,7 @@ if isdefined(Base, :ispublic)
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,
                 :keyword_arg_silent, Symbol("@add_kwonly"),
+                :has_paramjac, :has_vjp_p, :has_observed, :ParamJacobianWrapper, :Void,
             )
             @test Base.ispublic(SciMLBase, name)
             @test Base.Docs.hasdoc(SciMLBase, name)


### PR DESCRIPTION
## Summary
- publish the SciMLFunction sensitivity traits and parameter-Jacobian/Void wrappers as developer API
- document them at their definition sites and render them on the SciMLFunction interface page
- add generic trait and wrapper contract tests plus public-interface coverage

## Verification
- `Pkg.test()`
- `Pkg.test(; test_args=["QA"])`
- rendered local documentation build with cross-references
- Runic and `git diff --check`

The normal docs build still reaches the pre-existing `docs.sciml.ai` link-check 403; this PR does not alter link-check settings or add an ignore.

Ignore until reviewed by @ChrisRackauckas.