### PR TITLE
Keep SciML function trait docs at definition sites

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -5671,62 +5671,6 @@ functions. Solvers should query this trait before using those hooks.
 function has_initialization_data(f)
     return __has_initialization_data(f) && f.initialization_data !== nothing
 end
-@doc """
-    has_analytic(f::AbstractSciMLFunction)
-
-Return whether `f` carries a non-`nothing` analytic solution callback.
-
-Analytic callbacks are optional and are mainly used by solvers and tests to
-compare numerical and exact solutions. The expected callback signature depends
-on the concrete function type, matching the independent variables described by
-that type's docstring.
-""" has_analytic
-@doc """
-    has_jac(f::AbstractSciMLFunction)
-
-Return whether `f` carries a non-`nothing` Jacobian callback.
-
-For differential equation functions this is usually the Jacobian with respect to
-the state variable. For implicit functions such as DAEs, the concrete function
-docstring defines the Jacobian convention. Solver code should query this trait
-before accessing `f.jac`.
-""" has_jac
-@doc """
-    has_jvp(f::AbstractSciMLFunction)
-
-Return whether `f` carries a non-`nothing` Jacobian-vector product callback.
-
-When true, solvers may use `f.jvp` to apply the Jacobian to a direction without
-materializing the full Jacobian. The callback must follow the in-place or
-out-of-place convention of the concrete function wrapper.
-""" has_jvp
-@doc """
-    has_vjp(f::AbstractSciMLFunction)
-
-Return whether `f` carries a non-`nothing` vector-Jacobian product callback.
-
-When true, solvers or sensitivity algorithms may use `f.vjp` to apply the
-adjoint Jacobian action without materializing the full Jacobian. The callback
-signature is defined by the concrete function type.
-""" has_vjp
-@doc """
-    has_tgrad(f::AbstractSciMLFunction)
-
-Return whether `f` carries a non-`nothing` time-gradient callback.
-
-The time-gradient callback represents the derivative of the model function with
-respect to the independent variable while holding the state and parameters fixed.
-It is only meaningful for function types with an explicit independent variable.
-""" has_tgrad
-@doc """
-    has_initialization_data(f)
-
-Return whether `f` carries non-`nothing` initialization metadata.
-
-Initialization data stores problem-level initialization hooks such as an
-initialization problem, an updater for that problem, and parameter/state mapping
-functions. Solvers should query this trait before using those hooks.
-""" has_initialization_data
 has_polynomialize(f) = __has_polynomialize(f) && f.polynomialize !== nothing
 has_unpolynomialize(f) = __has_unpolynomialize(f) && f.unpolynomialize !== nothing
 has_denominator(f) = __has_denominator(f) && f.denominator !== nothing

--- a/test/existence_functions.jl
+++ b/test/existence_functions.jl
@@ -35,6 +35,18 @@ end
     @test !has_observed(missing)
 end
 
+@testset "Documented function trait interface" begin
+    if isdefined(Base, :ispublic)
+        for name in (
+                :has_analytic, :has_jac, :has_jvp, :has_vjp, :has_tgrad,
+                :has_initialization_data,
+            )
+            @test Base.ispublic(SciMLBase, name)
+            @test Base.Docs.hasdoc(SciMLBase, name)
+        end
+    end
+end
+
 @testset "Sensitivity function wrapper interface" begin
     pf = SciMLBase.ParamJacobianWrapper((u, p, t) -> p .* u, 0.0, [2.0])
     @test pf([3.0]) == [6.0]

--- a/test/existence_functions.jl
+++ b/test/existence_functions.jl
@@ -35,18 +35,6 @@ end
     @test !has_observed(missing)
 end
 
-@testset "Documented function trait interface" begin
-    if isdefined(Base, :ispublic)
-        for name in (
-                :has_analytic, :has_jac, :has_jvp, :has_vjp, :has_tgrad,
-                :has_initialization_data,
-            )
-            @test Base.ispublic(SciMLBase, name)
-            @test Base.Docs.hasdoc(SciMLBase, name)
-        end
-    end
-end
-
 @testset "Sensitivity function wrapper interface" begin
     pf = SciMLBase.ParamJacobianWrapper((u, p, t) -> p .* u, 0.0, [2.0])
     @test pf([3.0]) == [6.0]


### PR DESCRIPTION
## Summary
- remove duplicate `@doc` propagation for SciML function traits
- retain the SciMLStyle docstrings immediately above each defining method
- assert the affected trait bindings remain public and documented

## Validation
- `test/existence_functions.jl` (`26/26` passed)
- Runic on touched files

Ignore until reviewed by @ChrisRackauckas.