### PR TITLE
Add dynamic parameter despecialization for all SciML functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.44.0"
+version = "3.45.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.45.0"
+version = "3.46.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -62,6 +62,14 @@ SciMLBase.FunctionWrapperSpecialize
 SciMLBase.FullSpecialize
 ```
 
+#### Parameter Despecialization
+
+```@docs
+SciMLBase.DespecializedParameters
+SciMLBase.unwrap_parameters
+SciMLBase.invoke_with_despecialized_parameters
+```
+
 #### Specialization Interface Hooks
 
 Solver and modeling packages should query the marker rather than inspect concrete

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -55,6 +55,7 @@ Note that `iip` choice is required for specialization choices to be made.
 ```@docs
 SciMLBase.AbstractSpecialization
 SciMLBase.AutoSpecialize
+SciMLBase.AutoRespecialize
 SciMLBase.AutoDePSpecialize
 SciMLBase.NoSpecialize
 SciMLBase.FunctionWrapperSpecialize

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2318,7 +2318,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public DECache
 
 # Specialization markers
-@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize
+@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoRespecialize,
+    AutoDePSpecialize
 
 # SDE interpretation trait
 @public AlgorithmInterpretation, alg_interpretation

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1758,6 +1758,7 @@ end
 
 """
     specialization(f::AbstractSciMLFunction) -> Type{<:AbstractSpecialization}
+    specialization(::Type{<:AbstractSciMLFunction}) -> Type{<:AbstractSpecialization}
 
 Return the specialization marker carried by a SciML function wrapper.
 
@@ -1772,34 +1773,39 @@ result is a marker type, not an instance, and can be compared with `===`.
 """
 function specialization(
         ::Union{
-            ODEFunction{iip, specialize},
-            SDEFunction{iip, specialize}, DDEFunction{iip, specialize},
-            SDDEFunction{iip, specialize},
-            DAEFunction{iip, specialize},
-            DynamicalODEFunction{iip, specialize},
-            SplitFunction{iip, specialize},
-            DynamicalSDEFunction{iip, specialize},
-            SplitSDEFunction{iip, specialize},
-            DynamicalDDEFunction{iip, specialize},
-            DiscreteFunction{iip, specialize},
-            ImplicitDiscreteFunction{iip, specialize},
-            RODEFunction{iip, specialize},
-            NonlinearFunction{iip, specialize},
-            OptimizationFunction{iip, specialize},
-            BVPFunction{iip, specialize},
-            DynamicalBVPFunction{iip, specialize},
-            IntegralFunction{iip, specialize},
-            BatchIntegralFunction{iip, specialize},
+            ODEFunction{iip, specialize}, SDEFunction{iip, specialize},
+            DDEFunction{iip, specialize}, SDDEFunction{iip, specialize},
+            DAEFunction{iip, specialize}, DynamicalODEFunction{iip, specialize},
+            SplitFunction{iip, specialize}, DynamicalSDEFunction{iip, specialize},
+            SplitSDEFunction{iip, specialize}, DynamicalDDEFunction{iip, specialize},
+            DiscreteFunction{iip, specialize}, ImplicitDiscreteFunction{iip, specialize},
+            RODEFunction{iip, specialize}, NonlinearFunction{iip, specialize},
+            HomotopyNonlinearFunction{iip, specialize},
+            IntervalNonlinearFunction{iip, specialize}, ODEInputFunction{iip, specialize},
+            BVPFunction{iip, specialize}, DynamicalBVPFunction{iip, specialize},
+            IntegralFunction{iip, specialize}, BatchIntegralFunction{iip, specialize},
             IncrementingODEFunction{iip, specialize},
         }
-    ) where {
-        iip,
-        specialize,
-    }
+    ) where {iip, specialize}
     return specialize
 end
 
 specialization(f::AbstractSciMLFunction) = FullSpecialize
+
+for FunctionType in (
+        ODEFunction, SDEFunction, DDEFunction, SDDEFunction, DAEFunction,
+        DynamicalODEFunction, SplitFunction, DynamicalSDEFunction, SplitSDEFunction,
+        DynamicalDDEFunction, DiscreteFunction, ImplicitDiscreteFunction, RODEFunction,
+        NonlinearFunction, HomotopyNonlinearFunction, IntervalNonlinearFunction,
+        ODEInputFunction, BVPFunction, DynamicalBVPFunction, IntegralFunction,
+        BatchIntegralFunction, IncrementingODEFunction,
+    )
+    @eval specialization(
+        ::Type{<:$FunctionType{iip, specialize}}
+    ) where {iip, specialize} = specialize
+end
+
+specialization(::Type{<:AbstractSciMLFunction}) = FullSpecialize
 
 """
 $(TYPEDEF)

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1782,6 +1782,7 @@ function specialization(
             RODEFunction{iip, specialize}, NonlinearFunction{iip, specialize},
             HomotopyNonlinearFunction{iip, specialize},
             IntervalNonlinearFunction{iip, specialize}, ODEInputFunction{iip, specialize},
+            OptimizationFunction{iip, specialize},
             BVPFunction{iip, specialize}, DynamicalBVPFunction{iip, specialize},
             IntegralFunction{iip, specialize}, BatchIntegralFunction{iip, specialize},
             IncrementingODEFunction{iip, specialize},

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -1736,6 +1736,7 @@ include("initialization.jl")
 include("odenlstep.jl")
 include("utils.jl")
 include("function_wrappers.jl")
+include("despecialized_parameters.jl")
 include("scimlfunctions.jl")
 include("alg_traits.jl")
 include("debug.jl")
@@ -2167,12 +2168,13 @@ export ODEAliasSpecifier, LinearAliasSpecifier
     AbstractBVPAlgorithm, AbstractSecondOrderODEAlgorithm, AbstractAliasSpecifier
 
 # Solution / problem support types
-@public NLStats, NullParameters, AbstractSpecialization, AutoSpecialize,
+@public NLStats, NullParameters, DespecializedParameters, AbstractSpecialization, AutoSpecialize,
     AbstractOptimizationCache, DefaultOptimizationCache, OptimizationStats,
     AbstractDEOptions, ODENLStepData
 
 # Core functions
-@public build_solution, build_linear_solution, build_eigenvalue_solution, numargs
+@public build_solution, build_linear_solution, build_eigenvalue_solution, numargs,
+    unwrap_parameters, invoke_with_despecialized_parameters
 
 # Solver problem-concretization extension API
 @public get_concrete_p, get_concrete_u0, isconcreteu0, promote_u0,

--- a/src/despecialized_parameters.jl
+++ b/src/despecialized_parameters.jl
@@ -106,6 +106,13 @@ function SymbolicIndexingInterface.parameter_values(
     )
     return parameter_values(params.params, idx, args...)
 end
+function SymbolicIndexingInterface.parameter_values(
+        params::DespecializedParameters,
+        idx::SymbolicIndexingInterface.ParameterTimeseriesIndex,
+        subidx
+    )
+    return parameter_values(params.params, idx, subidx)
+end
 function SymbolicIndexingInterface.set_parameter!(
         params::DespecializedParameters, value, idx
     )
@@ -126,24 +133,51 @@ end
 adapt_structure(to, params::DespecializedParameters) =
     DespecializedParameters(adapt(to, params.params))
 
-Base.@noinline _invoke_with_despecialized_parameters(f, args...) = f(args...)
+Base.@noinline _invoke_with_despecialized_parameters(f, args...; kwargs...) =
+    f(args...; kwargs...)
 
 """
