### PR TITLE
Build SciMLBase docs from the checkout

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,8 @@
+using Pkg
+
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+Pkg.instantiate()
+
 using Documenter, SciMLBase
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)


### PR DESCRIPTION
## Summary
- develop the SciMLBase repository root at documentation-build time
- make Documenter inspect the branch under test instead of the registry SciMLBase version pinned in `docs/Manifest.toml`
- leave `docs/Project.toml` free of path-based `[sources]` configuration

## Validation
- local docs build reached Documenter without `no docs found` errors for current public bindings
- it then failed only on the pre-existing external `Problem_Traits` linkcheck `403`, which this PR does not ignore or suppress
- Runic on `docs/make.jl`

Ignore until reviewed by @ChrisRackauckas.