### PR TITLE
fix: respect `tspan` when plotting non-dense solutions

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -181,9 +181,8 @@ function Makie.convert_arguments(
         partition = sol.discretes[tsidx]
         ts = current_time(partition)
         if tspan !== nothing
-            tstart = searchsortedfirst(ts, tspan[1])
-            tend = searchsortedlast(ts, tspan[2])
-            if tstart == lastindex(ts) + 1 || tend == firstindex(ts) - 1
+            tstart, tend = SciMLBase.tspan_indices(ts, tspan)
+            if tstart > tend
                 continue
             end
         else

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -411,9 +411,8 @@ plottable_indices(x::Number) = 1
         partition = sol.discretes[tsidx]
         ts = current_time(partition)
         if tspan !== nothing
-            tstart = searchsortedfirst(ts, tspan[1])
-            tend = searchsortedlast(ts, tspan[2])
-            if tstart == lastindex(ts) + 1 || tend == firstindex(ts) - 1
+            tstart, tend = tspan_indices(ts, tspan)
+            if tstart > tend
                 continue
             end
         else
@@ -447,20 +446,33 @@ plottable_indices(x::Number) = 1
     end
 end
 
+"""
+    $(TYPEDSIGNATURES)
+
+Return the first and last index of the sorted time vector `t` whose times lie within
+`tspan`. `tspan` and `t` may run in either time direction. The returned range is empty
+if no time point lies within `tspan`.
+"""
+function tspan_indices(t, tspan)
+    lo, hi = minmax(tspan[1], tspan[end])
+    if length(t) > 1 && t[end] < t[1]
+        return searchsortedfirst(t, hi; rev = true), searchsortedlast(t, lo; rev = true)
+    else
+        return searchsortedfirst(t, lo), searchsortedlast(t, hi)
+    end
+end
+
 function diffeq_to_arrays(
         sol, plot_analytic, denseplot, plotdensity, tspan,
         vars, tscale, plotat
     )
+    last_idx = sol.tslocation == 0 ? lastindex(sol.t) : sol.tslocation
     if tspan === nothing
-        if sol.tslocation == 0
-            end_idx = length(sol.t)
-        else
-            end_idx = sol.tslocation
-        end
-        start_idx = 1
+        start_idx = firstindex(sol.t)
+        end_idx = last_idx
     else
-        start_idx = searchsortedfirst(sol.t, tspan[1])
-        end_idx = searchsortedlast(sol.t, tspan[end])
+        start_idx, end_idx = tspan_indices(sol.t, tspan)
+        end_idx = min(end_idx, last_idx)
     end
 
     # determine type of spacing for plot
@@ -502,26 +514,18 @@ function diffeq_to_arrays(
         end
     else
         # Plot for sparse output: use the timeseries itself
-        if sol.tslocation == 0
-            plott = sol.t
-            plot_timeseries = DiffEqArray(sol.u, sol.t)
-            if plot_analytic
-                plot_analytic_timeseries = sol.u_analytic
-            else
-                plot_analytic_timeseries = nothing
-            end
+        plott = sol.t[start_idx:end_idx]
+        if isempty(plott)
+            throw(
+                ArgumentError(
+                    "The solution has no saved time points within `tspan = $(tspan)`. Use `denseplot = true` or `plotat` to plot the interpolation over this interval instead."
+                )
+            )
+        end
+        if plot_analytic
+            plot_analytic_timeseries = sol.u_analytic[start_idx:end_idx]
         else
-            if tspan === nothing
-                plott = sol.t[start_idx:end_idx]
-            else
-                plott = collect(densetspacer(tspan[1], tspan[2], plotdensity))
-            end
-
-            if plot_analytic
-                plot_analytic_timeseries = sol.u_analytic[start_idx:end_idx]
-            else
-                plot_analytic_timeseries = nothing
-            end
+            plot_analytic_timeseries = nothing
         end
     end
 

--- a/test/downstream/comprehensive_indexing.jl
+++ b/test/downstream/comprehensive_indexing.jl
@@ -1035,6 +1035,16 @@ end
                 @test_nowarn plot(sol; idxs = idx)
             end
         end
+
+        @testset "`tspan` crops discrete timeseries" begin
+            for idx in (ud1, ud2)
+                x = plot(sol; idxs = idx, tspan = (0.4, 0.6)).series_list[1][:x]
+                @test !isempty(x)
+                @test all(t -> 0.4 <= t <= 0.6, x)
+            end
+            # No discrete save point in the window, so there is nothing to draw
+            @test isempty(plot(sol; idxs = ud1, tspan = (10.0, 20.0)).series_list)
+        end
     end
 
     @testset "`initialize_save_discretes`" begin

--- a/test/downstream/plot_lines.jl
+++ b/test/downstream/plot_lines.jl
@@ -22,3 +22,32 @@ end
     converted = Makie.convert_arguments(Makie.Lines, sol)
     @test !isempty(converted)
 end
+
+@testset "tspan crops the plotted series" begin
+    using Plots: Plots, plot
+    sparse_sol = solve(prob, Tsit5(), dense = false)
+    window = (10.0, 20.0)
+
+    for (s, dense) in ((sol, true), (sol, false), (sparse_sol, false))
+        x = plot(s; idxs = 1, denseplot = dense, tspan = window).series_list[1][:x]
+        @test !isempty(x)
+        @test all(t -> window[1] <= t <= window[2], x)
+    end
+
+    # A sparse plot draws exactly the saved points inside the window
+    x = plot(sparse_sol; idxs = 1, tspan = window).series_list[1][:x]
+    @test x == filter(t -> window[1] <= t <= window[2], sparse_sol.t)
+
+    @test_throws ArgumentError plot(sparse_sol; idxs = 1, tspan = (200.0, 300.0))
+end
+
+@testset "tspan crops solutions integrated backwards in time" begin
+    using Plots: Plots, plot
+    decay_prob = ODEProblem((u, p, t) -> -0.01 * u, 1.0, (100.0, 0.0))
+    backwards_sol = solve(decay_prob, Tsit5(), dense = false, saveat = 1.0)
+
+    for window in ((80.0, 20.0), (20.0, 80.0))
+        x = plot(backwards_sol; tspan = window).series_list[1][:x]
+        @test extrema(x) == (20.0, 80.0)
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/SciML/SciMLBase.jl/issues/1498.

**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`plot(sol; tspan = (300, 400))` drew the full trajectory when `sol` was solved with `dense = false`, while a dense solution cropped correctly (reported against Makie, but the Plots recipe shares the code path).

`diffeq_to_arrays` computes `start_idx`/`end_idx` from `tspan`, but the sparse (`denseplot = false`) branch ignored them whenever `sol.tslocation == 0` — i.e. in every non-animated plot — and used `plott = sol.t` instead:

https://github.com/SciML/SciMLBase.jl/blob/7d6af028da357849741acf56a6abe3501a8b30fb/src/solutions/solution_interface.jl#L505-L512

## Fix

- The sparse branch now uses `sol.t[start_idx:end_idx]`. The `tslocation == 0` and `tslocation != 0` cases are unified; the latter also built `plott` from `densetspacer` while cropping `plot_analytic_timeseries` with `start_idx:end_idx`, so the two had mismatched lengths when `tspan` was given.
- New internal `tspan_indices` helper handles solutions integrated backwards in time. `searchsortedfirst` on a decreasing `sol.t` returns meaningless indices; that did not matter while these indices were unused on this path, but it does now.
- A `tspan` containing no saved time point now throws an `ArgumentError` pointing at `denseplot = true` / `plotat`, instead of a `BoundsError` thrown from the `DiffEqArray` constructor deep inside the interpolation.
- The discrete-timeseries blocks in the recipe and in the Makie extension reuse the same helper. Their emptiness check is now `tstart > tend`, which also covers a window falling strictly between two save points — previously that reached `repeat([2, 0], length(ts) - 1)` with `length(ts) == 0` and errored.

Note that a sparse plot draws exactly the saved points inside the window, so the line stops at the last saved point rather than at the `tspan` edge. That is the same data the un-cropped sparse plot shows; `denseplot = true` or `plotat` gives edge-to-edge coverage.

## Tests

Added to `test/downstream/plot_lines.jl`:
- `tspan` crops the series for dense and sparse solutions, and the sparse series is exactly the saved points inside the window.
- A window with no saved points throws `ArgumentError`.
- Cropping works for solutions integrated backwards in time, with `tspan` given in either direction.

Added to the existing `Plotting` testset in `test/downstream/comprehensive_indexing.jl`: `tspan` crops discrete (clocked) timeseries, and a window with no discrete save point drops the series.

## Local runs

```
$ julia --project=test/downstream test/downstream/plot_lines.jl
Test Summary:                                      | Pass  Total     Time
Makie convert_arguments on multi-state ODESolution |    1      1  1m39.6s
Test Summary:                  | Pass  Total  Time
tspan crops the plotted series |    8      8  1.6s
Test Summary:                                      | Pass  Total  Time
tspan crops solutions integrated backwards in time |    2      2  2.8s

$ julia --project=test/downstream test/downstream/comprehensive_indexing.jl
Test Summary:          | Pass  Total   Time
Discrete save indexing |  354    354  48.4s
... (all testsets pass)
```

Checking the issue's scenario through `Makie.convert_arguments` directly, on a non-dense solution over `(0.0, 1000.0)` with `tspan = (300, 400)`:

```
before: sparse: n=20   range=(0.0, 1000.0)
after:  sparse: n=2    range=(302.3, 364.5)     # the saved points in the window
        dense:  n=1000 range=(300.0, 400.0)     # unchanged
```

Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hUGbwsEJnHYjTEX7i77L4