### PR TITLE
Rename parameter respecialization marker

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.44.0"
+version = "3.45.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -55,6 +55,7 @@ Note that `iip` choice is required for specialization choices to be made.
 ```@docs
 SciMLBase.AbstractSpecialization
 SciMLBase.AutoSpecialize
+SciMLBase.AutoRespecialize
 SciMLBase.AutoDePSpecialize
 SciMLBase.NoSpecialize
 SciMLBase.FunctionWrapperSpecialize

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2318,7 +2318,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public DECache
 
 # Specialization markers
-@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize
+@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoRespecialize,
+    AutoDePSpecialize
 
 # SDE interpretation trait
 @public AlgorithmInterpretation, alg_interpretation

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -172,7 +172,7 @@ struct FullSpecialize <: AbstractSpecialization end
 """
 $(TYPEDEF)
 
-`AutoDePSpecialize` extends
+`AutoRespecialize` extends
 [`AutoSpecialize`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 by additionally
 *de-specializing the parameter object*. Solver paths with a supported
@@ -186,7 +186,7 @@ across all `isbits` parameter types. Inside the user's `f`, `p` is recovered
 at its original concrete type via a type-stable, allocation-free unpack, so
 the model function itself remains fully specialized.
 
-`AutoDePSpecialize` is the recommended choice for latency-sensitive workflows
+`AutoRespecialize` is the recommended choice for latency-sensitive workflows
 that construct many problems with differently-typed parameter structs
 (parameter studies over configuration structs, package test suites,
 teaching setups).
@@ -205,18 +205,26 @@ struct MyParams
     k::Float64
 end
 f(du, u, p, t) = (du .= p.k .* u)
-ODEProblem{true, SciMLBase.AutoDePSpecialize}(f, [1.0], (0.0, 1.0), MyParams(2.0))
+ODEProblem{true, SciMLBase.AutoRespecialize}(f, [1.0], (0.0, 1.0), MyParams(2.0))
 ```
 """
-struct AutoDePSpecialize <: AbstractSpecialization end
+struct AutoRespecialize <: AbstractSpecialization end
+
+"""
+    AutoDePSpecialize
+
+Deprecated name for [`AutoRespecialize`](@ref). New code should use
+`AutoRespecialize`.
+"""
+const AutoDePSpecialize = AutoRespecialize
 
 specstring = Preferences.@load_preference("SpecializationLevel", "AutoSpecialize")
 if specstring ∉
         (
         "NoSpecialize", "FullSpecialize", "AutoSpecialize", "FunctionWrapperSpecialize",
-        "AutoDePSpecialize",
+        "AutoRespecialize", "AutoDePSpecialize",
     )
-    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize).")
+    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoRespecialize, AutoDePSpecialize).")
 end
 
 const DEFAULT_SPECIALIZATION = getproperty(SciMLBase, Symbol(specstring))

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -279,18 +279,20 @@ end
     @test state_values(sccprob2) isa SVector{3, Float64}
 end
 
-@testset "AutoDePSpecialize specialization marker" begin
+@testset "AutoRespecialize specialization marker" begin
+    @test SciMLBase.AutoDePSpecialize === SciMLBase.AutoRespecialize
+
     struct DePParams
         k::Float64
     end
     f_dep!(du, u, p, t) = (du[1] = -p.k * u[1]; nothing)
 
-    prob = ODEProblem{true, SciMLBase.AutoDePSpecialize}(
+    prob = ODEProblem{true, SciMLBase.AutoRespecialize}(
         f_dep!, [1.0], (0.0, 1.0), DePParams(0.5)
     )
     @test prob isa ODEProblem
-    @test prob.f isa ODEFunction{true, SciMLBase.AutoDePSpecialize}
-    @test SciMLBase.specialization(prob.f) === SciMLBase.AutoDePSpecialize
+    @test prob.f isa ODEFunction{true, SciMLBase.AutoRespecialize}
+    @test SciMLBase.specialization(prob.f) === SciMLBase.AutoRespecialize
     # The marker alone performs no wrapping or packing in SciMLBase: fields stay
     # concretely typed like FullSpecialize/AutoSpecialize construction, and p is
     # the user's struct until a solver path installs an opaque-parameter wrapper.
@@ -302,12 +304,12 @@ end
 
     # Available for other function families, e.g. nonlinear problems.
     f_nl!(res, u, p) = (res[1] = u[1] - p.k; nothing)
-    nlfun = NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(f_nl!)
-    @test SciMLBase.specialization(nlfun) === SciMLBase.AutoDePSpecialize
+    nlfun = NonlinearFunction{true, SciMLBase.AutoRespecialize}(f_nl!)
+    @test SciMLBase.specialization(nlfun) === SciMLBase.AutoRespecialize
 
     # unwrapped_f reconstruction keeps the marker
     uf = SciMLBase.unwrapped_f(prob.f)
-    @test SciMLBase.specialization(uf) === SciMLBase.AutoDePSpecialize
+    @test SciMLBase.specialization(uf) === SciMLBase.AutoRespecialize
 end
 
 @testset "Nonlinear preconditioning keywords are accepted solver options" begin


### PR DESCRIPTION
## What changed and why

Adds `AutoRespecialize` as the canonical name for the constrained parameter-respecialization marker and retains `AutoDePSpecialize` as a documented compatibility alias. The new name distinguishes this non-dynamic, solver-specific strategy from the forthcoming general `DespecializedParameters` dynamic-dispatch barrier.

General registry history shows that `AutoDePSpecialize` shipped in SciMLBase 3.37.0 through 3.44.0, so removing or silently breaking the old binding would not be safe. The existing `SpecializationLevel = "AutoDePSpecialize"` preference remains accepted. The package version is advanced to 3.45.0 for the new public name.

Ignore this draft until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before on clean `upstream/master` (`2b711f36b`):

```text
julia +release --project=. --startup-file=no -e 'using SciMLBase; @assert isdefined(SciMLBase, :AutoRespecialize)'
ERROR: AssertionError: isdefined(SciMLBase, :AutoRespecialize)
```

Passing after:

```text
julia +release --project=. --startup-file=no -e 'using SciMLBase; @assert SciMLBase.AutoDePSpecialize === SciMLBase.AutoRespecialize; p = ODEProblem{true,SciMLBase.AutoRespecialize}((du,u,p,t)->(du .= u), [1.0], (0.0,1.0)); @assert SciMLBase.specialization(p.f) === SciMLBase.AutoRespecialize; println("AutoRespecialize compatibility smoke: pass")'
AutoRespecialize compatibility smoke: pass
```

```text
GROUP=Core JULIA_NUM_PRECOMPILE_TASKS=1 julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass | Total
Remake        | 4430 | 4430
Testing SciMLBase tests passed
```

```text
julia +release --startup-file=no --project=/home/crackauc/.julia/environments/@runic -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/SciMLBase.jl src/scimlfunctions.jl test/problem_building_test.jl
git diff upstream/master...HEAD | typos -
git diff --check upstream/master...HEAD
# all exited 0
```

Local QA is green (51/51). The exact docs build reaches document expansion and then exits only because the pre-existing `Problem_Traits` link returns HTTP 403; a clean upstream/master docs build independently reproduces the same sixteen link-check failures. The result is documented at https://github.com/SciML/SciMLBase.jl/pull/1510#issuecomment-5239037587.

## Not yet verified

- Downstream solver packages; the compatibility alias is intended to keep their existing `AutoDePSpecialize` dispatch working unchanged
- A clean docs exit; current upstream/master is blocked by the independently reproduced external HTTP 403
