### PR TITLE
Add a module docstring for SciMLBase

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -206,6 +206,12 @@ that mixes inference, symbolics, and numerics.
 There are too many to name here. Check out the
 [SciML Organization Github Page](https://github.com/SciML) for details.
 
+## Module
+
+```@docs
+SciMLBase.SciMLBase
+```
+
 ## Contributing
 
   - Please refer to the

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1,3 +1,34 @@
+"""
+    SciMLBase
+
+The core interface definition of the SciML ecosystem.
+
+SciMLBase.jl is a low-dependency library holding the vocabulary that the SciML solver
+packages share: the problem types (`AbstractSciMLProblem` and its subtypes such as
+`ODEProblem`, `NonlinearProblem`, `OptimizationProblem`), the function wrappers that
+carry a model and its derivatives (`AbstractSciMLFunction`, e.g. `ODEFunction`), the
+algorithm supertype (`AbstractSciMLAlgorithm`), and the solution types
+(`AbstractSciMLSolution`). It contains no numerical methods of its own — packages like
+OrdinaryDiffEq.jl, NonlinearSolve.jl and Optimization.jl implement these interfaces, which
+is what lets a problem built once be handed to any of them.
+
+Users normally reach this interface through a solver package that re-exports it rather
+than by depending on SciMLBase directly. The common entry point is to build a problem and
+call `solve`:
+
+```julia
+using OrdinaryDiffEq                       # re-exports the SciMLBase interface
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, Tsit5())
+successful_retcode(sol)                    # check `sol.retcode` the supported way
+```
+
+`init` and `step!` expose the same solve as a stepwise iterator, and `remake` rebuilds a
+problem with some fields changed.
+
+See the [SciMLBase documentation](https://docs.sciml.ai/SciMLBase/stable/) for the full
+interface specification.
+"""
 module SciMLBase
 if isdefined(Base, :Experimental) &&
         isdefined(Base.Experimental, Symbol("@max_methods"))


### PR DESCRIPTION
## What changed and why

`SciMLBase` had no module docstring, so `?SciMLBase` and the manual both showed only Julia's auto-generated "No docstring found for public module SciMLBase" summary. This adds one — what the package is, and how a user actually enters the interface — and renders it in the manual, which Documenter's `checkdocs` requires for every docstring in `modules`.

This is **hygiene, not a fix.** Nothing depends on it. The undocumented module briefly broke downstream QA lanes, but that was a bug in the checker and is already resolved by SciML/SciMLTesting.jl#45; this PR does not unblock anything. The reason the gap sat here unnoticed is structural: `SciMLTesting.public_api_names` filters out `nameof(pkg)`, so a package is never asked to document its own module, and only a package that *re-exports* `SciMLBase` ever sees the name in its public API.

## Verification

The docstring is the whole behavioural change, so the discriminating check is the binding itself. `julia +1.12 --project -e 'using REPL, SciMLBase; Base.Docs.hasdoc(Main, :SciMLBase)'`:

```
master   62da7dd5 : hasdoc(:SciMLBase) = false
this branch        : hasdoc(:SciMLBase) = true
```

**`GROUP=QA` is unchanged, as expected** — this is the point of the hygiene framing, not an omission. `GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'`:

```
# master 62da7dd5
Test Summary: | Pass  Total     Time
QA            |   51     51  3m17.2s
     Testing SciMLBase tests passed

# this branch
Test Summary: | Pass  Total     Time
QA            |   51     51  3m11.5s
     Testing SciMLBase tests passed
```

Runic (`Runic.main(["--check","--diff","src/SciMLBase.jl"])`) exits 0; `typos` over the changed files exits 0.

## The docs build, and what I could not verify past

`julia --project=docs docs/make.jl` **fails on unmodified master**, before this branch is involved. I confirmed that on a clean worktree at `62da7dd5` rather than assuming it:

```
┌ Error: linkcheck 'https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/' status: 403.
   ... 16 identical linkcheck errors, all the same URL ...
[ Info: Populate: populating indices.
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```

`linkcheck` is the *only* error class in that run, and the build terminates before `RenderDocument`. So the stock `docs/make.jl` cannot tell me whether my new `@docs` entry renders — I could not verify past the 403s, and I am not claiming the stock docs build is green on this branch, because it is not green on master either.

To get an answer anyway I re-ran `docs/make.jl` verbatim except `linkcheck = false`, on both trees. Both reach the end with **zero errors and an identical 5 warnings**:

```
# master 62da7dd5, linkcheck = false      # this branch, linkcheck = false
[ Info: CheckDocument: running document checks.   [ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.       [ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.         [ Info: HTMLWriter: rendering HTML pages.
errors=0  warnings=5                              errors=0  warnings=5
```

That is what tells me the `@docs SciMLBase.SciMLBase` entry is accepted and no `missing_docs` error appears. It is a local diagnostic with a modified `linkcheck` flag, not a real docs build — treat it accordingly. The 403s are a separate pre-existing problem I have not touched or investigated.

## CI on this PR

Green on everything that a docstring change can affect:

```
Runic / Runic Format Check                                   pass
Spell Check with Typos                                       pass
tests / QA (julia 1, ubuntu-latest)                          pass  16m
```

Two jobs are red, **both already red on master** — neither is caused by this branch:

```
Documentation / Build and Deploy Documentation               fail
Downgrade / Downgrade Tests                                  fail
```

`Documentation` fails with the same pre-existing linkcheck 403s described above. I pulled the job log and checked rather than assuming: 16 occurrences of `linkcheck 'https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/' status: 403`, terminating with `encountered an error [:linkcheck]`, and **zero** `not included in the manual` / `missing_docs` occurrences. Master's own Documentation runs:

```
2026-08-07T16:30:21Z 62da7dd5a failure   <- this PR's base commit
2026-08-06T12:24:35Z 4d12f2917 failure
2026-08-05T13:11:41Z dd269bb9e failure
2026-08-05T10:47:05Z 7d6af028d failure
```

`Downgrade` is likewise long-broken on master and unrelated to this diff:

```
2026-08-07T16:30:21Z 62da7dd5a failure   <- this PR's base commit
2026-08-06T12:24:35Z 4d12f2917 failure
2026-08-05T13:11:41Z dd269bb9e failure
2026-08-05T10:47:05Z 7d6af028d failure
2026-08-05T10:33:53Z 76406c462 failure
```

It is being investigated separately; it should not be attributed to this PR or fixed inside it.

The large downstream-test fleet (ModelingToolkit, SciMLSensitivity, Catalyst, …) was not waited on — ~66 checks fire on this repo and they take hours. A docstring cannot affect them, but I did not confirm that.

## Not verified

Julia LTS was not exercised locally (1.12.6 only). Only `GROUP=QA` was run, not `Core`/`Downstream`/`Python` — the diff is a docstring plus a `@docs` entry, with no code path touched. No version bump: `Project.toml` is already at `3.43.1` against a registered `3.43.0`, so the docstring rides the existing unreleased bump.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF

