### PR TITLE
Publish sensitivity reconstruction developer API

### DIFF
--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -155,6 +155,7 @@ SciMLBase.postamble!
 ```@docs
 SciMLBase.OverrideInitData
 SciMLBase.get_initial_values
+SciMLBase.is_overdetermined_initialization
 ```
 
 ## Argument Validation

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -217,6 +217,7 @@ SciMLBase.OptimizationStats
 SciMLBase.build_solution
 SciMLBase.calculate_solution_errors!
 SciMLBase.solution_new_retcode
+SciMLBase.sensitivity_solution
 ```
 
 ### Interpolation Types

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2167,7 +2167,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
     requires_additive_noise
 
 # Initialization algorithms and interface
-@public NoInit, OverrideInit, get_initial_values
+@public NoInit, OverrideInit, get_initial_values, is_overdetermined_initialization
 @public OverrideInitData
 
 # Solution / integrator interface
@@ -2209,7 +2209,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public NoAD
 
 # Function-wrapper / solution interface helpers
-@public unwrapped_f, specialization, solution_new_retcode
+@public unwrapped_f, specialization, solution_new_retcode, sensitivity_solution
 @public parameterless_type, updated_u0_p, isdenseplot, plottable_indices
 @public isfunctionwrapper, wrapfun_oop, wrapfun_iip, unwrap_fw
 

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -430,3 +430,28 @@ function initialization_status(prob::AbstractSciMLProblem)
         return FULLY_DETERMINED
     end
 end
+
+"""
+    is_overdetermined_initialization(prob) -> Bool
+
+Return whether `prob` carries an initialization problem with more residual equations
+than unknown initial values.
+
+# Arguments
+
+  - `prob`: A SciML problem whose function may carry initialization metadata.
+
+# Returns
+
+`true` when the initialization problem is overdetermined, and `false` when it is
+fully determined, underdetermined, or absent.
+
+# Developer Interface
+
+Solver and sensitivity packages use this predicate to select initialization behavior
+without depending on SciMLBase's internal status enum. Implementations must query the
+problem's initialization metadata rather than caching the result across `remake` or
+parameter updates.
+"""
+is_overdetermined_initialization(prob::AbstractSciMLProblem) =
+    initialization_status(prob) === OVERDETERMINED

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -125,6 +125,35 @@ function strip_solution(sol::NonlinearSolution)
     return sol
 end
 
+"""
+    sensitivity_solution(sol, u)
+    sensitivity_solution(sol, u, t)
+
+Return a solution with state values replaced by sensitivity-compatible values.
+
+# Arguments
+
+  - `sol`: A nonlinear, ODE, or RODE solution whose solver metadata should be
+    preserved.
+  - `u`: Replacement state values, ordered consistently with the returned solution's
+    saved values.
+  - `t`: Replacement saved times for time-dependent solutions. This argument is not
+    used by nonlinear solutions.
+
+# Returns
+
+A solution of the same family as `sol`, preserving problem, algorithm, return-code,
+and solver metadata while replacing its state values and, for time-dependent solutions,
+saved times. Time-dependent solutions enable interpolation sensitivity mode.
+
+# Developer Interface
+
+Sensitivity packages call this after differentiating a solve to construct a result that
+retains the original solution's SciML interface. Methods must preserve all metadata not
+explicitly replaced and must require `u` and `t` to have compatible saved-value layouts.
+Packages defining a new public solution family may add a narrowly dispatched method when
+that family has a distinct reconstruction invariant.
+"""
 function sensitivity_solution(sol::AbstractNonlinearSolution, u)
     # Some of the subtypes might not have a trace field
     trace = hasfield(typeof(sol), :trace) ? sol.trace : nothing

--- a/test/initialization.jl
+++ b/test/initialization.jl
@@ -426,6 +426,7 @@ end
         fn = ODEFunction(rhs2; initialization_data)
         prob = ODEProblem(fn, [2.0, 0.0], (0.0, 1.0), 0.0)
         @test SciMLBase.initialization_status(prob) == SciMLBase.OVERDETERMINED
+        @test SciMLBase.is_overdetermined_initialization(prob)
     end
 
     @testset "Initialization status for underdetermined case" begin
@@ -439,7 +440,19 @@ end
         fn = ODEFunction(rhs2; initialization_data)
         prob = ODEProblem(fn, [2.0, 0.0], (0.0, 1.0), 0.0)
         @test SciMLBase.initialization_status(prob) == SciMLBase.UNDERDETERMINED
+        @test !SciMLBase.is_overdetermined_initialization(prob)
     end
+end
+
+@testset "Sensitivity solution developer interface" begin
+    prob = ODEProblem((u, p, t) -> u, [1.0], (0.0, 1.0))
+    sol = solve(prob, Tsit5(); saveat = [0.0, 1.0])
+    sensitivity_sol = SciMLBase.sensitivity_solution(sol, [[2.0], [3.0]], [0.0, 1.0])
+
+    @test sensitivity_sol.prob === sol.prob
+    @test sensitivity_sol.alg === sol.alg
+    @test sensitivity_sol.u == [[2.0], [3.0]]
+    @test sensitivity_sol.t == [0.0, 1.0]
 end
 
 @testset "NoInit" begin

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -301,6 +301,7 @@ if isdefined(Base, :ispublic)
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,
                 :keyword_arg_silent, Symbol("@add_kwonly"),
+                :is_overdetermined_initialization, :sensitivity_solution,
             )
             @test Base.ispublic(SciMLBase, name)
             @test Base.Docs.hasdoc(SciMLBase, name)


### PR DESCRIPTION
## Summary
- publish the stable overdetermined-initialization predicate and sensitivity-solution reconstruction hook as developer API
- document the definition-site contract and render both names in the canonical interfaces
- add initialization and solution-reconstruction contract tests plus public-interface coverage

## Verification
- `Pkg.test()`
- `Pkg.test(; test_args=["QA"])`
- rendered local documentation build with cross-references
- Runic and `git diff --check`

The normal docs build still reaches the pre-existing `docs.sciml.ai` link-check 403; this PR does not alter link-check settings or add an ignore.

Ignore until reviewed by @ChrisRackauckas.