### PR TITLE
Add AutoDespecialize parameter policy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.45.0"
+version = "3.46.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -55,6 +55,7 @@ Note that `iip` choice is required for specialization choices to be made.
 ```@docs
 SciMLBase.AbstractSpecialization
 SciMLBase.AutoSpecialize
+SciMLBase.AutoDespecialize
 SciMLBase.AutoRespecialize
 SciMLBase.AutoDePSpecialize
 SciMLBase.NoSpecialize

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2327,8 +2327,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 @public DECache
 
 # Specialization markers
-@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoRespecialize,
-    AutoDePSpecialize
+@public FullSpecialize, NoSpecialize, FunctionWrapperSpecialize, AutoDespecialize,
+    AutoRespecialize, AutoDePSpecialize
 
 # SDE interpretation trait
 @public AlgorithmInterpretation, alg_interpretation

--- a/src/despecialized_parameters.jl
+++ b/src/despecialized_parameters.jl
@@ -11,7 +11,8 @@ SciMLStructures, SymbolicIndexingInterface, ArrayInterface, and Adapt interfaces
 wrapped value. The dynamic dispatch isolates inference loss at the function barrier, but
 adds runtime overhead. Use [`unwrap_parameters`](@ref) in transformations such as AD that
 need to reconstruct a problem with concrete parameters. Use [`FullSpecialize`](@ref) when
-runtime performance takes priority over compilation reuse.
+runtime performance takes priority over compilation reuse. Supported solvers select this
+container with [`AutoDespecialize`](@ref).
 
 `DespecializedParameters` is distinct from [`AutoRespecialize`](@ref): the latter lets a
 supporting solver recover a concrete parameter type without dynamic dispatch, but imposes

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -19,12 +19,13 @@ with [`specialization`](@ref) instead of relying on a particular parameter
 position. Problem construction and `remake` should preserve an explicitly chosen
 marker unless the caller requests a different function representation.
 
-The built-in markers are [`AutoSpecialize`](@ref), [`NoSpecialize`](@ref),
-[`FunctionWrapperSpecialize`](@ref), and [`FullSpecialize`](@ref). Their behavior
-is implemented jointly by SciMLBase constructors and downstream solver packages:
-a marker alone does not automatically erase types or install callable wrappers.
-New `AbstractSpecialization` subtypes therefore require explicit support in every
-function constructor and solver path that is expected to honor them.
+The built-in markers are [`AutoSpecialize`](@ref), [`AutoDespecialize`](@ref),
+[`AutoRespecialize`](@ref), [`NoSpecialize`](@ref),
+[`FunctionWrapperSpecialize`](@ref), and [`FullSpecialize`](@ref). Their behavior is
+implemented jointly by SciMLBase constructors and downstream solver packages: a marker
+alone does not automatically erase types or install callable wrappers. New
+`AbstractSpecialization` subtypes therefore require explicit support in every function
+constructor and solver path that is expected to honor them.
 
 Solver and transformation code must not assume that a type-restricted wrapped
 callable accepts new state, time, parameter, or AD types. Use
@@ -87,6 +88,41 @@ ODEProblem{true, SciMLBase.AutoSpecialize}(f, [1.0], (0.0, 1.0))
 ```
 """
 struct AutoSpecialize <: AbstractSpecialization end
+
+"""
+$(TYPEDEF)
+
+`AutoDespecialize` asks supported solver paths to store `p` in a
+[`DespecializedParameters`](@ref) container. [`AutoSpecialize`](@ref) retains its existing
+function-specialization behavior and does not select this parameter container. The
+container has a stable outer type and stores the original parameter object in an `Any`
+field, so solver compilation can be reused across parameter-container types. Built-in
+SciML function containers cross a dynamic function barrier before calling model code,
+where the original concrete parameter object is recovered.
+
+This policy accepts arbitrary parameter objects and does not impose the opaque-container
+constraints of [`AutoRespecialize`](@ref). The tradeoff is dynamic dispatch at the model
+function barrier. Transformations such as parameter AD may call
+[`unwrap_parameters`](@ref) and reconstruct a concretely parameterized problem when
+needed. Symbolic and modeling packages must forward their parameter interfaces through
+`DespecializedParameters` for indexed access to remain available.
+
+Support is solver-specific. A solver without an `AutoDespecialize` path may fall back to
+ordinary specialization without wrapping `p`.
+
+## Example
+
+```julia
+struct MyParameters
+    rate::Float64
+end
+f(du, u, p, t) = (du .= -p.rate .* u)
+ODEProblem{true, SciMLBase.AutoDespecialize}(
+    f, [1.0], (0.0, 1.0), MyParameters(2.0)
+)
+```
+"""
+struct AutoDespecialize <: AbstractSpecialization end
 
 """
 $(TYPEDEF)
