### PR TITLE
Publish solver code-generation developer APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.43.1"
+version = "3.44.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -47,6 +47,15 @@ SciMLBase.value
 SciMLBase.unitfulvalue
 ```
 
+## Solver Code-Generation Utilities
+
+These utilities support solver implementation code and are not application-facing API.
+
+```@docs
+SciMLBase.@def
+SciMLBase._unwrap_val
+```
+
 ## Solution Construction Hooks
 
 Solver packages use these hooks after finishing a linear or eigenvalue solve. They preserve

--- a/docs/src/interfaces/Internal_API.md
+++ b/docs/src/interfaces/Internal_API.md
@@ -22,7 +22,6 @@ SciMLBase.AbstractReactionNetwork
 ## Construction And Remake
 
 ```@docs
-SciMLBase.@def
 SciMLBase.num_types_in_tuple
 SciMLBase._get_new_A_b
 SciMLBase.UpdateABWrapper

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2245,7 +2245,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Versioned solver-author extension API. These names are deliberately not exported:
 # application code should use the user-facing solve and solution interfaces instead.
 @public enable_interpolation_sensitivitymode, get_root_indp, has_initializeprob,
-    late_binding_update_u0_p, strip_interpolation, unitfulvalue, value, last_step_failed
+    late_binding_update_u0_p, strip_interpolation, unitfulvalue, value, last_step_failed,
+    @def, _unwrap_val
 
 # Versioned symbolic-system and input-preparation extension API
 @public RemakeInitializationDataContext, remake_initialization_data,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -413,6 +413,45 @@ get_colorizers(io::IO) = get(io, :color, false) ? (TYPE_COLOR, NO_COLOR) : ("", 
 
 """
     @def name definition
+
+Define a zero-argument macro named `@name` whose expansion is `definition`.
+
+Solver packages use `@def` to define repeated preambles that must expand in the
+generated macro's invocation scope.
+
+# Arguments
+
+- `name`: The name of the macro to define, without the leading `@`.
+- `definition`: The expression returned when the generated macro is expanded.
+
+# Returns
+
+An expression that defines `@name` in the module where `@def` is invoked.
+
+# Extension Rules
+
+Invoke `@def` at module scope and invoke the generated macro without arguments. Names in
+`definition` resolve in the generated macro's invocation scope, so each invocation must
+provide every referenced local. Do not extend `@def` or use it to define user-facing API.
+
+# Examples
+
+```julia
+module ExampleSolver
+using SciMLBase: @def
+
+@def affine_preamble begin
+    shifted = x + offset
+end
+
+function evaluate(x, offset)
+    @affine_preamble
+    return shifted
+end
+end
+
+ExampleSolver.evaluate(2, 3) # 5
+```
 """
 macro def(name, definition)
     return quote
@@ -649,6 +688,39 @@ function mergedefaults(defaults, varmap, vars)
     end
 end
 
+"""
+    _unwrap_val(::Val{B}) where {B}
+    _unwrap_val(x)
+
+Return the value encoded by a `Val`, or return any other input unchanged.
+
+Solver constructors use `_unwrap_val` for options that accept either a compile-time
+`Val` marker or an ordinary runtime value.
+
+# Arguments
+
+- `x`: A `Val` instance or a value that should pass through unchanged.
+
+# Returns
+
+The type parameter `B` for `Val{B}()`; otherwise `x` itself, preserving its type and
+identity.
+
+# Extension Rules
+
+Call `_unwrap_val` only when both `Val` and runtime-value forms are part of the option's
+documented contract. Downstream packages should not add methods; support for another
+wrapper type must be implemented in SciMLBase.
+
+# Examples
+
+```julia
+using SciMLBase: _unwrap_val
+
+_unwrap_val(Val(true)) # true
+_unwrap_val(:runtime) # :runtime
+```
+"""
 _unwrap_val(::Val{B}) where {B} = B
 _unwrap_val(B) = B
 

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -1,5 +1,20 @@
 using SciMLBase, Test
 
+module ExternalSolverUtilities
+    using SciMLBase: @def, _unwrap_val
+
+    @def affine_preamble begin
+        shifted = x + offset
+    end
+
+    function evaluate(x, offset)
+        @affine_preamble
+        return shifted
+    end
+
+    unwrap(x) = _unwrap_val(x)
+end
+
 struct ProblemTypeTestProblem <: SciMLBase.AbstractSciMLProblem end
 struct ProblemTypeTestMarker end
 struct ProblemTypeTestSolution
@@ -459,6 +474,14 @@ end
     end
 end
 
+@testset "Solver code-generation developer API" begin
+    @test ExternalSolverUtilities.evaluate(2, 3) == 5
+    @test ExternalSolverUtilities.unwrap(Val(:compile_time)) === :compile_time
+
+    runtime_value = Ref(1)
+    @test ExternalSolverUtilities.unwrap(runtime_value) === runtime_value
+end
+
 if isdefined(Base, :ispublic)
     @testset "Extension hooks public API" begin
         for name in (
@@ -466,6 +489,7 @@ if isdefined(Base, :ispublic)
                 :done, :postamble!, :enable_interpolation_sensitivitymode,
                 :get_root_indp, :has_initializeprob, :late_binding_update_u0_p,
                 :strip_interpolation, :unitfulvalue, :value, :last_step_failed,
+                Symbol("@def"), :_unwrap_val,
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,
                 :keyword_arg_silent, Symbol("@add_kwonly"),


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- declare `@def` and `_unwrap_val` as unexported, versioned solver-developer API
- add SciMLStyle definition-site docstrings with signatures, contracts, extension rules,
  and executable usage examples
- render both APIs on the warned developer reference page
- test downstream code generation, public visibility, and docstring availability
- bump SciMLBase from 3.43.1 to 3.44.0 for the new public developer API

The instability hooks from the previous revision are intentionally excluded because their
interfaces are expected to change. This PR does not change SciMLTesting configuration, QA
ignores, package sources, dependencies, or unrelated implementation code. Current master
already runs its strict QA through SciMLTesting 2.6.

## Local verification

- release `Pkg.test(; test_args = ["Core"])`: passed
- LTS `Pkg.test(; test_args = ["Core"])`: passed
- release/LTS public-interface tests: `209/209` passed on each
- release/LTS Remake tests: `4430/4430` passed on each
- release strict QA: Quality Assurance `20/20`, AllocCheck `6/6`, extensions `16/16`,
  Aqua `2/2` and `6/6`
- LTS strict QA: Quality Assurance `18/18`, AllocCheck `6/6`, extensions `16/16`,
  Aqua `2/2` and `6/6`
- Runic `--check --diff` over every tracked Julia file: passed
- `git diff --check`: passed

On release and LTS, Documenter completed doctests, template expansion, cross-references,
and document checks, then strict link checking failed on the pre-existing
`https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/` HTTP 403. The same
failure was reproduced from a fresh worktree at current clean master. #1485 is the existing
narrow fix for that baseline failure and has a green Documentation check; this PR does not
hide or duplicate it.