-    invoke_with_despecialized_parameters(f, args, params, ::Val{parameter_index})
+    invoke_with_despecialized_parameters(f, args; kwargs...)
+    invoke_with_despecialized_parameters(
+        f, args, params, ::Val{parameter_index}; kwargs...)
 
-Call `f(args...)` after replacing `args[parameter_index]` with the object wrapped by
-`params::DespecializedParameters`. The call crosses a non-inlined dynamic-dispatch
-barrier: code above the barrier sees the stable outer parameter type, while `f` compiles
-for the concrete wrapped parameter type.
+Call `f(args...; kwargs...)` after replacing a [`DespecializedParameters`](@ref) argument
+with its wrapped object. The two-argument form locates the wrapper in `args`; the explicit
+form accepts its statically known position. The call crosses a non-inlined dynamic-dispatch
+barrier: code above the barrier sees the stable outer parameter type, while `f` compiles for
+the concrete wrapped parameter type.
 
-This is a developer interface for SciML function wrappers whose parameter position is
-known statically. `args[parameter_index]` must be the same wrapper passed as `params`.
+This is a developer interface used by all built-in [`AbstractSciMLFunction`](@ref)
+containers. `args` may contain at most one despecialized parameter object. In the explicit
+form, `args[parameter_index]` must be the same wrapper passed as `params`.
 """
 Base.@inline @generated function invoke_with_despecialized_parameters(
         f, args::Tuple{Vararg{Any, N}}, params::DespecializedParameters,
-        ::Val{PIdx}
+        ::Val{PIdx}; kwargs...
     ) where {N, PIdx}
     1 <= PIdx <= N || error("parameter_index must be between 1 and $N, got $PIdx")
     call_args = [i == PIdx ? :(getfield(params, :params)) : :(args[$i]) for i in 1:N]
-    return :(_invoke_with_despecialized_parameters(f, $(call_args...)))
+    return :(_invoke_with_despecialized_parameters(f, $(call_args...); kwargs...))
+end
+
+Base.@inline @generated function invoke_with_despecialized_parameters(
+        f, args::Tuple{Vararg{Any, N}}; kwargs...
+    ) where {N}
+    parameter_indices = findall(T -> T <: DespecializedParameters, args.parameters)
+    length(parameter_indices) <= 1 ||
+        error("a SciML function call may contain at most one DespecializedParameters argument")
+    isempty(parameter_indices) && return :(f(args...; kwargs...))
+
+    parameter_index = only(parameter_indices)
+    return :(
+        invoke_with_despecialized_parameters(
+            f, args, args[$parameter_index], Val($parameter_index); kwargs...
+        )
+    )
+end
+
+function invoke_with_despecialized_parameters(
+        f::FunctionWrappersWrappers.FunctionWrappersWrapper, args::Tuple; kwargs...
+    )
+    return f(args...; kwargs...)
 end

--- a/src/despecialized_parameters.jl
+++ b/src/despecialized_parameters.jl
@@ -1,0 +1,149 @@
+"""
+$(TYPEDEF)
+
+Store a parameter object behind the stable field type `Any`. This prevents callers such
+as solver internals from specializing on the concrete parameter-container layout. Use
+[`invoke_with_despecialized_parameters`](@ref) to cross a dynamic function barrier before
+calling code that needs the original concrete parameter type.
+
+This strategy accepts arbitrary parameter objects and forwards the common `Base`,
+SciMLStructures, SymbolicIndexingInterface, ArrayInterface, and Adapt interfaces to the
+wrapped value. The dynamic dispatch isolates inference loss at the function barrier, but
+adds runtime overhead. Use [`unwrap_parameters`](@ref) in transformations such as AD that
+need to reconstruct a problem with concrete parameters. Use [`FullSpecialize`](@ref) when
+runtime performance takes priority over compilation reuse.
+
+`DespecializedParameters` is distinct from [`AutoRespecialize`](@ref): the latter lets a
+supporting solver recover a concrete parameter type without dynamic dispatch, but imposes
+solver-specific restrictions on symbolic indexing and parameter differentiation.
+
+The wrapped object is available through the `params` field. Other properties and
+collection operations are forwarded to it.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct DespecializedParameters
+    params::Any
+end
+
+DespecializedParameters(params::DespecializedParameters) = params
+
+"""
+    unwrap_parameters(params)
+
+Return the parameter object stored in [`DespecializedParameters`](@ref). The fallback is
+the identity, so downstream transformations can call this function without first testing
+whether parameters were despecialized.
+"""
+unwrap_parameters(params) = params
+unwrap_parameters(params::DespecializedParameters) = getfield(params, :params)
+
+function Base.getproperty(params::DespecializedParameters, name::Symbol)
+    name === :params && return getfield(params, :params)
+    return getproperty(getfield(params, :params), name)
+end
+
+function Base.propertynames(params::DespecializedParameters, private::Bool = false)
+    return (:params, propertynames(getfield(params, :params), private)...)
+end
+
+Base.copy(params::DespecializedParameters) = DespecializedParameters(copy(params.params))
+Base.:(==)(a::DespecializedParameters, b::DespecializedParameters) = a.params == b.params
+Base.isequal(a::DespecializedParameters, b::DespecializedParameters) =
+    isequal(a.params, b.params)
+Base.hash(params::DespecializedParameters, h::UInt) = hash(params.params, h)
+
+Base.IndexStyle(::Type{DespecializedParameters}) = IndexLinear()
+Base.eltype(::Type{DespecializedParameters}) = Any
+Base.getindex(params::DespecializedParameters, idx...) = getindex(params.params, idx...)
+Base.setindex!(params::DespecializedParameters, val, idx...) =
+    setindex!(params.params, val, idx...)
+Base.length(params::DespecializedParameters) = length(params.params)
+Base.size(params::DespecializedParameters) = size(params.params)
+Base.axes(params::DespecializedParameters) = axes(params.params)
+Base.firstindex(params::DespecializedParameters) = firstindex(params.params)
+Base.lastindex(params::DespecializedParameters) = lastindex(params.params)
+Base.iterate(params::DespecializedParameters) = iterate(params.params)
+Base.iterate(params::DespecializedParameters, state) = iterate(params.params, state)
+
+ArrayInterface.ismutable(params::DespecializedParameters) =
+    ArrayInterface.ismutable(params.params)
+
+SciMLStructures.isscimlstructure(params::DespecializedParameters) =
+    SciMLStructures.isscimlstructure(params.params)
+function SciMLStructures.ismutablescimlstructure(params::DespecializedParameters)
+    return applicable(SciMLStructures.ismutablescimlstructure, params.params) &&
+        SciMLStructures.ismutablescimlstructure(params.params)
+end
+function SciMLStructures.hasportion(
+        portion::SciMLStructures.AbstractPortion, params::DespecializedParameters
+    )
+    return SciMLStructures.hasportion(portion, params.params)
+end
+function SciMLStructures.canonicalize(
+        portion::SciMLStructures.AbstractPortion, params::DespecializedParameters
+    )
+    values, repack, aliases = SciMLStructures.canonicalize(portion, params.params)
+    repack === nothing && return values, nothing, aliases
+    return values, values -> DespecializedParameters(repack(values)), aliases
+end
+function SciMLStructures.replace(
+        portion::SciMLStructures.AbstractPortion, params::DespecializedParameters, values
+    )
+    return DespecializedParameters(SciMLStructures.replace(portion, params.params, values))
+end
+function SciMLStructures.replace!(
+        portion::SciMLStructures.AbstractPortion, params::DespecializedParameters, values
+    )
+    return SciMLStructures.replace!(portion, params.params, values)
+end
+
+SymbolicIndexingInterface.parameter_values(params::DespecializedParameters) = params
+function SymbolicIndexingInterface.parameter_values(
+        params::DespecializedParameters, idx, args...
+    )
+    return parameter_values(params.params, idx, args...)
+end
+function SymbolicIndexingInterface.set_parameter!(
+        params::DespecializedParameters, value, idx
+    )
+    return set_parameter!(params.params, value, idx)
+end
+function SymbolicIndexingInterface.remake_buffer(
+        indp, params::DespecializedParameters, idxs, values
+    )
+    return DespecializedParameters(remake_buffer(indp, params.params, idxs, values))
+end
+function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
+        indp, params::DespecializedParameters, args...
+    )
+    updated = with_updated_parameter_timeseries_values(indp, params.params, args...)
+    return DespecializedParameters(updated)
+end
+
+adapt_structure(to, params::DespecializedParameters) =
+    DespecializedParameters(adapt(to, params.params))
+
+Base.@noinline _invoke_with_despecialized_parameters(f, args...) = f(args...)
+
+"""
+    invoke_with_despecialized_parameters(f, args, params, ::Val{parameter_index})
+
+Call `f(args...)` after replacing `args[parameter_index]` with the object wrapped by
+`params::DespecializedParameters`. The call crosses a non-inlined dynamic-dispatch
+barrier: code above the barrier sees the stable outer parameter type, while `f` compiles
+for the concrete wrapped parameter type.
+
+This is a developer interface for SciML function wrappers whose parameter position is
+known statically. `args[parameter_index]` must be the same wrapper passed as `params`.
+"""
+Base.@inline @generated function invoke_with_despecialized_parameters(
+        f, args::Tuple{Vararg{Any, N}}, params::DespecializedParameters,
+        ::Val{PIdx}
+    ) where {N, PIdx}
+    1 <= PIdx <= N || error("parameter_index must be between 1 and $N, got $PIdx")
+    call_args = [i == PIdx ? :(getfield(params, :params)) : :(args[$i]) for i in 1:N]
+    return :(_invoke_with_despecialized_parameters(f, $(call_args...)))
+end

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2901,6 +2901,18 @@ function (f::DynamicalODEFunction)(du, u, p, t)
     )
 end
 
