### PR TITLE
Render all SciMLBase definition-site documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,6 @@ makedocs(
     authors = "Chris Rackauckas",
     modules = [SciMLBase],
     clean = true, doctest = true, linkcheck = true,
-    warnonly = [:docs_block, :missing_docs],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/SciMLBase/stable"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -26,6 +26,7 @@ pages = [
         "interfaces/Common_Keywords.md",
         "interfaces/Differentiation.md",
         "interfaces/PDE.md",
+        "interfaces/Internal_API.md",
     ],
     "Fundamentals" => Any["fundamentals/FAQ.md"],
 ]

--- a/docs/src/interfaces/Clocks.md
+++ b/docs/src/interfaces/Clocks.md
@@ -22,5 +22,6 @@ SciMLBase.iseventclock
 SciMLBase.is_discrete_time_domain
 SciMLBase.first_clock_tick_time
 SciMLBase.IndexedClock
+Base.getindex(::SciMLBase.AbstractClock, ::Any)
 SciMLBase.canonicalize_indexed_clock
 ```

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -17,7 +17,27 @@ SciMLBase.strip_interpolation
 ```@docs
 SciMLBase.get_root_indp
 SciMLBase.has_initializeprob
+SciMLBase.RemakeInitializationDataContext
+SciMLBase.remake_initialization_data
+SciMLBase.LateBindingUpdateU0PContext
 SciMLBase.late_binding_update_u0_p
+SciMLBase.detect_cycles
+SciMLBase.get_updated_symbolic_problem
+```
+
+## Symbolic Linear Problem Hooks
+
+```@docs
+SciMLBase.SymbolicLinearInterface
+SciMLBase.get_new_A_b
+```
+
+## Function Preparation Hooks
+
+```@docs
+SciMLBase.prepare_initial_state
+SciMLBase.prepare_function
+SciMLBase.widen_bounded_type_params
 ```
 
 ## Numeric Wrapper Hooks
@@ -42,6 +62,9 @@ SciMLBase.build_eigenvalue_solution
 
 ```@docs
 SciMLBase.last_step_failed
+SciMLBase.AbstractDEOptions
+SciMLBase.ODENLStepData
+SciMLBase.JacobianWrapper
 ```
 
 ## Solver Preparation Hooks

--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -19,6 +19,14 @@ SciMLBase.DEFAULT_OUTPUT_FUNC
 SciMLBase.DEFAULT_REDUCTION
 ```
 
