### PR TITLE
Add `nlstep_data` to `DAEFunction`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.43.1"
+version = "3.44.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/odenlstep.jl
+++ b/src/odenlstep.jl
@@ -1,22 +1,37 @@
 """
     ODENLStepData(nlprob, u0perm, set_gamma_c, set_outer_tmp, set_inner_tmp, nlprobmap)
 
-A collection of hooks for custom nonlinear stage solves in implicit ODE
+A collection of hooks for custom nonlinear stage solves in implicit ODE and DAE
 algorithms.
 
-`ODENLStepData` lets an `ODEFunction` provide a structured
+`ODENLStepData` lets an `ODEFunction`, `SplitFunction` or `DAEFunction` provide a structured
 `AbstractNonlinearProblem` template for solver packages that form implicit stage
 equations. Before each nonlinear solve, the algorithm updates the stage guess,
 scaling factors, time information, and temporary vectors through the stored
 setter callables. After the nonlinear solve, `nlprobmap` converts the nonlinear
-unknown back to the state vector used by the original ODE problem.
+unknown back to the state vector used by the original problem.
 
-The nonlinear problem should represent a stage equation of the form
-`M * z = outer_tmp + gamma1 * f(gamma2 * z + inner_tmp, p, t_c)`, equivalently
+## Mass-matrix form
+
+For `M * du/dt = f(u, p, t)` the nonlinear problem should represent a stage equation of the
+form `M * z = outer_tmp + gamma1 * f(gamma2 * z + inner_tmp, p, t_c)`, equivalently
 `g(z, p') = gamma1 * f(gamma2 * z + inner_tmp, p, t_c) + outer_tmp - M * z`.
 Here `z` is the nonlinear stage unknown, `p` is the ODE parameter object, `t_c`
 is the stage evaluation time, and `gamma1`, `gamma2`, `outer_tmp`, and
 `inner_tmp` are supplied by the ODE algorithm.
+
+## Fully implicit form
+
+For `0 = F(du, u, p, t)` (a `DAEFunction`) the stage equation has the same shape, with both
+arguments of `F` affine in the stage unknown:
+`g(z, p') = F(gamma1 * z + outer_tmp, gamma2 * z + inner_tmp, p, t_c)`.
+`gamma2` and `inner_tmp` build the state argument from the stage unknown exactly as in the
+mass-matrix form, while `gamma1` and `outer_tmp` build the derivative argument. Taking the
+stage unknown to be the stage state (`gamma2 = 1`, `inner_tmp = 0`), a BDF-type step with
+`du ≈ (u - tmp) / (γ * dt)` gives `gamma1 = inv(γ * dt)` and `outer_tmp = -tmp / (γ * dt)`.
+With that convention `gamma1` is the `gamma` of the `DAEFunction` Jacobian signature
+`jac(J, du, u, p, gamma, t)`: the Jacobian of the stage residual with respect to `z` is
+`gamma1 * dF/d(du) + dF/du`.
 
 # Fields
 
@@ -24,11 +39,12 @@ $(TYPEDFIELDS)
 
 # Extension Rules
 
-Symbolic-system packages construct this value and store it as an `ODEFunction`'s
-nonlinear-stage metadata. Solver packages may consume the six fields through their
-callable contracts, but must not assume concrete callable types or mutate the container.
-Each setter must update the object it closes over consistently with `nlprob`, and
-`nlprobmap` must map a completed nonlinear solution back to the ODE stage representation.
+Symbolic-system packages construct this value and store it as the `nlstep_data` of an
+`ODEFunction`, `SplitFunction` or `DAEFunction`. Solver packages may consume the six fields
+through their callable contracts, but must not assume concrete callable types or mutate the
+container. Each setter must update the object it closes over consistently with `nlprob`, and
+`nlprobmap` must map a completed nonlinear solution back to the stage representation of the
+original problem.
 """
 struct ODENLStepData{NLProb, SetU0, SetGammaC, SetOuterTmp, SetInnerTmp, NLProbMap}
     """

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -1586,7 +1586,8 @@ DAEFunction{iip,specialize}(f;
                            jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
                            sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
                            colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+                           sys = __has_sys(f) ? f.sys : nothing,
+                           nlstep_data = __has_nlstep_data(f) ? f.nlstep_data : nothing)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1622,6 +1623,11 @@ the usage of `f`. These include:
   based on the sparsity pattern. Defaults to `nothing`, which means a color vector will be
   internally computed on demand when required. The cost of this operation is highly dependent
   on the sparsity pattern.
+- `nlstep_data`: an [`ODENLStepData`](@ref SciMLBase.ODENLStepData) holding a structured
+  nonlinear problem for the implicit stage solve, or `nothing`. Implicit DAE integrators
+  which support it solve this problem in place of building a stage-equation closure. See the
+  `ODENLStepData` documentation for the stage equation the nonlinear problem must represent
+  in the fully implicit case.
 
 ## iip: In-Place vs Out-Of-Place
 
@@ -1685,7 +1691,7 @@ numerically-defined functions.
 struct DAEFunction{
         iip, specialize, F, Ta, Tt, TJ, TJU, TJD, JVP, VJP, JP, SP, TW, TWt, TPJ, O,
         TCV,
-        SYS, ID,
+        SYS, ID, NLP <: Union{Nothing, ODENLStepData},
     } <:
     AbstractDAEFunction{iip}
     f::F
@@ -1705,6 +1711,7 @@ struct DAEFunction{
     colorvec::TCV
     sys::SYS
     initialization_data::ID
+    nlstep_data::NLP
 end
 
 """