+function (f::DynamicalSDEFunction)(u, p, t)
+    f1 = invoke_with_despecialized_parameters(f.f1, (u.x[1], u.x[2], p, t))
+    f2 = invoke_with_despecialized_parameters(f.f2, (u.x[1], u.x[2], p, t))
+    return ArrayPartition(f1, f2)
+end
+function (f::DynamicalSDEFunction)(du, u, p, t)
+    invoke_with_despecialized_parameters(f.f1, (du.x[1], u.x[1], u.x[2], p, t))
+    return invoke_with_despecialized_parameters(
+        f.f2, (du.x[2], u.x[1], u.x[2], p, t)
+    )
+end
+
 (f::SplitFunction)(u, p, t) =
     invoke_with_despecialized_parameters(f.f1, (u, p, t)) +
     invoke_with_despecialized_parameters(f.f2, (u, p, t))

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -172,7 +172,7 @@ struct FullSpecialize <: AbstractSpecialization end
 """
 $(TYPEDEF)
 
-`AutoDePSpecialize` extends
+`AutoRespecialize` extends
 [`AutoSpecialize`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 by additionally
 *de-specializing the parameter object*. Solver paths with a supported
@@ -186,7 +186,7 @@ across all `isbits` parameter types. Inside the user's `f`, `p` is recovered
 at its original concrete type via a type-stable, allocation-free unpack, so
 the model function itself remains fully specialized.
 
-`AutoDePSpecialize` is the recommended choice for latency-sensitive workflows
+`AutoRespecialize` is the recommended choice for latency-sensitive workflows
 that construct many problems with differently-typed parameter structs
 (parameter studies over configuration structs, package test suites,
 teaching setups).
@@ -205,18 +205,26 @@ struct MyParams
     k::Float64
 end
 f(du, u, p, t) = (du .= p.k .* u)
-ODEProblem{true, SciMLBase.AutoDePSpecialize}(f, [1.0], (0.0, 1.0), MyParams(2.0))
+ODEProblem{true, SciMLBase.AutoRespecialize}(f, [1.0], (0.0, 1.0), MyParams(2.0))
 ```
 """
