### PR TITLE
Fix DynamicalDDEFunction constructors

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -4353,7 +4353,7 @@ DDEFunction(f::DDEFunction; kwargs...) = f
         typeof(mass_matrix),
         typeof(analytic), typeof(tgrad), typeof(jac), typeof(jvp),
         typeof(vjp),
-        typeof(jac_prototype),
+        typeof(jac_prototype), typeof(sparsity),
         typeof(Wfact), typeof(Wfact_t), typeof(paramjac), typeof(observed),
         typeof(colorvec),
         typeof(sys), typeof(initialization_data),
@@ -4388,7 +4388,7 @@ function DynamicalDDEFunction{iip, specialize}(
         colorvec = __has_colorvec(f1) ? f1.colorvec :
             nothing,
         sys = __has_sys(f1) ? f1.sys : nothing,
-        initialization_data = __has_initialization_data(f) ? f.initialization_data :
+        initialization_data = __has_initialization_data(f1) ? f1.initialization_data :
             nothing
     ) where {
         iip,
@@ -4414,7 +4414,7 @@ function DynamicalDDEFunction{iip, specialize}(
         )
     else
         DynamicalDDEFunction{
-            iip, typeof(f1), typeof(f2), typeof(mass_matrix),
+            iip, specialize, typeof(f1), typeof(f2), typeof(mass_matrix),
             typeof(analytic),
             typeof(tgrad), typeof(jac), typeof(jvp), typeof(vjp),
             typeof(jac_prototype), typeof(sparsity),

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -207,6 +207,28 @@ end
     @test resid[2] ≈ u0[1] + u0[2] - 1.0
 end
 
+@testset "DynamicalDDEFunction constructors" begin
+    f1(u, h, p, t) = u
+    f2(u, h, p, t) = -u
+    initialization_data = Ref(:initialization_data)
+    wrapped_f1 = DDEFunction{false}(f1; initialization_data)
+
+    for specialize in (SciMLBase.FullSpecialize, SciMLBase.NoSpecialize)
+        f = DynamicalDDEFunction{false, specialize}(wrapped_f1, f2)
+        @test f isa DynamicalDDEFunction{false, specialize}
+        @test f.initialization_data === initialization_data
+    end
+
+    f = DynamicalDDEFunction{false}(;
+        f1, f2, mass_matrix = nothing, analytic = nothing, tgrad = nothing,
+        jac = nothing, jvp = nothing, vjp = nothing, jac_prototype = nothing,
+        sparsity = nothing, Wfact = nothing, Wfact_t = nothing, paramjac = nothing,
+        observed = nothing, colorvec = nothing, sys = nothing
+    )
+    @test f isa DynamicalDDEFunction{false, SciMLBase.FullSpecialize}
+    @test f.sparsity === nothing
+end
+
 # test for tspan promotion in DiscreteProblem
 let
     p = (0.1 / 1000, 0.01)


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Fix all three type/default-argument errors in the `DynamicalDDEFunction` constructor paths: inherit `initialization_data` from `f1`, retain the requested specialization marker, and include the `sparsity` field type in the keyword-only constructor. Together these errors made explicit specialization fail before the function container could be constructed.

`git bisect` identified https://github.com/SciML/SciMLBase.jl/commit/b7468f9b012ab2b41f6b225eba2006f5544e606b as the first revision producing the undefined-`f` error. The regression tests cover `FullSpecialize`, `NoSpecialize`, initialization-data propagation, and the keyword-only constructor.

## Verification

### Failing before

On unmodified `master` at `2b711f36b1cd93d5da098997081a416bcec1e07b`, the new test failed with:

```text
DynamicalDDEFunction constructors: Error During Test
UndefVarError: `f` not defined
Test Summary:          | Pass  Error  Total
Problem building tests |  124      1    125
```

Command:

```sh
GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
```

### Passing after

The same command on this branch passed, including:

```text
Test Summary:          | Pass  Total
Problem building tests |  130    130
Test Summary: | Pass  Total
Remake        | 4430   4430
Testing SciMLBase tests passed
```

Additional checks:

```text
GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
QA | 49 passed / 49 total

julia +1.12 --project=.runic-env --startup-file=no -m Runic --check --diff src/scimlfunctions.jl test/problem_building_test.jl
exit 0 (Runic 1.7.0)

typos --diff
exit 0

git diff --check
exit 0
```

## Not verified

`GROUP=Everything`, downstream groups, and the documentation build were not run. This change does not touch documentation, docstrings, or public API declarations.