@@ -4143,7 +4150,8 @@ function DAEFunction{iip, specialize}(
         initializeprobmap = __has_initializeprobmap(f) ? f.initializeprobmap : nothing,
         initializeprobpmap = __has_initializeprobpmap(f) ? f.initializeprobpmap : nothing,
         initialization_data = __has_initialization_data(f) ? f.initialization_data :
-            nothing
+            nothing,
+        nlstep_data = __has_nlstep_data(f) ? f.nlstep_data : nothing
     ) where {
         iip,
         specialize,
@@ -4188,12 +4196,12 @@ function DAEFunction{iip, specialize}(
             iip, specialize, Any, Any, Any,
             Any, Any, Any, Any, Any, Any, Any,
             Any, Any, Any,
-            Any, typeof(_colorvec), Any, Any,
+            Any, typeof(_colorvec), Any, Any, Union{Nothing, ODENLStepData},
         }(
             _f, analytic, tgrad, jac, jac_u, jac_du, jvp,
             vjp, jac_prototype, sparsity,
             Wfact, Wfact_t, paramjac, observed,
-            _colorvec, sys, initdata
+            _colorvec, sys, initdata, nlstep_data
         )
     else
         DAEFunction{
@@ -4203,12 +4211,12 @@ function DAEFunction{iip, specialize}(
             typeof(sparsity), typeof(Wfact), typeof(Wfact_t),
             typeof(paramjac),
             typeof(observed), typeof(_colorvec),
-            typeof(sys), typeof(initdata),
+            typeof(sys), typeof(initdata), typeof(nlstep_data),
         }(
             _f, analytic, tgrad, jac, jac_u, jac_du, jvp, vjp,
             jac_prototype, sparsity, Wfact, Wfact_t,
             paramjac, observed,
-            _colorvec, sys, initdata
+            _colorvec, sys, initdata, nlstep_data
         )
     end
 end

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -387,6 +387,60 @@ DAEFunction(dfiip, vjp = dvjp)
 DAEFunction(dfoop, vjp = dvjp)
 DAEFunction{true, SciMLBase.NoSpecialize}(dfiip, observed = 1)
 
+@testset "DAEFunction nlstep_data" begin
+    nlstep = SciMLBase.ODENLStepData(
+        NonlinearProblem((z, p) -> z, [1.0]), identity,
+        (gamma1, gamma2, c) -> nothing, identity, identity, identity
+    )
+
+    @testset "construction" begin
+        @test DAEFunction(dfiip).nlstep_data === nothing
+        @test typeof(DAEFunction(dfiip)).parameters[end] === Nothing
+        @test DAEFunction(dfiip; nlstep_data = nlstep).nlstep_data === nlstep
+        @test DAEFunction(dfoop; nlstep_data = nlstep).nlstep_data === nlstep
+        # a `DAEFunction` passed as the function carries its `nlstep_data` over
+        wrapped = DAEFunction{true, SciMLBase.FullSpecialize}(
+            DAEFunction(dfiip; nlstep_data = nlstep)
+        )
+        @test wrapped.nlstep_data === nlstep
+    end
+
+    @testset "specialization $spec" for spec in (
+            SciMLBase.FullSpecialize, SciMLBase.NoSpecialize, SciMLBase.AutoSpecialize,
+        )
+        f = DAEFunction{true, spec}(dfiip; nlstep_data = nlstep)
+        @test f.nlstep_data === nlstep
+
+        # `remake` reconstructs the struct through the keyword constructor, which builds
+        # it positionally with an explicit type-parameter list. `unwrapped_f` has no
+        # `DAEFunction` method and so is the identity here; assert it anyway so a future
+        # method has to keep the field.
+        @test SciMLBase.unwrapped_f(f).nlstep_data === nlstep
+        @test SciMLBase.remake(f).nlstep_data === nlstep
+        @test SciMLBase.remake(f; jac_prototype = zeros(1, 1)).nlstep_data === nlstep
+        # explicit overrides still win, matching `ODEFunction`
+        @test SciMLBase.remake(f; nlstep_data = nothing).nlstep_data === nothing
+
+        # AutoSpecialize erases the bounded parameters to keep the function type
+        # model-independent; `remake` must not narrow them back.
+        widened = SciMLBase.widen_bounded_type_params(f)
+        @test typeof(widened).parameters[end] === Union{Nothing, SciMLBase.ODENLStepData}
+        @test widened.nlstep_data === nlstep
+        rewidened = SciMLBase.remake(widened; jac_prototype = zeros(1, 1))
+        @test typeof(rewidened).parameters[end] ===
+            Union{Nothing, SciMLBase.ODENLStepData}
+        @test rewidened.nlstep_data === nlstep
+    end
+
+    @testset "problem construction" begin
+        prob = DAEProblem(
+            DAEFunction(dfiip; nlstep_data = nlstep), [0.0], [1.0], (0.0, 1.0)
+        )
+        @test prob.f.nlstep_data === nlstep
+        @test SciMLBase.remake(prob; u0 = [2.0]).f.nlstep_data === nlstep
+    end
+end
+
 # DDEFunction
 
 ddefoop(u, h, p, t) = u


### PR DESCRIPTION
> Draft, opened by an agent. **Please ignore until reviewed by @ChrisRackauckas.**

## Contract (read this first — the downstream PRs build on it)

**`ODENLStepData` is reused as-is for DAEs. No blocker was found, and no new type is introduced.**

Every field transfers to the fully implicit case:

| field | DAE meaning |
| --- | --- |
| `nlprob` | the stage `AbstractNonlinearProblem`; unchanged (the DAE stage system is *already* a plain residual root-find, with no mass matrix to carry) |
| `u0perm` (MTK passes `subsetidxs`) | index map from the stage unknowns into the DAE state; unchanged |
| `set_γ_c` | sets the stage scalings and the stage time; `gamma1` becomes the DAE `gamma` (below) |
| `set_outer_tmp` | the affine offset of the **derivative** argument `du` |
| `set_inner_tmp` | the affine offset of the **state** argument `u`; unchanged from the ODE case |
| `nlprobmap` | maps the nonlinear solution back to the state; unchanged |

The documented stage equation for `0 = F(du, u, p, t)` (added to the `ODENLStepData` docstring in this PR):

```
g(z, p') = F(gamma1 * z + outer_tmp, gamma2 * z + inner_tmp, p, t_c)
```

`gamma2`/`inner_tmp` build the state argument exactly as in the mass-matrix form; `gamma1`/`outer_tmp` build the derivative argument. Taking the stage unknown to be the stage state (`gamma2 = 1`, `inner_tmp = 0`), a BDF-type step with `du ≈ (u - tmp) / (γ * dt)` gives `gamma1 = inv(γ * dt)` and `outer_tmp = -tmp / (γ * dt)`. With that convention **`gamma1` is exactly the `gamma` of the existing `DAEFunction` Jacobian signature `jac(J, du, u, p, gamma, t)`** — the Jacobian of the stage residual with respect to `z` is `gamma1 * dF/d(du) + dF/du`. That is the whole reason the reuse is clean: the DAE stage system is structurally the same shape as the ODE one, with `du` substituted affinely instead of `M * z` moved to the other side.

### Two notes for the MTK / OrdinaryDiffEq PRs

1. **`gamma3`.** SciMLBase's documented mass-matrix form has only `gamma1`/`gamma2`, but MTK's `generate_ODENLStepData` actually emits three (`γ₁ₘₜₖ, γ₂ₘₜₖ, γ₃ₘₜₖ`), with `gamma3` scaling the `M * z` term, and `set_γ_c = setsym(nlsys, (ODE_GAMMA..., ODE_C))`. The fully implicit form has no `M * z` term, so `gamma3` has no role in it. The DAE codegen should either set `(gamma1, gamma2, c)` or keep a 3-tuple with `gamma3 ≡ 1` for uniformity — worth deciding explicitly there rather than inheriting it by accident.
2. **Naming.** `ODE`-prefixed naming is now slightly off for the fully implicit case. I deliberately did **not** rename or alias the type (renaming is breaking, and an alias would be new public API needing its own docs entry). Flagging it in case a `DENLStepData` alias is wanted before the downstream PRs land, since that is cheaper to decide now than after MTK and OrdinaryDiffEq reference it.

## What this PR does

SciMLBase half only — the field and its plumbing, docs, and tests. MTK codegen (`generate_ODENLStepData` for `DAEFunction`) and OrdinaryDiffEq consumption (`lib/OrdinaryDiffEqNonlinearSolve/src/utils.jl`) are separate PRs.

Motivation: `ODENLStepData` lets a solver hand the implicit stage solve a pre-built `NonlinearProblem` instead of a closure. `ODEFunction` and `SplitFunction` carry it as `nlstep_data`; `DAEFunction` did not. Circuit simulation — the target application for the limiter/bounds work built on this path — is predominantly DAE, since modified nodal analysis produces algebraic constraints by construction, so today the feature reaches DC operating points and ODE-shaped transients but not the DAE transients it was aimed at.

- `DAEFunction` gains a trailing `nlstep_data::NLP` field, with `NLP <: Union{Nothing, ODENLStepData}` bounded exactly as on `ODEFunction`/`SplitFunction` so `widen_bounded_type_params` erases it under `AutoSpecialize` and `remake` does not narrow it back.
- `DAEFunction{iip, specialize}` gains the `nlstep_data = __has_nlstep_data(f) ? f.nlstep_data : nothing` keyword, so `remake` (which round-trips every field through the keyword constructor) and `DAEFunction(f::SomeOtherFunction)` carry it over.
- `ODENLStepData`'s docstring now states both the mass-matrix and the fully implicit stage equation, and `DAEFunction`'s docstring documents the new keyword.

No new public names, so no new docs entries are required: `ODENLStepData` is already `@public` and already rendered in `docs/src/interfaces/Developer_API.md`, and `DAEFunction`'s docstring (rendered from `docs/src/interfaces/Stochastic_Delay_and_DAE_Function_Types.md`) picks up the new keyword.

Minor version bump, `3.43.1` → `3.44.0`.

## Positional-construction sites updated

Adding a field to a SciML function struct breaks any site that reconstructs it positionally with an explicit type-parameter list. Every such site for `DAEFunction` in this repo:

- `src/scimlfunctions.jl` — `DAEFunction{iip, specialize}` constructor, `NoSpecialize` branch. Passes `Union{Nothing, ODENLStepData}` for the new parameter (not `Any`, which would not satisfy the bound), matching what `ODEFunction` does.
- `src/scimlfunctions.jl` — `DAEFunction{iip, specialize}` constructor, specializing branch. Passes `typeof(nlstep_data)`.

Checked and found to need no change:

- There is no `unwrapped_f(f::DAEFunction, ...)` method (only `ODEFunction`, `SDEFunction`, `NonlinearFunction`, `DiscreteFunction`, `ImplicitDiscreteFunction` have one), so `unwrapped_f` falls through to the identity for `DAEFunction`. The test asserts field preservation through it anyway, so a future DAE method has to keep the field.
- `ConstructionBase.constructorof(::Type{<:DAEFunction{iip}})` builds the parameter list with `map(typeof, args)`, so it adapts.
- `remake`, `_reconstruct_as_type`, `_has_type_erased_params` and `widen_bounded_type_params` are generic/`@generated` over `fieldcount`, so they adapt.
- No package in the local depot (ModelingToolkit, OrdinaryDiffEq*, SciMLSensitivity, DiffEqBase, Sundials) constructs `DAEFunction` with a full explicit type-parameter list — they all go through `DAEFunction{iip}` / `DAEFunction{iip, spec}` keyword constructors, which are unaffected.

## Tests

New `@testset "DAEFunction nlstep_data"` in `test/function_building_error_messages.jl` (Core group), covering:

- construction with and without the field, in-place and out-of-place, and pass-through when a `DAEFunction` is handed to the constructor as `f`;
- for each of `FullSpecialize`, `NoSpecialize`, `AutoSpecialize`: field preservation through `unwrapped_f`, through `remake` (bare, with an unrelated keyword override, and with an explicit `nlstep_data` override), and through `widen_bounded_type_params` — including that `remake` of a widened function keeps `Union{Nothing, ODENLStepData}` rather than narrowing it back, which is where the positional-reconstruction bug hides;
- `DAEProblem` construction and `remake(prob; u0)` preserving the field.

## Local test results

Julia 1.11.9, on this branch.

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` — passed, exit 0:

```
Test Summary:                    | Pass  Total   Time
Function Building Error Messages |  323    323  33.4s   <- includes the 34 new assertions
Test Summary:                 | Pass  Total  Time
Public interface declarations |  545    545  5.3s
Test Summary:          | Pass  Total  Time
Problem building tests |  124    124  7.5s
Test Summary: | Pass  Total     Time
Remake        | 4430   4430  4m11.3s
...
     Testing SciMLBase tests passed
```

(all 27 Core testsets pass; the four above are the ones this change can touch.)

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` — passed, exit 0:

```
Test Summary: | Pass  Total     Time
QA            |   51     51  2m33.8s
     Testing SciMLBase tests passed
```

Runic clean on all changed files.
