### PR TITLE
Keep Makie tspan indexing private

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -10,6 +10,15 @@ using Makie: Makie, Lines, Plot, PlotSpec
 
 import Makie.SpecApi as S
 
+function _tspan_indices(t, tspan)
+    lo, hi = minmax(tspan[1], tspan[end])
+    if length(t) > 1 && t[end] < t[1]
+        return searchsortedfirst(t, hi; rev = true), searchsortedlast(t, lo; rev = true)
+    else
+        return searchsortedfirst(t, lo), searchsortedlast(t, hi)
+    end
+end
+
 function ensure_plottrait(PT::Type, arg, desired_plottrait_type::Type)
     return if !(Makie.conversion_trait(PT, arg) isa desired_plottrait_type)
         error(
@@ -181,7 +190,7 @@ function Makie.convert_arguments(
         partition = sol.discretes[tsidx]
         ts = current_time(partition)
         if tspan !== nothing
-            tstart, tend = SciMLBase.tspan_indices(ts, tspan)
+            tstart, tend = _tspan_indices(ts, tspan)
             if tstart > tend
                 continue
             end

--- a/test/downstream/comprehensive_indexing.jl
+++ b/test/downstream/comprehensive_indexing.jl
@@ -4,6 +4,7 @@ using ModelingToolkit, JumpProcesses, LinearAlgebra, NonlinearSolve, Optimizatio
     DiffEqCallbacks, Test, Plots
 import Symbolics
 import SymbolicUtils as SU
+import Makie
 using ModelingToolkit: t_nounits as t, D_nounits as D
 
 # Sets rnd number.
@@ -1041,9 +1042,28 @@ end
                 x = plot(sol; idxs = idx, tspan = (0.4, 0.6)).series_list[1][:x]
                 @test !isempty(x)
                 @test all(t -> 0.4 <= t <= 0.6, x)
+
+                specs = Makie.convert_arguments(
+                    Makie.Lines, sol; idxs = idx, tspan = (0.4, 0.6)
+                )
+                @test !isempty(specs)
+                points = Iterators.flatten(only(spec.args) for spec in specs)
+                lo, hi = Float32.((0.4, 0.6))
+                @test all(point -> lo <= point[1] <= hi, points)
             end
             # No discrete save point in the window, so there is nothing to draw
             @test isempty(plot(sol; idxs = ud1, tspan = (10.0, 20.0)).series_list)
+            @test isempty(
+                Makie.convert_arguments(
+                    Makie.Lines, sol; idxs = ud1, tspan = (10.0, 20.0)
+                )
+            )
+
+            makie_ext = Base.get_extension(SciMLBase, :SciMLBaseMakieExt)
+            @test makie_ext._tspan_indices([0.2, 0.4, 0.6, 0.8], (0.65, 0.35)) ==
+                (2, 3)
+            @test makie_ext._tspan_indices([0.8, 0.6, 0.4, 0.2], (0.35, 0.65)) ==
+                (2, 3)
         end
     end
 


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- keep `SciMLBase.tspan_indices` private
- restore a Makie-extension-local index helper for cropped discrete saves
- cover ascending/decreasing time vectors, reversed spans, cropped coordinates, and empty windows

The private qualified access was introduced by `dd269bb9e` (#1499); its parent used extension-local `searchsorted*` calls.

## Local verification
- clean master release QA reproduced the sole error: private `tspan_indices` access
- fixed release QA: 51/51 passed
- fixed Julia 1.10 QA: 49/49 passed
- release comprehensive indexing file: 361/361 discrete-save indexing checks passed; file exited zero
- Julia 1.10 focused extension behavior: 3/3 passed
- repository-wide Runic: passed
- `git diff --check`: passed