-struct AutoDePSpecialize <: AbstractSpecialization end
+struct AutoRespecialize <: AbstractSpecialization end
+
+"""
+    AutoDePSpecialize
+
+Deprecated name for [`AutoRespecialize`](@ref). New code should use
+`AutoRespecialize`.
+"""
+const AutoDePSpecialize = AutoRespecialize
 
 specstring = Preferences.@load_preference("SpecializationLevel", "AutoSpecialize")
 if specstring ∉
         (
         "NoSpecialize", "FullSpecialize", "AutoSpecialize", "FunctionWrapperSpecialize",
-        "AutoDePSpecialize",
+        "AutoRespecialize", "AutoDePSpecialize",
     )
-    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoDePSpecialize).")
+    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoRespecialize, AutoDePSpecialize).")
 end
 
 const DEFAULT_SPECIALIZATION = getproperty(SciMLBase, Symbol(specstring))

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2851,6 +2851,20 @@ end
 
 (f::ODEFunction)(args...) = f.f(args...)
 
+function (f::ODEFunction)(du, u, p::DespecializedParameters, t)
+    if f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
+        return f.f(du, u, p, t)
+    end
+    return invoke_with_despecialized_parameters(f, (du, u, p, t), p, Val(3))
+end
+
+function (f::ODEFunction)(u, p::DespecializedParameters, t)
+    if f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
+        return f.f(u, p, t)
+    end
+    return invoke_with_despecialized_parameters(f, (u, p, t), p, Val(2))
+end
+
 @static if isdefined(SciMLOperators, :isv1)
     function (f::ODEFunction)(du, u, p, t)
         if f.f isa AbstractSciMLOperator

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2849,7 +2849,7 @@ end
 
 ######### Backwards Compatibility Overloads
 
