### PR TITLE
ci: allow the downgrade job to fail until Enzyme's inactive_kwarg is public

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,4 +20,11 @@ jobs:
       # DifferentiationInterface is skipped: DI 0.6-0.7 requires ADTypes >= ~1.6,
       # but julia-downgrade-compat would pin ADTypes to 1.0.0 (minimum of compat "1"),
       skip: "DifferentiationInterface"
+      # The Enzyme floor cannot currently be stated: SciMLBaseEnzymeExt needs
+      # `EnzymeRules.inactive_kwarg` (Enzyme 0.13.100+), but that name is not yet
+      # public API upstream, so raising the compat floor to it would only trade a
+      # downgrade failure for a dependency on unsupported API (SciML/SciMLBase.jl#1457).
+      # Allowed to fail until EnzymeAD/Enzyme.jl#3428 lands and the floor can be raised;
+      # revert then.
+      continue-on-error: true
     secrets: "inherit"


### PR DESCRIPTION
Closes the CI half of #1457.

## Problem

The Julia LTS downgrade job resolves Enzyme 0.13.17, and precompiling `SciMLBaseEnzymeExt` then fails with `UndefVarError: inactive_kwarg not defined`. This reproduces on clean master.

Raising the Enzyme floor is not a valid fix on its own. `EnzymeRules.inactive_kwarg` first appears in Enzyme 0.13.100 (EnzymeCore 0.8.16), but on current Enzyme master (0.13.198 / EnzymeCore 0.8.21) its docstring still reads *"currently considered internal/experimental and may not respect semver"*, and it is neither exported nor declared `public`. So there is no released version where the floor would point at supported API, and `inactive`/`inactive_noinl` are not substitutes — they mark the whole call and its result inactive, whereas the extension needs keyword-only inactivity for a differentiable `solve`.

## Change

Mark the downgrade job as an allowed failure, with a comment recording why and when to revert. Nothing is skipped or silenced in the test suite itself — the job still runs and still reports the failure; it just stops blocking on a floor that cannot yet be stated.

## Dependencies and follow-up

- Needs SciML/.github#124, which adds the `continue-on-error` input to the reusable `downgrade.yml` (callers pin `@v1`, so that tag has to move before this takes effect).
- Upstream fix: EnzymeAD/Enzyme.jl#3428 makes `EnzymeRules.inactive_kwarg` public and bumps EnzymeCore to 0.8.22.
- Once that is released, the revert is: drop `continue-on-error` here, add an explicit `EnzymeCore` compat floor of `0.8.22` (the module that owns the name, rather than the `Enzyme` re-export), and raise the `Enzyme` floor to the first release carrying it.

## Testing

The `continue-on-error` plumbing was verified end-to-end against the reusable workflow branch, in a repo with no Julia project so the inner job is guaranteed to fail:

| caller passes | inner job conclusion | overall run conclusion |
|---|---|---|
| `continue-on-error: true` | `failure` | **`success`** |
| `continue-on-error: false` | `failure` | **`failure`** |

`actionlint` is clean on this workflow. The effect on this repo's own Downgrade check cannot be observed until SciML/.github#124 merges and `v1` moves; until then this PR's Downgrade run will still fail as it does on master.

Draft; should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eUfG5RgLbbZY4LRawwRG9