+`WeightedEnsembleProblem` delegates ordinary problem properties to its wrapped
+ensemble problem and adds the `weights` property:
+
+```@docs
+Base.propertynames(::SciMLBase.WeightedEnsembleProblem)
+Base.getproperty(::SciMLBase.WeightedEnsembleProblem, ::Symbol)
+```
+
 ### Solving the Problem
 
 ```@docs

--- a/docs/src/interfaces/Internal_API.md
+++ b/docs/src/interfaces/Internal_API.md
@@ -1,0 +1,73 @@
+# Internal Implementation Reference
+
+!!! warning "Private implementation details"
+    The bindings on this page are not public API. They are rendered so that every
+    intentional SciMLBase docstring is checked by Documenter, not to establish an
+    extension contract. Downstream packages must use the public interfaces documented
+    on the other interface pages.
+
+## Problem Representation
+
+```@docs
+SciMLBase.AbstractSplitSDEProblem
+SciMLBase.AbstractDynamicalSDEProblem
+SciMLBase.StandardSDEProblem
+SciMLBase.AbstractIncrementingODEProblem
+SciMLBase.DEElement
+SciMLBase.DESensitivity
+SciMLBase.AbstractWrappedFunction
+SciMLBase.AbstractReactionNetwork
+```
+
+## Construction And Remake
+
+```@docs
+SciMLBase.@def
+SciMLBase.num_types_in_tuple
+SciMLBase._get_new_A_b
+SciMLBase.UpdateABWrapper
+SciMLBase._similar_namedtuple_merge_ignore_nothing
+SciMLBase._has_type_erased_params
+SciMLBase._reconstruct_as_type
+SciMLBase.handle_varmap
+SciMLBase.warn_paramtype
+```
+
+## Initialization
+
+```@docs
+SciMLBase.evaluate_f
+SciMLBase._evaluate_f
+SciMLBase._vec
+```
+
+## Interpolation
+
+```@docs
+SciMLBase.tspan_indices
+SciMLBase.interpolant
+SciMLBase.interpolant!
+SciMLBase.interpolation
+SciMLBase.interpolation!
+SciMLBase.linear_interpolant
+SciMLBase.linear_interpolant!
+SciMLBase.hermite_interpolant
+SciMLBase.hermite_interpolant!
+```
+
+## Symbolic Save Selection
+
+```@docs
+SciMLBase.translate_symbolic_save_idxs
+SciMLBase._invalid_save_idxs_symbol_error
+```
+
+## Diagnostics And Maintenance
+
+```@docs
+SciMLBase.@CSI_str
+SciMLBase.strip_solution
+SciMLBase.controller_kwargs
+SciMLBase.undefined_exports
+SciMLBase._has_sciml_in_stacktrace
+```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1038,12 +1038,28 @@ abstract type AbstractDiffEqInterpolation end
 """
 $(TYPEDEF)
 
-Reserved supertype for differential-equation solver option containers.
+Developer interface for differential-equation solver option containers.
 
 SciMLBase currently stores most common solve options as keyword arguments rather
 than through concrete `AbstractDEOptions` subtypes. The abstract type remains as
 a compatibility hook for solver packages that need to share option-container
 types without introducing a dependency cycle.
+
+# Extension Rules
+
+Solver packages may subtype `AbstractDEOptions` for a concrete options container.
+The subtype owns its fields and constructors; SciMLBase does not require a field
+layout. User-facing options must still be accepted through the documented `solve`
+and `init` keywords, and a solver must not require applications to inspect the
+container directly.
+
+# Example
+
+```julia
+struct MySolverOptions{T} <: SciMLBase.AbstractDEOptions
+    abstol::T
+end
+```
 """
 abstract type AbstractDEOptions end
 
@@ -2152,7 +2168,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Solution / problem support types
 @public NLStats, NullParameters, AbstractSpecialization, AutoSpecialize,
-    AbstractOptimizationCache, DefaultOptimizationCache, OptimizationStats
+    AbstractOptimizationCache, DefaultOptimizationCache, OptimizationStats,
+    AbstractDEOptions, ODENLStepData
 
 # Core functions
 @public build_solution, build_linear_solution, build_eigenvalue_solution, numargs
@@ -2229,6 +2246,12 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # application code should use the user-facing solve and solution interfaces instead.
 @public enable_interpolation_sensitivitymode, get_root_indp, has_initializeprob,
     late_binding_update_u0_p, strip_interpolation, unitfulvalue, value, last_step_failed
+
+# Versioned symbolic-system and input-preparation extension API
+@public RemakeInitializationDataContext, remake_initialization_data,
+    LateBindingUpdateU0PContext, detect_cycles, get_updated_symbolic_problem,
+    SymbolicLinearInterface, get_new_A_b, widen_bounded_type_params,
+    prepare_initial_state, prepare_function
 
 # Problem types and alias specifiers
 @public ImmutableODEProblem, ImmutableNonlinearProblem, NonlinearAliasSpecifier
@@ -2316,7 +2339,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # AD / sensitivity function wrappers
 @public TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper,
-    ParamJacobianWrapper, Void
+    ParamJacobianWrapper, JacobianWrapper, Void
 
 # Problem alias specifiers
 @public RODEAliasSpecifier, SDEAliasSpecifier

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -235,12 +235,27 @@ struct IndexedClock{C <: AbstractClock, I}
     idx::I
 end
 
-# public
 """
-    $(TYPEDSIGNATURES)
+    Base.getindex(clock::AbstractClock, idx) -> IndexedClock
 
-Return a `SciMLBase.IndexedClock` representing the subset of the time points that the clock
-ticked indicated by `idx`.
+Select one or more tick indices from `clock` without resolving them to times.
+
+# Arguments
+
+- `clock`: A SciML clock whose ticks will be selected.
+- `idx`: An integer, integer collection, range, or `Colon()` selector.
+
+# Returns
+
+- [`IndexedClock`](@ref): A lazy clock/index pair. A solution resolves the pair to
+  concrete independent-variable values when it is interpolated.
+
+# Example
+
+```julia
+indexed_clock = Clock(0.1)[2:4]
+indexed_clock.idx
+```
 """
 Base.getindex(c::AbstractClock, idx) = IndexedClock(c, idx)
 

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -164,18 +164,47 @@ Ensembles Simulations Interface page for more details",
 end
 
 """
-$(TYPEDEF)
+    WeightedEnsembleProblem(ensembleprob, weights)
+    WeightedEnsembleProblem(args...; weights, kwargs...)
 
-Weighted ensemble problem wrapper.
+Associate an [`EnsembleProblem`](@ref) with one weight per trajectory.
 
-`WeightedEnsembleProblem` associates an [`EnsembleProblem`](@ref) with a vector
-of trajectory weights. The weights are used by weighted ensemble analysis
-utilities and must match the number of underlying trajectories.
+The direct constructor wraps an existing ensemble problem. The keyword constructor
+forwards `args` and `kwargs` to `EnsembleProblem`, verifies that `weights` sum to one,
+and verifies that their length matches the generated problem collection.
 
-## Fields
+# Arguments
 
-  - `ensembleprob`: The wrapped ensemble problem.
-  - `weights`: A vector of trajectory weights.
+- `ensembleprob`: The ensemble problem whose trajectories are weighted.
+- `weights`: An `AbstractVector` containing one weight per trajectory.
+
+# Keywords
+
+- `weights`: Required by the forwarding constructor.
+- `kwargs...`: Forwarded to [`EnsembleProblem`](@ref).
+
+# Fields
+
+- `ensembleprob`: The wrapped ensemble problem.
+- `weights`: The trajectory weights.
+
+# Returns
+
+- `WeightedEnsembleProblem`: A wrapper that delegates ordinary ensemble-problem
+  properties and exposes `weights`.
+
+# Throws
+
+- `AssertionError`: The forwarding constructor throws when the weights do not sum to
+  one or their length does not match the generated problem collection.
+
+# Example
+
+```julia
+ensembleprob = EnsembleProblem([:first, :second])
+weighted = WeightedEnsembleProblem(ensembleprob, [0.25, 0.75])
+weighted.weights
+```
 """
 struct WeightedEnsembleProblem{T1 <: AbstractEnsembleProblem, T2 <: AbstractVector} <:
     AbstractEnsembleProblem
@@ -184,15 +213,36 @@ struct WeightedEnsembleProblem{T1 <: AbstractEnsembleProblem, T2 <: AbstractVect
 end
 
 """
-Return the properties of the wrapped ensemble problem plus `:weights`.
+    Base.propertynames(prob::WeightedEnsembleProblem) -> Tuple
+
+Return the delegated property names of `prob.ensembleprob`, followed by `:weights`.
+
+This method defines the properties advertised to reflection and tab completion. The
+returned tuple may include `:ensembleprob` when the wrapped problem advertises it.
 """
 function Base.propertynames(e::WeightedEnsembleProblem)
     return (Base.propertynames(getfield(e, :ensembleprob))..., :weights)
 end
 
 """
-Access `:weights`, `:ensembleprob`, or a delegated property of the wrapped
-ensemble problem.
+    Base.getproperty(prob::WeightedEnsembleProblem, name::Symbol)
+
+Return `prob.weights`, the wrapped `prob.ensembleprob`, or a property delegated to the
+wrapped ensemble problem.
+
+# Arguments
+
+- `prob`: The weighted ensemble wrapper.
+- `name`: `:weights`, `:ensembleprob`, or a property supported by the wrapped problem.
+
+# Returns
+
+- The stored weights, wrapped problem, or delegated property value.
+
+# Throws
+
+Errors from `getproperty(prob.ensembleprob, name)` propagate for unsupported delegated
+properties.
 """
 function Base.getproperty(e::WeightedEnsembleProblem, f::Symbol)
     f === :weights && return getfield(e, :weights)
@@ -200,12 +250,6 @@ function Base.getproperty(e::WeightedEnsembleProblem, f::Symbol)
     return getproperty(getfield(e, :ensembleprob), f)
 end
 
-"""
-$(SIGNATURES)
-
-Construct a [`WeightedEnsembleProblem`](@ref), asserting that the supplied
-`weights` sum to one and match the number of generated problems.
-"""
 function WeightedEnsembleProblem(args...; weights, kwargs...)
     # TODO: allow skipping checks?
     @assert sum(weights) ≈ 1

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -125,7 +125,7 @@ See <https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts> for more
 Step size controller keyword arguments that were moved onto the controller objects
 (`PIController`, `PIDController`, `IController`, `PredictiveController`). They are no
 longer accepted by `solve`/`init`; passing one produces a `CommonKwargError` carrying
-[`CONTROLLER_KWARG_MESSAGE`](@ref) rather than the generic unrecognized-keyword text.
+`CONTROLLER_KWARG_MESSAGE` rather than the generic unrecognized-keyword text.
 """
 const controller_kwargs = (
     :gamma,

--- a/src/function_wrappers.jl
+++ b/src/function_wrappers.jl
@@ -213,22 +213,48 @@ function (ff::ParamJacobianWrapper{false})(du1, p)
 end
 
 """
-    JacobianWrapper{iip, fType, pType} <: AbstractWrappedFunction{iip}
+    JacobianWrapper(f, p)
+    JacobianWrapper{iip}(f, p)
 
-A general-purpose Jacobian wrapper that can be configured for different types of Jacobian computations. 
-This wrapper provides a unified interface for various Jacobian calculations across the SciML ecosystem.
+Fix the parameter argument of a residual function and expose the state as its free
+argument.
+
+# Arguments
+
+- `f`: An in-place `f(residual, u, p)` or out-of-place `f(u, p)` function.
+- `p`: The fixed parameter value.
+- `iip`: Whether `f` follows the in-place convention. The unparameterized constructor
+  infers this from `f`.
 
 # Fields
-- `f`: The function to wrap
-- `p`: Parameters
+
+- `f`: The wrapped residual function.
+- `p`: The fixed parameter value.
 
 # Type Parameters
-- `iip`: Boolean indicating if the function is in-place (`true`) or out-of-place (`false`)
-- `fType`: Type of the wrapped function
-- `pType`: Type of the parameters
 
-This wrapper provides a flexible interface for Jacobian computations that can adapt to different
-automatic differentiation backends and numerical methods.
+- `iip`: Whether the wrapped function is in-place.
+- `fType`: Type of the wrapped function.
+- `pType`: Type of the fixed parameter value.
+
+# Returns
+
+Calling an out-of-place wrapper as `wrapper(u)` returns `f(u, p)`. Calling either
+convention as `wrapper(residual, u)` fills `residual`; the in-place form returns the
+return value of `f`, while the out-of-place form returns the broadcast assignment.
+
+# Example
+
+```julia
+wrapper = JacobianWrapper((u, p) -> u .- p, [1.0, 2.0])
+wrapper([3.0, 5.0])
+```
+
+# Developer Interface
+
+Nonlinear solver and differentiation packages may construct this wrapper when they need
+a one-argument residual with fixed parameters. Use its callable interface rather than
+depending on the mutable field layout.
 """
 mutable struct JacobianWrapper{iip, fType, pType} <: AbstractWrappedFunction{iip}
     f::fType

--- a/src/odenlstep.jl
+++ b/src/odenlstep.jl
@@ -1,5 +1,5 @@
 """
-    $(TYPEDEF)
+    ODENLStepData(nlprob, u0perm, set_gamma_c, set_outer_tmp, set_inner_tmp, nlprobmap)
 
 A collection of hooks for custom nonlinear stage solves in implicit ODE
 algorithms.
@@ -21,6 +21,14 @@ is the stage evaluation time, and `gamma1`, `gamma2`, `outer_tmp`, and
 # Fields
 
 $(TYPEDFIELDS)
+
+# Extension Rules
+
+Symbolic-system packages construct this value and store it as an `ODEFunction`'s
+nonlinear-stage metadata. Solver packages may consume the six fields through their
+callable contracts, but must not assume concrete callable types or mutate the container.
+Each setter must update the object it closes over consistently with `nlprob`, and
+`nlprobmap` must map a completed nonlinear solution back to the ODE stage representation.
 """
 struct ODENLStepData{NLProb, SetU0, SetGammaC, SetOuterTmp, SetInnerTmp, NLProbMap}
     """

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -21,14 +21,46 @@ function (up::UpdateABWrapper)(p)
 end
 
 """
-    $(TYPEDEF)
+    SymbolicLinearInterface(; update_Ab, sys, observed, metadata)
+    SymbolicLinearInterface(update_A!, update_b!, sys, observed, metadata)
 
-A utility struct stored inside `LinearProblem` to enable a symbolic interface. Intended for
-use by ModelingToolkit.jl.
+Attach symbolic indexing and parameter-dependent matrix reconstruction to a
+[`LinearProblem`](@ref).
+
+# Arguments
+
+- `update_Ab`: A callable that updates mutable `A` and `b` as
+  `update_Ab(A, b, p)` or returns replacements as `update_Ab(p) -> (A, b)`.
+- `sys`: The symbolic container used by `SymbolicIndexingInterface` and by
+  [`get_new_A_b`](@ref) dispatch.
+- `observed`: A callable that builds observed-value functions, or `nothing` to delegate to
+  `sys`.
+- `metadata`: Symbolic-backend metadata not interpreted by SciMLBase.
+- `update_A!`, `update_b!`: Legacy separate matrix and right-hand-side update callables.
 
 # Fields
 
 $(TYPEDFIELDS)
+
+# Returns
+
+- `SymbolicLinearInterface`: Metadata stored in a linear problem's `f` field.
+
+# Extension Rules
+
+Symbolic-system packages construct this type and specialize [`get_new_A_b`](@ref) on the
+type of `sys`. Consumers must use the documented fields and
+`SymbolicIndexingInterface` operations; they must not depend on the concrete type
+parameters. New code should use the unified `update_Ab` keyword constructor.
+
+# Example
+
+```julia
+update_Ab = (A, b, p) -> (A .= p[1]; b .= p[2]; (A, b))
+interface = SciMLBase.SymbolicLinearInterface(
+    ; update_Ab, sys = :my_system, observed = nothing, metadata = nothing
+)
+```
 """
 @kwdef struct SymbolicLinearInterface{F, S, O, M}
     # the docstrings cannot start with a newline because otherwise the docs

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -118,7 +118,7 @@ function remake(
 end
 
 """
-    $(TYPEDSIGNATURES)
+    _has_type_erased_params(::Type{T}) -> Bool where {T <: AbstractSciMLFunction}
 
 Check if the type `T` of an `AbstractSciMLFunction` has any type-erased (abstract) type
 parameters beyond `iip` and `specialize`. Returns `true` if any field type parameter (index
@@ -137,7 +137,10 @@ erasure was applied (e.g. by `promote_f` for AutoSpecialize compilation caching)
 end
 
 """
-    $(TYPEDSIGNATURES)
+    _reconstruct_as_type(::Type{TargetType}, source::SourceType) -> TargetType
+
+where `TargetType <: AbstractSciMLFunction` and
+`SourceType <: AbstractSciMLFunction`.
 
 Reconstruct `source` preserving the non-concrete (erased) type parameters from
 `TargetType` while using `source`'s actual concrete types for all other parameters.
@@ -172,7 +175,7 @@ OverrideInitData}` for initialization_data) while allowing concrete field types
 end
 
 """
-    $(TYPEDSIGNATURES)
+    widen_bounded_type_params(f::AbstractSciMLFunction) -> AbstractSciMLFunction
 
 Widen all bounded type parameters of an `AbstractSciMLFunction` to their upper bounds.
 
@@ -184,6 +187,30 @@ respectively, while leaving all unbounded (`<: Any`) type parameters concrete.
 This ensures that all AutoSpecialize instances of a function type share the same type
 regardless of model-specific details (e.g. initialization functions), preventing
 recompilation of `promote_f` and solver code for each model.
+
+# Arguments
+
+- `f`: A concrete SciML function wrapper.
+
+# Returns
+
+- A reconstruction of `f` with the same field values and with bounded type parameters
+  replaced by their declared upper bounds. Unbounded parameters remain concrete.
+
+# Developer Interface
+
+Symbolic-system packages may call this after attaching model-specific initialization or
+nonlinear-stage metadata to a function that uses `AutoSpecialize`. Callers must treat the
+returned wrapper as immutable metadata reconstruction and must not depend on its exact
+concrete type parameters.
+
+# Example
+
+```julia
+f = ODEFunction{false, AutoSpecialize}((u, p, t) -> u)
+widened = SciMLBase.widen_bounded_type_params(f)
+SciMLBase.isinplace(widened)
+```
 """
 @generated function widen_bounded_type_params(f::F) where {F <: AbstractSciMLFunction}
     # Walk the UnionAll chain to collect TypeVars and their upper bounds
