### PR TITLE
Document callback and Mooncake developer APIs

### DIFF
--- a/docs/src/interfaces/Callbacks.md
+++ b/docs/src/interfaces/Callbacks.md
@@ -37,6 +37,7 @@ which is documented with the [symbolic save-index interface](@ref symbolic_save_
 SciMLBase.DECallback
 SciMLBase.AbstractContinuousCallback
 SciMLBase.AbstractDiscreteCallback
+SciMLBase.RootfindOpt
 SciMLBase.NoRootFind
 SciMLBase.LeftRootFind
 SciMLBase.RightRootFind

--- a/docs/src/interfaces/Differentiation.md
+++ b/docs/src/interfaces/Differentiation.md
@@ -111,6 +111,10 @@ order and must return the ordinary primal result together with the corresponding
 pullback or pushforward. It must preserve the primal solve semantics and may not mutate
 the problem or differentiated inputs.
 
+`set_mooncakeoriginator_if_mooncake` is the Mooncake overlay boundary for this
+protocol. Solver packages call it only while constructing their low-level
+originator keyword; application code must not call it.
+
 ```@docs
 SciMLBase.ADOriginator
 SciMLBase.ChainRulesOriginator
@@ -118,6 +122,7 @@ SciMLBase.EnzymeOriginator
 SciMLBase.ReverseDiffOriginator
 SciMLBase.TrackerOriginator
 SciMLBase.MooncakeOriginator
+SciMLBase.set_mooncakeoriginator_if_mooncake
 SciMLBase._concrete_solve_adjoint
 SciMLBase._concrete_solve_forward
 ```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2263,7 +2263,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Versioned automatic-differentiation concrete-solve extension API. These names are
 # deliberately not exported: application code selects a documented `sensealg` instead.
 @public ADOriginator, ChainRulesOriginator, EnzymeOriginator, ReverseDiffOriginator,
-    TrackerOriginator, MooncakeOriginator, _concrete_solve_adjoint, _concrete_solve_forward
+    TrackerOriginator, MooncakeOriginator, set_mooncakeoriginator_if_mooncake,
+    _concrete_solve_adjoint, _concrete_solve_forward
 
 # Function-wrapper / solution interface helpers
 @public unwrapped_f, specialization, solution_new_retcode, sensitivity_solution
@@ -2305,7 +2306,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Callback interface
 @public DECallback, AbstractContinuousCallback, AbstractDiscreteCallback,
-    NoRootFind, LeftRootFind, RightRootFind,
+    RootfindOpt, NoRootFind, LeftRootFind, RightRootFind,
     split_callbacks, save_final_discretes!, save_discretes_if_enabled!
 
 # Ensemble interface

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -3,6 +3,27 @@
 INITIALIZE_DEFAULT(cb, u, t, integrator) = derivative_discontinuity!(integrator, false)
 FINALIZE_DEFAULT(cb, u, t, integrator) = nothing
 
+"""
+    RootfindOpt
+
+Select how a continuous callback localizes a detected zero crossing.
+
+# Values
+
+- `NoRootFind`: apply the callback at the detected step endpoint without root localization.
+- `LeftRootFind`: localize the event and use the solution's left-limit value.
+- `RightRootFind`: localize the event and use the solution's right-limit value.
+
+# Usage
+
+```julia
+callback = ContinuousCallback(condition, affect!; rootfind = LeftRootFind)
+```
+
+The `rootfind` keyword of `ContinuousCallback` and `VectorContinuousCallback`
+accepts one of these values. `Bool` values remain accepted for compatibility and
+convert to `LeftRootFind` or `NoRootFind`.
+"""
 @enum RootfindOpt::Int8 begin
     NoRootFind = 0
     LeftRootFind = 1

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -481,6 +481,19 @@ _reshape(v, siz) = reshape(v, siz)
 _reshape(v::Number, siz) = v
 _reshape(v::AbstractSciMLScalarOperator, siz) = v
 
+"""
+    set_mooncakeoriginator_if_mooncake(originator::ADOriginator)
+
+Return the automatic-differentiation originator for a solver call, preserving
+`originator` in ordinary execution and switching to `MooncakeOriginator()` when
+Mooncake's overlay evaluates the call.
+
+# Developer API
+
+Solver and sensitivity packages pass a concrete `ADOriginator` through their
+low-level solve path so AD rules can dispatch on its origin. End-user code
+should not call this function or dispatch on its result.
+"""
 set_mooncakeoriginator_if_mooncake(x::SciMLBase.ADOriginator) = x
 
 # Copied from Static.jl https://github.com/SciML/Static.jl/blob/b50279cc9b33741fd60f382c789fbaef8622d964/src/Static.jl#L743

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -359,6 +359,7 @@ if isdefined(Base, :ispublic)
                 :has_paramjac, :has_vjp_p, :has_observed, :ParamJacobianWrapper, :Void,
                 :ADOriginator, :ChainRulesOriginator, :EnzymeOriginator,
                 :ReverseDiffOriginator, :TrackerOriginator, :MooncakeOriginator,
+                :set_mooncakeoriginator_if_mooncake,
                 :_concrete_solve_adjoint, :_concrete_solve_forward,
             )
             @test Base.ispublic(SciMLBase, name)
@@ -611,6 +612,7 @@ if isdefined(Base, :ispublic)
                 :VectorContinuousCallback,
                 :DiscreteCallback,
                 :CallbackSet,
+                :RootfindOpt,
                 :NoRootFind,
                 :LeftRootFind,
                 :RightRootFind,


### PR DESCRIPTION
## Summary
- declare and document `RootfindOpt` as the continuous-callback root-localization API
- declare and document `set_mooncakeoriginator_if_mooncake` as a developer-only AD integration hook
- add rendered API entries and public-declaration coverage

## Verification
- `julia --project -e 'using Test, SciMLBase; include("test/public_interface.jl")'`\n- full docs build reached Documenter checks but failed only on the existing external linkcheck 403 for `https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/`\n\nIgnore until reviewed by @ChrisRackauckas.