@@ -222,9 +258,9 @@ specstring = Preferences.@load_preference("SpecializationLevel", "AutoSpecialize
 if specstring ∉
         (
         "NoSpecialize", "FullSpecialize", "AutoSpecialize", "FunctionWrapperSpecialize",
-        "AutoRespecialize", "AutoDePSpecialize",
+        "AutoDespecialize", "AutoRespecialize", "AutoDePSpecialize",
     )
-    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoRespecialize, AutoDePSpecialize).")
+    error("SpecializationLevel preference $specstring is not in the allowed set of choices (NoSpecialize, FullSpecialize, AutoSpecialize, FunctionWrapperSpecialize, AutoDespecialize, AutoRespecialize, AutoDePSpecialize).")
 end
 
 const DEFAULT_SPECIALIZATION = getproperty(SciMLBase, Symbol(specstring))

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -99,6 +99,10 @@ end
     @test all(==(DespecializedCallParameters), seen)
     @test SciMLBase.specialization(NonlinearFunction{false, SciMLBase.AutoSpecialize}) ===
         SciMLBase.AutoSpecialize
+    @test SciMLBase.specialization(
+        NonlinearFunction{false, SciMLBase.AutoDespecialize}
+    ) === SciMLBase.AutoDespecialize
+    @test SciMLBase.AutoDespecialize !== SciMLBase.AutoRespecialize
     @test SciMLBase.specialization(OptimizationFunction) === SciMLBase.FullSpecialize
 end
 
@@ -163,8 +167,8 @@ end
         return -p.rate .* u
     end
 
-    f_iip = ODEFunction{true, SciMLBase.AutoSpecialize}(rhs!)
-    f_oop = ODEFunction{false, SciMLBase.AutoSpecialize}(rhs)
+    f_iip = ODEFunction{true, SciMLBase.AutoDespecialize}(rhs!)
+    f_oop = ODEFunction{false, SciMLBase.AutoDespecialize}(rhs)
     du = zeros(1)
     f_iip(du, [3.0], params, 0.0)
     @test du == [-6.0]


### PR DESCRIPTION
## What changed

Adds `AutoDespecialize` as a specialization policy distinct from both the unchanged `AutoSpecialize` policy and the constrained `AutoRespecialize` policy. Supporting solvers can use it to place arbitrary parameter objects behind the existing `DespecializedParameters` dynamic function barrier, while transformations can opt out through `unwrap_parameters`.

The new public marker is documented and included in the specialization preference allowlist. This is a minor public API addition, so the package version advances to 3.46.0.

## Verification

Before this commit, the public marker discriminator failed:

```text
$ julia +release --project=. -e 'using SciMLBase; @assert SciMLBase.AutoDespecialize <: SciMLBase.AbstractSpecialization'
ERROR: UndefVarError: `AutoDespecialize` not defined in `SciMLBase`
```

After this commit:

```text
$ julia +release --project=. -e 'using SciMLBase; @assert SciMLBase.AutoDespecialize <: SciMLBase.AbstractSpecialization; @assert SciMLBase.AutoSpecialize !== SciMLBase.AutoDespecialize; @assert SciMLBase.AutoRespecialize !== SciMLBase.AutoDespecialize; println("AutoDespecialize marker: pass")'
AutoDespecialize marker: pass
```

```text
$ GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
Despecialized Parameters | 42 passed
Public interface checks | 552 passed
Remake | 4430 passed
Testing SciMLBase tests passed
```

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
QA | 51 passed | 51 total
Testing SciMLBase tests passed
```

The exact docs build on current `master` reaches `CheckDocument` and then fails only on the 16 pre-existing `Problem_Traits` HTTP 403 links. With the focused existing fix from https://github.com/SciML/SciMLBase.jl/pull/1485 stacked locally, the same command completes doctests, cross-references, rendering, and link checking with exit 0:

```text
$ julia +release --project=docs docs/make.jl
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="3.46.0"` for inventory from ../Project.toml
```

Runic 1.7, `typos` over the changed files, and `git diff --check` all exit 0.

## Not verified here

Solver-side automatic wrapping and precompilation are intentionally separate changes in DiffEqBase/OrdinaryDiffEq. ModelingToolkit's default selection and parameter-interface forwarding are also separate so each ownership boundary remains independently reviewable.

Draft: ignore until reviewed by @ChrisRackauckas.

## Links

- Existing clean-base docs fix: https://github.com/SciML/SciMLBase.jl/pull/1485
- Existing dynamic barrier implementation: https://github.com/SciML/SciMLBase.jl/pull/1511
- Existing constrained-policy rename: https://github.com/SciML/SciMLBase.jl/pull/1510
- ModelingToolkit integration draft: https://github.com/SciML/ModelingToolkit.jl/pull/4919