-(f::ODEFunction)(args...) = f.f(args...)
+(f::ODEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
 function (f::ODEFunction)(du, u, p::DespecializedParameters, t)
     if f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
@@ -2883,21 +2883,27 @@ end
     end
 end
 
-(f::NonlinearFunction)(args...) = f.f(args...)
-(f::HomotopyNonlinearFunction)(args...) = f.f(args...)
-(f::IntervalNonlinearFunction)(args...) = f.f(args...)
-(f::IntegralFunction)(args...) = f.f(args...)
-(f::BatchIntegralFunction)(args...) = f.f(args...)
+(f::NonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::HomotopyNonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::IntervalNonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::IntegralFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::BatchIntegralFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
 function (f::DynamicalODEFunction)(u, p, t)
-    return ArrayPartition(f.f1(u.x[1], u.x[2], p, t), f.f2(u.x[1], u.x[2], p, t))
+    f1 = invoke_with_despecialized_parameters(f.f1, (u.x[1], u.x[2], p, t))
+    f2 = invoke_with_despecialized_parameters(f.f2, (u.x[1], u.x[2], p, t))
+    return ArrayPartition(f1, f2)
 end
 function (f::DynamicalODEFunction)(du, u, p, t)
-    f.f1(du.x[1], u.x[1], u.x[2], p, t)
-    return f.f2(du.x[2], u.x[1], u.x[2], p, t)
+    invoke_with_despecialized_parameters(f.f1, (du.x[1], u.x[1], u.x[2], p, t))
+    return invoke_with_despecialized_parameters(
+        f.f2, (du.x[2], u.x[1], u.x[2], p, t)
+    )
 end
 
-(f::SplitFunction)(u, p, t) = f.f1(u, p, t) + f.f2(u, p, t)
+(f::SplitFunction)(u, p, t) =
+    invoke_with_despecialized_parameters(f.f1, (u, p, t)) +
+    invoke_with_despecialized_parameters(f.f2, (u, p, t))
 function (f::SplitFunction)(du, u, p, t)
     if f._func_cache === nothing
         throw(
@@ -2912,23 +2918,27 @@ function (f::SplitFunction)(du, u, p, t)
         )
     end
     tmp = get_tmp(f._func_cache, du)
-    f.f1(tmp, u, p, t)
-    f.f2(du, u, p, t)
+    invoke_with_despecialized_parameters(f.f1, (tmp, u, p, t))
+    invoke_with_despecialized_parameters(f.f2, (du, u, p, t))
     return du .+= tmp
 end
 
-(f::DiscreteFunction)(args...) = f.f(args...)
-(f::ImplicitDiscreteFunction)(args...) = f.f(args...)
-(f::DAEFunction)(args...) = f.f(args...)
-(f::DDEFunction)(args...) = f.f(args...)
-(f::ODEInputFunction)(args...) = f.f(args...)
+(f::DiscreteFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::ImplicitDiscreteFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::DAEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::DDEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::ODEInputFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
 function (f::DynamicalDDEFunction)(u, h, p, t)
-    return ArrayPartition(f.f1(u.x[1], u.x[2], h, p, t), f.f2(u.x[1], u.x[2], h, p, t))
+    f1 = invoke_with_despecialized_parameters(f.f1, (u.x[1], u.x[2], h, p, t))
+    f2 = invoke_with_despecialized_parameters(f.f2, (u.x[1], u.x[2], h, p, t))
+    return ArrayPartition(f1, f2)
 end
 function (f::DynamicalDDEFunction)(du, u, h, p, t)
-    f.f1(du.x[1], u.x[1], u.x[2], h, p, t)
-    return f.f2(du.x[2], u.x[1], u.x[2], h, p, t)
+    invoke_with_despecialized_parameters(f.f1, (du.x[1], u.x[1], u.x[2], h, p, t))
+    return invoke_with_despecialized_parameters(
+        f.f2, (du.x[2], u.x[1], u.x[2], h, p, t)
+    )
 end
 function Base.getproperty(f::DynamicalDDEFunction, name::Symbol)
     if name === :f
@@ -2938,40 +2948,42 @@ function Base.getproperty(f::DynamicalDDEFunction, name::Symbol)
     return getfield(f, name)
 end
 
-(f::SDEFunction)(args...) = f.f(args...)
+(f::SDEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
 @static if isdefined(SciMLOperators, :isv1)
     function (f::SDEFunction)(du, u, p, t)
         if f.f isa AbstractSciMLOperator
-            f.f(du, u, u, p, t)
+            invoke_with_despecialized_parameters(f.f, (du, u, u, p, t))
         else
-            f.f(du, u, p, t)
+            invoke_with_despecialized_parameters(f.f, (du, u, p, t))
         end
     end
 
     function (f::SDEFunction)(u, p, t)
         if f.f isa AbstractSciMLOperator
-            f.f(u, u, p, t)
+            invoke_with_despecialized_parameters(f.f, (u, u, p, t))
         else
-            f.f(u, p, t)
+            invoke_with_despecialized_parameters(f.f, (u, p, t))
         end
     end
 end
 
-(f::SDDEFunction)(args...) = f.f(args...)
-(f::SplitSDEFunction)(u, p, t) = f.f1(u, p, t) + f.f2(u, p, t)
+(f::SDDEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::SplitSDEFunction)(u, p, t) =
+    invoke_with_despecialized_parameters(f.f1, (u, p, t)) +
+    invoke_with_despecialized_parameters(f.f2, (u, p, t))
 
 function (f::SplitSDEFunction)(du, u, p, t)
     tmp = get_tmp(f._func_cache, du)
-    f.f1(tmp, u, p, t)
-    f.f2(du, u, p, t)
+    invoke_with_despecialized_parameters(f.f1, (tmp, u, p, t))
+    invoke_with_despecialized_parameters(f.f2, (du, u, p, t))
     return du .+= tmp
 end
 
-(f::RODEFunction)(args...) = f.f(args...)
+(f::RODEFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
-(f::BVPFunction)(args...) = f.f(args...)
-(f::DynamicalBVPFunction)(args...) = f.f(args...)
+(f::BVPFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::DynamicalBVPFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 
 ######### Basic Constructor
 
@@ -4767,7 +4779,7 @@ chosen by the solver rather than generated via automatic differentiation.
 """
 struct NoAD <: AbstractADType end
 
-(f::OptimizationFunction)(args...) = f.f(args...)
+(f::OptimizationFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 function OptimizationFunction(f, args...; kwargs...)
     isinplace(f, 2, outofplace_param_number = 2)
     return OptimizationFunction{true}(f, args...; kwargs...)
@@ -4823,7 +4835,8 @@ function OptimizationFunction{iip}(
 end
 
 # Function call operator for MultiObjectiveOptimizationFunction
-(f::MultiObjectiveOptimizationFunction)(args...) = f.f(args...)
+(f::MultiObjectiveOptimizationFunction)(args...) =
+    invoke_with_despecialized_parameters(f.f, args)
 
 # Convenience constructor
 function MultiObjectiveOptimizationFunction(f, args...; kwargs...)
@@ -5880,7 +5893,8 @@ function IncrementingODEFunction(f)
     return IncrementingODEFunction{isinplace(f, 7), DEFAULT_SPECIALIZATION}(f)
 end
 
-(f::IncrementingODEFunction)(args...; kwargs...) = f.f(args...; kwargs...)
+(f::IncrementingODEFunction)(args...; kwargs...) =
+    invoke_with_despecialized_parameters(f.f, args; kwargs...)
 
 for S in [
         :ODEFunction

--- a/src/solutions/save_idxs.jl
+++ b/src/solutions/save_idxs.jl
@@ -462,6 +462,14 @@ function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
     return ps
 end
 
+
+function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
+        sswf::SavedSubsystemWithFallback, params::DespecializedParameters, args...
+    )
+    updated = with_updated_parameter_timeseries_values(sswf, params.params, args...)
+    return DespecializedParameters(updated)
+end
+
 """
     $(TYPEDSIGNATURES)
 

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -118,6 +118,13 @@ for fn in [
     end
 end
 
+function SymbolicIndexingInterface.with_updated_parameter_timeseries_values(
+        sol::AbstractTimeseriesSolution, params::DespecializedParameters, args...
+    )
+    updated = with_updated_parameter_timeseries_values(sol, params.params, args...)
+    return DespecializedParameters(updated)
+end
+
 function SymbolicIndexingInterface.state_values(sol::AbstractTimeseriesSolution, i)
     ss = get_saved_subsystem(sol)
     ss === nothing && return sol.u[i]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -392,6 +392,8 @@ end
 
 anyeltypedual(x) = anyeltypedual(x, Val{0})
 anyeltypedual(x, counter) = Any
+anyeltypedual(x::DespecializedParameters) = anyeltypedual(x.params)
+anyeltypedual(x::DespecializedParameters, counter) = anyeltypedual(x.params, counter)
 anyeltypedual(x::FixedSizeDiffCache, counter = 0) = Any
 
 """

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -394,6 +394,11 @@ anyeltypedual(x) = anyeltypedual(x, Val{0})
 anyeltypedual(x, counter) = Any
 anyeltypedual(x::DespecializedParameters) = anyeltypedual(x.params)
 anyeltypedual(x::DespecializedParameters, counter) = anyeltypedual(x.params, counter)
+function anyeltypedual(
+        x::DespecializedParameters, counter::Type{Val{N}}
+    ) where {N}
+    return anyeltypedual(x.params, counter)
+end
 anyeltypedual(x::FixedSizeDiffCache, counter = 0) = Any
 
 """

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -92,6 +92,9 @@ end
     foreach(call -> call(), calls)
     @test !isempty(seen)
     @test all(==(DespecializedCallParameters), seen)
+    @test SciMLBase.specialization(NonlinearFunction{false, SciMLBase.AutoSpecialize}) ===
+        SciMLBase.AutoSpecialize
+    @test SciMLBase.specialization(OptimizationFunction) === SciMLBase.FullSpecialize
 end
 
 @testset "stable container and forwarded interfaces" begin

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -82,6 +82,11 @@ end
             (x, v, p, t) -> [record_parameter_type(p)],
             (x, v, p, t) -> [record_parameter_type(p)]
         )(dynamical_u, params, 0.0),
+        () -> DynamicalSDEFunction{false}(
+            (x, v, p, t) -> [record_parameter_type(p)],
+            (x, v, p, t) -> [record_parameter_type(p)],
+            (u, p, t) -> u
+        )(dynamical_u, params, 0.0),
         () -> SplitSDEFunction{false}(
             (u, p, t) -> record_parameter_type(p),
             (u, p, t) -> record_parameter_type(p),

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -172,8 +172,9 @@ end
     @test args[1] == [-8.0]
 
     dual = ForwardDiff.Dual{:despecialized_parameters}(2.0, 1.0)
-    @test SciMLBase.anyeltypedual(SciMLBase.DespecializedParameters([dual])) <:
-    ForwardDiff.Dual
+    dual_params = SciMLBase.DespecializedParameters([dual])
+    @test SciMLBase.anyeltypedual(dual_params) <: ForwardDiff.Dual
+    @test SciMLBase.anyeltypedual(dual_params, Val{0}) <: ForwardDiff.Dual
 
     function wrapped_rhs!(du, u, p, t)
         return rhs!(du, u, SciMLBase.unwrap_parameters(p), t)

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -1,5 +1,7 @@
 using Adapt
 using FunctionWrappersWrappers
+using ForwardDiff
+using RecursiveArrayTools: ArrayPartition
 using SciMLBase
 using SciMLStructures
 using SymbolicIndexingInterface
@@ -7,6 +9,89 @@ using Test
 
 struct DespecializedCallParameters
     rate::Float64
+end
+
+@testset "all callable SciMLFunction families" begin
+    params = SciMLBase.DespecializedParameters(DespecializedCallParameters(2.0))
+    seen = DataType[]
+    function record_parameter_type(p)
+        push!(seen, typeof(p))
+        return p.rate
+    end
+
+    u = [1.0]
+    dynamical_u = ArrayPartition([1.0], [2.0])
+    calls = (
+        () -> NonlinearFunction{false}((u, p) -> record_parameter_type(p))(u, params),
+        () -> IntervalNonlinearFunction{false}((u, p) -> record_parameter_type(p))(
+            1.0, params
+        ),
+        () -> IntegralFunction{false}((u, p) -> record_parameter_type(p), nothing)(
+            u, params
+        ),
+        () -> BatchIntegralFunction{false}(
+            (u, p) -> record_parameter_type(p), nothing
+        )(u, params),
+        () -> DiscreteFunction{false}((u, p, t) -> record_parameter_type(p))(
+            u, params, 0.0
+        ),
+        () -> ImplicitDiscreteFunction{false}(
+            (unext, u, p, t) -> record_parameter_type(p)
+        )(u, u, params, 0.0),
+        () -> DAEFunction{false}((du, u, p, t) -> record_parameter_type(p))(
+            u, u, params, 0.0
+        ),
+        () -> DDEFunction{false}((u, h, p, t) -> record_parameter_type(p))(
+            u, nothing, params, 0.0
+        ),
+        () -> SDEFunction{false}(
+            (u, p, t) -> record_parameter_type(p), (u, p, t) -> u
+        )(u, params, 0.0),
+        () -> SDDEFunction{false}(
+            (u, h, p, t) -> record_parameter_type(p), (u, h, p, t) -> u
+        )(u, nothing, params, 0.0),
+        () -> RODEFunction{false}((u, p, t, W) -> record_parameter_type(p))(
+            u, params, 0.0, nothing
+        ),
+        () -> ODEInputFunction{false}((x, u, p, t) -> record_parameter_type(p))(
+            u, u, params, 0.0
+        ),
+        () -> OptimizationFunction((u, p) -> record_parameter_type(p))(u, params),
+        () -> MultiObjectiveOptimizationFunction((u, p) -> record_parameter_type(p))(
+            u, params
+        ),
+        () -> HomotopyNonlinearFunction{false}((u, p) -> record_parameter_type(p))(
+            u, params
+        ),
+        () -> BVPFunction{false}(
+            (u, p, t) -> record_parameter_type(p), (u, p, t) -> nothing
+        )(u, params, 0.0),
+        () -> DynamicalBVPFunction{false}(
+            (du, u, p, t) -> record_parameter_type(p),
+            (du, u, p, t) -> nothing
+        )(u, u, params, 0.0),
+        () -> IncrementingODEFunction{false}(
+            (u, p, t, alpha, beta; scale = 1) ->
+            scale * record_parameter_type(p)
+        )(u, params, 0.0, 1.0, 2.0; scale = 2),
+        () -> SplitFunction{false}(
+            (u, p, t) -> record_parameter_type(p),
+            (u, p, t) -> record_parameter_type(p)
+        )(u, params, 0.0),
+        () -> DynamicalODEFunction{false}(
+            (x, v, p, t) -> [record_parameter_type(p)],
+            (x, v, p, t) -> [record_parameter_type(p)]
+        )(dynamical_u, params, 0.0),
+        () -> SplitSDEFunction{false}(
+            (u, p, t) -> record_parameter_type(p),
+            (u, p, t) -> record_parameter_type(p),
+            (u, p, t) -> u
+        )(u, params, 0.0),
+    )
+
+    foreach(call -> call(), calls)
+    @test !isempty(seen)
+    @test all(==(DespecializedCallParameters), seen)
 end
 
 @testset "stable container and forwarded interfaces" begin
@@ -82,6 +167,10 @@ end
     args = (zeros(1), [4.0], params, 0.0)
     SciMLBase.invoke_with_despecialized_parameters(rhs!, args, params, Val(3))
     @test args[1] == [-8.0]
+
+    dual = ForwardDiff.Dual{:despecialized_parameters}(2.0, 1.0)
+    @test SciMLBase.anyeltypedual(SciMLBase.DespecializedParameters([dual])) <:
+    ForwardDiff.Dual
 
     function wrapped_rhs!(du, u, p, t)
         return rhs!(du, u, SciMLBase.unwrap_parameters(p), t)

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -1,0 +1,95 @@
+using Adapt
+using FunctionWrappersWrappers
+using SciMLBase
+using SciMLStructures
+using SymbolicIndexingInterface
+using Test
+
+struct DespecializedCallParameters
+    rate::Float64
+end
+
+@testset "stable container and forwarded interfaces" begin
+    params = SciMLBase.DespecializedParameters([1.0, 2.0])
+    other = SciMLBase.DespecializedParameters((rate = 2.0,))
+
+    @test typeof(params) === typeof(other)
+    @test fieldtype(typeof(params), :params) === Any
+    @test SciMLBase.DespecializedParameters(params) === params
+    @test SciMLBase.unwrap_parameters(params) === params.params
+    @test SciMLBase.unwrap_parameters(params.params) === params.params
+    @test params[2] == 2.0
+    @test length(params) == 2
+    @test size(params) == (2,)
+    @test collect(params) == [1.0, 2.0]
+    @test copy(params) == params
+    @test hash(copy(params)) == hash(params)
+
+    params[1] = 3.0
+    @test params.params == [3.0, 2.0]
+    @test SymbolicIndexingInterface.parameter_values(params) === params
+    @test SymbolicIndexingInterface.parameter_values(params, 2) == 2.0
+    @test SymbolicIndexingInterface.set_parameter!(params, 4.0, 2) == 4.0
+    @test params.params == [3.0, 4.0]
+
+    @test SciMLStructures.isscimlstructure(params)
+    @test !SciMLStructures.ismutablescimlstructure(params)
+    @test SciMLStructures.hasportion(SciMLStructures.Tunable(), params)
+    values, repack, aliases = SciMLStructures.canonicalize(
+        SciMLStructures.Tunable(), params
+    )
+    @test values == [3.0, 4.0]
+    @test aliases
+    repacked = repack([5.0, 6.0])
+    @test repacked isa SciMLBase.DespecializedParameters
+    @test repacked.params == [5.0, 6.0]
+    replaced = SciMLStructures.replace(SciMLStructures.Tunable(), params, [7.0, 8.0])
+    @test replaced isa SciMLBase.DespecializedParameters
+    @test replaced.params == [7.0, 8.0]
+
+    remade = SymbolicIndexingInterface.remake_buffer(
+        nothing, SciMLBase.DespecializedParameters(Dict(:rate => 1.0)), [:rate], [2.0]
+    )
+    @test remade isa SciMLBase.DespecializedParameters
+    @test remade.params == Dict(:rate => 2.0)
+    @test Adapt.adapt(Array, params) isa SciMLBase.DespecializedParameters
+end
+
+@testset "dynamic function barrier" begin
+    params = SciMLBase.DespecializedParameters(DespecializedCallParameters(2.0))
+    seen_iip = Ref{DataType}()
+    seen_oop = Ref{DataType}()
+
+    function rhs!(du, u, p, t)
+        seen_iip[] = typeof(p)
+        du[1] = -p.rate * u[1]
+        return nothing
+    end
+    function rhs(u, p, t)
+        seen_oop[] = typeof(p)
+        return -p.rate .* u
+    end
+
+    f_iip = ODEFunction{true, SciMLBase.AutoSpecialize}(rhs!)
+    f_oop = ODEFunction{false, SciMLBase.AutoSpecialize}(rhs)
+    du = zeros(1)
+    f_iip(du, [3.0], params, 0.0)
+    @test du == [-6.0]
+    @test seen_iip[] === DespecializedCallParameters
+    @test f_oop([3.0], params, 0.0) == [-6.0]
+    @test seen_oop[] === DespecializedCallParameters
+
+    args = (zeros(1), [4.0], params, 0.0)
+    SciMLBase.invoke_with_despecialized_parameters(rhs!, args, params, Val(3))
+    @test args[1] == [-8.0]
+
+    function wrapped_rhs!(du, u, p, t)
+        return rhs!(du, u, SciMLBase.unwrap_parameters(p), t)
+    end
+    wrapped = FunctionWrappersWrappers.FunctionWrappersWrapper(
+        SciMLBase.Void(wrapped_rhs!), (typeof((du, [3.0], params, 0.0)),), (Nothing,)
+    )
+    wrapped_f = ODEFunction{true, SciMLBase.AutoSpecialize}(wrapped)
+    wrapped_f(du, [3.0], params, 0.0)
+    @test du == [-6.0]
+end

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -279,18 +279,20 @@ end
     @test state_values(sccprob2) isa SVector{3, Float64}
 end
 
-@testset "AutoDePSpecialize specialization marker" begin
+@testset "AutoRespecialize specialization marker" begin
+    @test SciMLBase.AutoDePSpecialize === SciMLBase.AutoRespecialize
+
     struct DePParams
         k::Float64
     end
     f_dep!(du, u, p, t) = (du[1] = -p.k * u[1]; nothing)
 
-    prob = ODEProblem{true, SciMLBase.AutoDePSpecialize}(
+    prob = ODEProblem{true, SciMLBase.AutoRespecialize}(
         f_dep!, [1.0], (0.0, 1.0), DePParams(0.5)
     )
     @test prob isa ODEProblem
-    @test prob.f isa ODEFunction{true, SciMLBase.AutoDePSpecialize}
-    @test SciMLBase.specialization(prob.f) === SciMLBase.AutoDePSpecialize
+    @test prob.f isa ODEFunction{true, SciMLBase.AutoRespecialize}
+    @test SciMLBase.specialization(prob.f) === SciMLBase.AutoRespecialize
     # The marker alone performs no wrapping or packing in SciMLBase: fields stay
     # concretely typed like FullSpecialize/AutoSpecialize construction, and p is
     # the user's struct until a solver path installs an opaque-parameter wrapper.
@@ -302,12 +304,12 @@ end
 
     # Available for other function families, e.g. nonlinear problems.
     f_nl!(res, u, p) = (res[1] = u[1] - p.k; nothing)
-    nlfun = NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(f_nl!)
-    @test SciMLBase.specialization(nlfun) === SciMLBase.AutoDePSpecialize
+    nlfun = NonlinearFunction{true, SciMLBase.AutoRespecialize}(f_nl!)
+    @test SciMLBase.specialization(nlfun) === SciMLBase.AutoRespecialize
 
     # unwrapped_f reconstruction keeps the marker
     uf = SciMLBase.unwrapped_f(prob.f)
-    @test SciMLBase.specialization(uf) === SciMLBase.AutoDePSpecialize
+    @test SciMLBase.specialization(uf) === SciMLBase.AutoRespecialize
 end
 
 @testset "Nonlinear preconditioning keywords are accepted solver options" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,9 @@ run_tests(;
         @time @safetestset "Function wrappers" begin
             include("function_wrappers.jl")
         end
+        @time @safetestset "Despecialized parameters" begin
+            include("despecialized_parameters.jl")
+        end
         @time @safetestset "Performance warnings" begin
             include("performance_warnings.jl")
         end


### PR DESCRIPTION
Ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

Adds the public `DespecializedParameters` container and a shared dynamic function barrier. Its `params::Any` field gives solver-facing code one stable parameter type; `invoke_with_despecialized_parameters` unwraps immediately before the concrete model call, containing inference loss at that boundary.

The barrier is applied to every callable built-in SciMLFunction family: ODE, nonlinear and interval nonlinear, homotopy nonlinear, integral and batched integral, discrete and implicit discrete, DAE, DDE and SDDE, SDE and RODE, ODE input, optimization and multi-objective optimization, BVP and dynamical BVP, plus split, dynamical, and incrementing variants. FunctionWrappersWrapper keeps receiving the stable outer parameter type so its fixed signature remains valid.

The wrapper forwards common collection operations, SciMLStructures, SymbolicIndexingInterface, ArrayInterface, and Adapt. `unwrap_parameters` gives AD and transformation code a public opt-out hook. `specialization` now has instance and type-level queries so modeling packages can choose this behavior without inspecting concrete type-parameter positions.

This is distinct from `AutoRespecialize`: `DespecializedParameters` supports arbitrary dynamic parameter objects at the cost of one dispatch barrier, while `AutoRespecialize` lets supporting solvers recover a concrete parameter type without dynamic dispatch but has solver-specific packing, symbolic-indexing, and differentiation constraints.

This PR is stacked on the rename/API clarification in https://github.com/SciML/SciMLBase.jl/pull/1510. ModelingToolkit integration is https://github.com/SciML/ModelingToolkit.jl/pull/4919.

## Failing before / passing after

Against the prerequisite branch before `DespecializedParameters` exists, the exact new test file errors immediately:

```text
julia +release --project=/path/to/rename-branch --startup-file=no -e 'using SciMLBase; include("/path/to/despecialized-branch/test/despecialized_parameters.jl")'
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
UndefVarError: `DespecializedParameters` not defined in `SciMLBase`
```

The all-family barrier discriminator was also run on commit `ebe2bbffd08b660e98f4e6636c83853a9d38e8bf`, before the shared SciMLFunction call methods. `NonlinearFunction` delivered `SciMLBase.DespecializedParameters` to the user function instead of the concrete wrapped parameter type and failed. With the barrier commit applied, the same discriminator printed `nonlinear barrier: pass`.

On current HEAD, the complete focused test passes:

```text
julia +release --project=. --startup-file=no -e 'using SciMLBase; include("test/despecialized_parameters.jl")'
Test Summary:                          | Pass  Total
all callable SciMLFunction families    |    4      4
stable container and forwarded interfaces | 28     28
dynamic function barrier               |    7      7
```

The first test executes 21 callable SciMLFunction containers and verifies that every user function sees the concrete wrapped parameter type.

```text
julia +release --project=. --startup-file=no -e 'using SciMLBase, Test; @show length(Test.detect_ambiguities(SciMLBase))'
length(Test.detect_ambiguities(SciMLBase)) = 0
```

Runic, `typos` over the diff, and `git diff --check` all exit 0.

## Additional verification

```text
GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
Remake | 4430/4430
Testing SciMLBase tests passed

GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
QA | 51/51
Testing SciMLBase tests passed
```

The focused ModelingToolkitBase ForwardDiff/Zygote/SciMLSensitivity test passes 2/2 in 5m37.1s. The exact docs build reaches document expansion and then exits only because the pre-existing `Problem_Traits` link returns HTTP 403; clean upstream/master reproduces the same sixteen link-check failures.

## Still running / not yet verified

- Full ModelingToolkit feature-group rerun
- A clean docs exit; current upstream/master is blocked by the independently reproduced external HTTP 403
- Final compile-time and runtime benchmark reruns

The draft was pushed before those long validations completed at the explicit request of @ChrisRackauckas. Results will be added from actual runs.

No dependency was added or newly enabled.