@@ -444,22 +471,56 @@ function SciMLBase.remake(
 end
 
 """
-    $TYPEDEF
+    RemakeInitializationDataContext()
 
-Additional information passed to `remake_initialization_data` which influences behavior of
-implementors. Currently does not contain any fields.
+Context passed to [`remake_initialization_data`](@ref).
+
+The context currently has no fields. It reserves a positional extension point so future
+context can be added without changing the symbolic-remake dispatch shape. Extensions must
+accept the context argument and must not dispatch on undocumented implementation details.
 """
 struct RemakeInitializationDataContext end
 
 """
-    remake_initialization_data(sys, scimlfn, u0, t0, p, newu0, newp, ctx::RemakeInitializationDataContext)
+    remake_initialization_data(sys, scimlfn, u0, t0, p, newu0, newp,
+        ctx = RemakeInitializationDataContext())
+        -> initialization_data
 
-Re-create the initialization data present in the function `scimlfn`, using the
-associated system `sys`, the user provided new values of `u0`, initial time `t0`,
-user-provided `p`, new u0 vector `newu0` and new parameter object `newp`. By default,
-returns `nothing` if `scimlfn` does not have initialization data. 
+Recreate a SciML function's initialization data after symbolic `remake` changes state or
+parameters.
 
-Note that `u0` or `p` may be `missing` if the user does not provide a value for them.
+# Arguments
+
+- `sys`: The symbolic system associated with `scimlfn`; this is the primary extension
+  dispatch argument.
+- `scimlfn`: The SciML function whose initialization data is being reconstructed.
+- `u0`, `p`: Values supplied to `remake`; either may be `missing` when not overridden.
+- `t0`: The new initial independent-variable value.
+- `newu0`, `newp`: Concrete state and parameter values already resolved by `remake`.
+- `ctx`: A [`RemakeInitializationDataContext`](@ref).
+
+# Returns
+
+- Reconstructed initialization data, or `nothing` when `scimlfn` has none. The generic
+  method preserves the existing initialization callbacks and maps.
+
+# Extension Rules
+
+Symbolic-system packages may specialize on `sys` and function types they own. A method
+must accept the context argument, must handle `missing` user overrides, and must return
+data accepted by the target SciML function constructor. It must not mutate `u0`, `p`,
+`newu0`, or `newp` unless those objects' public contracts explicitly permit mutation.
+
+# Example
+
+```julia
+struct MyInitializationSystem end
+
+function SciMLBase.remake_initialization_data(
+        ::MyInitializationSystem, scimlfn, u0, t0, p, newu0, newp, ctx)
+    return (; previous = scimlfn.initialization_data, newu0, newp)
+end
+```
 """
 function remake_initialization_data(sys, scimlfn, u0, t0, p, newu0, newp, ctx::RemakeInitializationDataContext = RemakeInitializationDataContext())
     if !has_initialization_data(scimlfn)
@@ -1226,17 +1287,46 @@ function _get_new_A_b(f::SymbolicLinearInterface, p, A, b; kw...)
     return get_new_A_b(f.sys, f, p, A, b; kw...)
 end
 
-# public API
 """
-    $(TYPEDSIGNATURES)
+    get_new_A_b(root_indp, f, p, A, b; kwargs...) -> (new_A, new_b)
 
-A function to return the updated `A` and `b` matrices for a `LinearProblem` after `remake`.
-`root_indp` is the innermost index provider found by recursively, calling
-`SymbolicIndexingInterface.symbolic_container`, provided for dispatch. Returns the new `A`
-`b` matrices. Mutation of `A` and `b` is permitted.
+Return the matrix and right-hand side for a symbolic `LinearProblem` after `remake`.
 
-All implementations must accept arbitrary keyword arguments in case they are added in the
-future.
+# Arguments
+
+- `root_indp`: The innermost index provider obtained by recursively following
+  `SymbolicIndexingInterface.symbolic_container`; this is the primary extension dispatch
+  argument.
+- `f`: The problem's [`SymbolicLinearInterface`](@ref).
+- `p`: The remade parameter object.
+- `A`, `b`: Copies of the previous matrix and right-hand side.
+
+# Keywords
+
+Implementations must accept and forward arbitrary keyword arguments for compatibility
+with future symbolic remake options.
+
+# Returns
+
+- `(new_A, new_b)`: Updated linear-system data. Implementations may mutate and return
+  `A` and `b`, or return replacement objects.
+
+# Extension Rules
+
+Symbolic-system packages may specialize on `root_indp` and interface types they own. The
+returned objects must define the same linear problem represented by `f` and `p`, and must
+remain valid inputs to the original `LinearProblem` constructor.
+
+# Example
+
+```julia
+struct MyLinearSystem end
+
+function SciMLBase.get_new_A_b(::MyLinearSystem, f, p, A, b; kwargs...)
+    f.update_Ab(A, b, p)
+    return A, b
+end
+```
 """
 get_new_A_b(root_indp, f, p, A, b; kw...) = A, b
 
@@ -1258,10 +1348,34 @@ function varmap_get(varmap, var, default = nothing)
 end
 
 """
-    $(TYPEDSIGNATURES)
+    detect_cycles(indp, varmap, syms) -> Bool
 
-Check if `varmap::Dict{Any, Any}` contains cyclic values for any symbolic variables in
-`syms`. Falls back on the basis of `symbolic_container(indp)`. Returns `false` by default.
+Return whether symbolic substitutions in `varmap` contain a cycle involving `syms`.
+
+# Arguments
+
+- `indp`: An index provider used for extension dispatch.
+- `varmap`: A symbolic assignment map.
+- `syms`: Symbols whose dependencies should be checked.
+
+# Returns
+
+- `Bool`: The result from the innermost symbolic container. The generic fallback returns
+  `false` when no more specific container method exists.
+
+# Extension Rules
+
+Symbolic-system packages may specialize this function for index-provider types they own.
+A method must return `true` only for a dependency cycle that prevents deterministic
+symbolic replacement; it must not mutate `varmap` or `syms`.
+
+# Example
+
+```julia
+struct MyCycleCheckedSystem end
+SciMLBase.detect_cycles(::MyCycleCheckedSystem, varmap, syms) =
+    any(sym -> get(varmap, sym, nothing) === sym, syms)
+```
 """
 function detect_cycles(indp, varmap, syms)
     if hasmethod(symbolic_container, Tuple{typeof(indp)}) &&
@@ -1545,10 +1659,13 @@ function updated_u0_p(
 end
 
 """
-    $TYPEDEF
+    LateBindingUpdateU0PContext()
 
-Additional information passed to `late_binding_update_u0_p` which influences behavior of
-implementors. Currently does not contain any fields.
+Context passed to [`late_binding_update_u0_p`](@ref).
+
+The context currently has no fields. It reserves a positional extension point for
+symbolic-system packages. Extensions must accept it and must not assume that it remains
+fieldless in later minor releases.
 """
 struct LateBindingUpdateU0PContext end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -185,20 +185,47 @@ function checkkwargs(kwargshandle, allowed; kwargs...)
     end
 end
 """
-    $(TYPEDSIGNATURES)
+    get_updated_symbolic_problem(indp, prob; kwargs...) -> updated_prob
 
-Given the index provider `indp` used to construct the problem `prob` being solved, return
-an updated `prob` to be used for solving. All implementations should accept arbitrary
-keyword arguments.
+Return the problem that a solver should use after applying symbolic solve-time updates.
 
-Should be called before the problem is solved, after performing type-promotion on the
-problem. If the returned problem is not `===` the provided `prob`, it is assumed to
-contain the `u0` and `p` passed as keyword arguments.
+# Arguments
 
-# Keyword Arguments
+- `indp`: The root index provider returned by [`get_root_indp`](@ref); this is the
+  primary extension dispatch argument.
+- `prob`: The type-promoted SciML problem about to be solved.
 
-- `u0`, `p`: Override values for `state_values(prob)` and `parameter_values(prob)` which
-  should be used instead of the ones in `prob`.
+# Keywords
+
+- `u0`: A solve-time state override, defaulting to the problem's state values.
+- `p`: A solve-time parameter override, defaulting to the problem's parameter values.
+- `kwargs...`: Additional solve keywords. Implementations must accept arbitrary keywords.
+
+# Returns
+
+- `updated_prob`: `prob` or a replacement problem ready for `init`/`solve`. When the
+  result is not `=== prob`, it must already contain the effective `u0` and `p` values.
+
+# Extension Rules
+
+Symbolic-system packages may specialize on `indp` and problem types they own. This hook is
+called after type promotion and before solver initialization. Implementations must preserve
+the problem family and all solve-relevant fields not explicitly replaced.
+
+# Example
+
+```julia
+struct MySolveSystem end
+struct MySymbolicProblem
+    u0
+    p
+end
+
+function SciMLBase.get_updated_symbolic_problem(
+        ::MySolveSystem, prob::MySymbolicProblem; u0 = prob.u0, p = prob.p, kwargs...)
+    return MySymbolicProblem(u0, p)
+end
+```
 """
 function get_updated_symbolic_problem(indp, prob; kw...)
     return prob

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -653,37 +653,72 @@ _unwrap_val(::Val{B}) where {B} = B
 _unwrap_val(B) = B
 
 """
-    prepare_initial_state(u0) = u0
+    prepare_initial_state(u0) -> prepared_u0
 
-Whenever an initial state is passed to the SciML ecosystem, is passed to
-`prepare_initial_state` and the result is used instead. If you define a
-type which cannot be used as a state but can be converted to something that
-can be, then you may define `prepare_initial_state(x::YourType) = ...`.
+Convert an object supplied as a SciML initial state into its solver-facing form.
 
-!!! warning
+# Arguments
 
-    This function is experimental and may be removed in the future.
+- `u0`: An initial-state value supplied to a problem or ensemble constructor.
 
-See also: `prepare_function`.
+# Returns
+
+- `prepared_u0`: The state stored by the constructor. The generic method returns `u0`
+  unchanged.
+
+# Extension Rules
+
+Wrapper and language-bridge packages may specialize this function for input types they
+own. A method must preserve the mathematical state values and shape expected by the model,
+must not evaluate the model, and must return an object accepted by SciML problem
+constructors. Do not specialize on broad types owned by another package.
+
+# Example
+
+```julia
+struct ExternalState{T}
+    values::T
+end
+
+SciMLBase.prepare_initial_state(state::ExternalState) = state.values
+```
+
+See also [`prepare_function`](@ref).
 """
 prepare_initial_state(u0) = u0
 
 """
-    prepare_function(f) = f
+    prepare_function(f) -> prepared_f
 
-Whenever a function is passed to the SciML ecosystem, is passed to
-`prepare_function` and the result is used instead. If you define a type which
-cannot be used as a function in the SciML ecosystem but can be converted to
-something that can be, then you may define `prepare_function(x::YourType) = ...`.
+Convert an object supplied as a SciML model or callback into a Julia-callable form.
 
-`prepare_function` may be called before or after
-the arity of a function is computed with `numargs`
+# Arguments
 
-!!! warning
+- `f`: A function or foreign-language callable supplied to a SciML constructor.
 
-    This function is experimental and may be removed in the future.
+# Returns
 
-See also: `prepare_initial_state`.
+- `prepared_f`: A callable implementing the same argument and mutation convention as
+  `f`. The generic method returns `f` unchanged.
+
+# Extension Rules
+
+Wrapper and language-bridge packages may specialize this function for callable types they
+own. `prepare_function` may run before or after [`numargs`](@ref), so both the original
+object and prepared callable must expose compatible arity. In-place callables must retain
+`nothing` return semantics, and implementations must not invoke `f` during preparation.
+
+# Example
+
+```julia
+struct ExternalCallable{F}
+    f::F
+end
+
+SciMLBase.prepare_function(f::ExternalCallable) = f.f
+```
+
+See also [`prepare_initial_state`](@ref).
 """
 prepare_function(f) = f
 

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -44,6 +44,48 @@ function SciMLBase._concrete_solve_forward(
     return (; u0, p, args, kwargs = (; kwargs...)), Δ -> (:forward, Δ)
 end
 
+struct SymbolicRemakeContractRoot end
+struct SymbolicRemakeContractProblem
+    u0
+    p
+end
+struct PreparedStateContract{T}
+    value::T
+end
+struct PreparedFunctionContract{F}
+    f::F
+end
+struct SolverOptionsContract <: SciMLBase.AbstractDEOptions end
+
+function SciMLBase.remake_initialization_data(
+        ::SymbolicRemakeContractRoot, scimlfn, u0, t0, p, newu0, newp,
+        ::SciMLBase.RemakeInitializationDataContext
+    )
+    return (; scimlfn, u0, t0, p, newu0, newp)
+end
+
+function SciMLBase.get_new_A_b(
+        ::SymbolicRemakeContractRoot, f, p, A, b; scale = one(p), kwargs...
+    )
+    return scale .* A, scale .* b
+end
+
+function SciMLBase.detect_cycles(
+        ::SymbolicRemakeContractRoot, varmap, syms
+    )
+    return any(sym -> get(varmap, sym, nothing) === sym, syms)
+end
+
+function SciMLBase.get_updated_symbolic_problem(
+        ::SymbolicRemakeContractRoot, prob::SymbolicRemakeContractProblem;
+        u0 = prob.u0, p = prob.p, kwargs...
+    )
+    return SymbolicRemakeContractProblem(u0, p)
+end
+
+SciMLBase.prepare_initial_state(state::PreparedStateContract) = state.value
+SciMLBase.prepare_function(f::PreparedFunctionContract) = f.f
+
 @testset "Common keyword interface documentation" begin
     common_keywords = read(
         joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Common_Keywords.md"),
@@ -184,6 +226,78 @@ end
     )
     @test primal == (; u0 = :u0, p = :p, args = (:extra,), kwargs = (; saveat = :saved))
     @test pushforward(:tangent) == (:forward, :tangent)
+end
+
+@testset "Symbolic-system developer interface" begin
+    root = SymbolicRemakeContractRoot()
+    prob = SymbolicRemakeContractProblem([1.0], [2.0])
+
+    @test SciMLBase.RemakeInitializationDataContext() isa
+        SciMLBase.RemakeInitializationDataContext
+    @test SciMLBase.LateBindingUpdateU0PContext() isa
+        SciMLBase.LateBindingUpdateU0PContext
+
+    initdata = SciMLBase.remake_initialization_data(
+        root, :function, :old_u0, 0.0, :old_p, :new_u0, :new_p
+    )
+    @test initdata == (;
+        scimlfn = :function, u0 = :old_u0, t0 = 0.0, p = :old_p,
+        newu0 = :new_u0, newp = :new_p,
+    )
+
+    @test SciMLBase.get_new_A_b(nothing, nothing, 2.0, [1.0], [3.0]) ==
+        ([1.0], [3.0])
+    @test SciMLBase.get_new_A_b(root, nothing, 2.0, [1.0], [3.0]; scale = 2.0) ==
+        ([2.0], [6.0])
+
+    @test !SciMLBase.detect_cycles(nothing, Dict(:x => :x), [:x])
+    @test SciMLBase.detect_cycles(root, Dict(:x => :x), [:x])
+    @test !SciMLBase.detect_cycles(root, Dict(:x => 1), [:x])
+
+    @test SciMLBase.get_updated_symbolic_problem(nothing, prob) === prob
+    updated = SciMLBase.get_updated_symbolic_problem(root, prob; u0 = [3.0], p = [4.0])
+    @test updated.u0 == [3.0]
+    @test updated.p == [4.0]
+
+    update_Ab = (A, b, p) -> (A .= p[1]; b .= p[2]; (A, b))
+    symbolic_linear = SciMLBase.SymbolicLinearInterface(
+        ; update_Ab, sys = root, observed = nothing, metadata = :metadata
+    )
+    A, b = symbolic_linear.update_Ab(zeros(1, 1), zeros(1), (2.0, 3.0))
+    @test A == fill(2.0, 1, 1)
+    @test b == [3.0]
+    @test symbolic_linear.sys === root
+    @test symbolic_linear.metadata === :metadata
+end
+
+@testset "Input-preparation developer interface" begin
+    state = PreparedStateContract([1.0, 2.0])
+    callable = PreparedFunctionContract(x -> x + 1)
+
+    @test SciMLBase.prepare_initial_state(:unchanged) === :unchanged
+    @test SciMLBase.prepare_initial_state(state) === state.value
+    @test SciMLBase.prepare_function(identity) === identity
+    @test SciMLBase.prepare_function(callable)(2) == 3
+end
+
+@testset "Solver support developer types" begin
+    @test SolverOptionsContract() isa SciMLBase.AbstractDEOptions
+
+    nlstep = SciMLBase.ODENLStepData(
+        :nlprob, :u0perm, :set_gamma_c, :set_outer_tmp, :set_inner_tmp, :nlprobmap
+    )
+    @test nlstep.nlprob === :nlprob
+    @test nlstep.u0perm === :u0perm
+    @test nlstep.set_γ_c === :set_gamma_c
+    @test nlstep.set_outer_tmp === :set_outer_tmp
+    @test nlstep.set_inner_tmp === :set_inner_tmp
+    @test nlstep.nlprobmap === :nlprobmap
+
+    wrapper = SciMLBase.JacobianWrapper((u, p) -> u .- p, [1.0, 2.0])
+    @test wrapper([3.0, 5.0]) == [2.0, 3.0]
+    residual = zeros(2)
+    @test wrapper(residual, [4.0, 7.0]) === residual
+    @test residual == [3.0, 5.0]
 end
 
 @testset "Concrete interface reference documentation" begin
@@ -361,6 +475,11 @@ if isdefined(Base, :ispublic)
                 :ReverseDiffOriginator, :TrackerOriginator, :MooncakeOriginator,
                 :set_mooncakeoriginator_if_mooncake,
                 :_concrete_solve_adjoint, :_concrete_solve_forward,
+                :RemakeInitializationDataContext, :remake_initialization_data,
+                :LateBindingUpdateU0PContext, :detect_cycles,
+                :get_updated_symbolic_problem, :SymbolicLinearInterface, :get_new_A_b,
+                :widen_bounded_type_params, :prepare_initial_state, :prepare_function,
+                :AbstractDEOptions, :ODENLStepData, :JacobianWrapper,
             )
             @test Base.ispublic(SciMLBase, name)
             @test Base.Docs.hasdoc(SciMLBase, name)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -107,10 +107,10 @@ end
 # is expected to wire its internals to an optional dependency.
 const _ei_own_internals = (
     :set_mooncakeoriginator_if_mooncake,
-    :DualEltypeChecker, :ODENLStepData,
+    :DualEltypeChecker,
     :_reshape, :add_labels!, :anyeltypedual, :build_linear_solution, :checkkwargs,
     :diffeq_to_arrays, :getobserved, :handle_distribution_u0, :interpret_vars,
-    :isdistribution, :isdualtype, :prepare_function, :prepare_initial_state,
+    :isdistribution, :isdualtype,
     :reduce_tup, :responsible_map, :sse, :tmap, :totallength,
 )
 
@@ -182,15 +182,13 @@ const _ei_nonpublic_qualified_accesses = (
 )
 
 # The CommonSolve verbs. SciMLBase does not own them, but they are the SciML solve
-# interface as users and solver packages write it, and they are documented here, so
-# they stay exported and are allow-listed rather than dropped. They are documented at
-# CommonSolve as well, so the rendered-docs check skips them.
+# interface as users and solver packages write it, so they stay exported and are
+# allow-listed rather than dropped.
 const _reexports_allow = (:init, :solve, :solve!, :step!)
 
 run_qa(
     SciMLBase;
     reexports_allow = _reexports_allow,
-    api_docs_kwargs = (; rendered_ignore = _reexports_allow),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = _ei_nonpublic_qualified_accesses),
         all_explicit_imports_are_public = (; ignore = _ei_nonpublic_explicit_imports),


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Depends on #1495. Do not merge this PR first: #1495 supplies the SciMLBase 3.44.0 minor-version bump and promotes `@def`; after #1495 merges, this branch must be rebased and the temporary `@def` private-reference entry removed in favor of #1495’s developer API entry.

## Summary

- replace the remaining abbreviated or incomplete SciMLBase docstrings with definition-site SciMLStyle contracts, including arguments, returns, failures, extension rules, and examples where appropriate
- mark the symbolic remake, input preparation, nonlinear-stage metadata, and Jacobian-wrapper hooks as developer public API and test them from external extension types
- render every intentional private docstring on a clearly warned internal implementation page without making those bindings public
- remove Documenter `warnonly` for `docs_block` and `missing_docs`, and remove the repository-specific rendered-doc QA ignore

## Validation

- Julia release full `Pkg.test()`: passed, including public declarations 551/551 and remake tests 4430/4430
- Julia release QA: 51/51 passed
- Julia 1.10 QA: 49/49 passed
- strict docs build: passed with doctests, linkcheck, cross-references, docs blocks, and missing docs treated as errors
- focused Julia 1.10 `_reconstruct_as_type` documentation checks: passed
- Runic `--check .`: passed
- `git diff --check`: passed