### PR TITLE
Document the generic isinplace interface

### DIFF
--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -50,6 +50,16 @@ change the first value). This is automatically determined using the methods tabl
 but note that for full type-inferability of the `AbstractSciMLProblem` this iip-ness should
 be specified.
 
+### In-place Trait Contract
+
+Every concrete `AbstractSciMLFunction{iip}` subtype must encode whether its
+primary callback mutates its first argument in the `iip` parameter. Generic
+solver and extension code must obtain this information through
+`isinplace(f)`, rather than inspecting fields or type parameters. The generic
+trait returns `true` for in-place and `false` for out-of-place function
+containers; callers can therefore support new concrete subtypes without adding
+type-specific dispatches.
+
 ### Specialization Choices
 
 Each `SciMLFunction` type allows for specialization choices

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -291,19 +291,48 @@ Check whether a user callback follows the in-place SciML convention.
 For an [`AbstractSciMLFunction`](@ref), `isinplace` returns the `iip` type
 parameter without inspecting methods. For an ordinary callable, it inspects the
 method table and compares available arities to the expected in-place and
-out-of-place signatures. `inplace_param_number` is the number of positional
-arguments for the in-place form, while `outofplace_param_number` defaults to one
-fewer argument. For example, an ODE right-hand side uses `4` for
-`f!(du, u, p, t)` and `3` for `f(u, p, t)`.
+out-of-place signatures.
+
+# Arguments
+
+- `f`: An [`AbstractSciMLFunction`](@ref) or callback whose calling convention is
+  being queried.
+- `inplace_param_number`: Number of positional arguments in the in-place callback
+  signature. For example, an ODE right-hand side uses `4` for `f!(du, u, p, t)`.
+- `fname`: Name used to identify `f` in an argument-convention error.
+- `iip_preferred`: Convention selected when `f` provides both accepted arities.
+
+# Keywords
+
+- `has_two_dispatches`: Whether the interface accepts both in-place and
+  out-of-place callback signatures. Set this to `false` for interfaces with only
+  one accepted arity, such as optimization objectives.
+- `isoptimization`: Whether errors should use optimization-specific wording.
+- `outofplace_param_number`: Number of positional arguments in the out-of-place
+  callback signature. It defaults to `inplace_param_number - 1`; the ODE
+  out-of-place form is therefore `f(u, p, t)`.
+
+# Returns
+
+Returns `true` for the in-place convention and `false` for the out-of-place
+convention. Concrete `AbstractSciMLFunction` subtypes must expose their
+convention through this trait; generic solver code must query `isinplace(f)` and
+must not inspect subtype fields or type parameters directly.
 
 If neither accepted arity is present, `isinplace` throws a function-argument
 error that uses `fname` to identify the offending callback. If both accepted
 arities are present, `iip_preferred = true` chooses the in-place interpretation
 and `iip_preferred = false` chooses the out-of-place interpretation.
 
-Set `has_two_dispatches = false` for interfaces that only accept one arity, such
-as optimization objective functions, so a shorter out-of-place form is not
-treated as valid.
+# Examples
+
+```julia
+f!(du, u, p, t) = (du .= u)
+f(u, p, t) = u
+
+isinplace(f!, 4) # true
+isinplace(f, 4)  # false
+```
 
 # See also
 

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -38,6 +38,8 @@ SciMLBase.get_concrete_problem(
 SciMLBase.check_prob_alg_pairing(::ConcretizationHookProblem, ::ConcretizationHookAlgorithm) =
     nothing
 
+struct GenericSciMLFunction{iip} <: SciMLBase.AbstractSciMLFunction{iip} end
+
 struct ConcreteSolveContractProblem end
 struct ConcreteSolveContractAlgorithm end
 struct ConcreteSolveContractSenseAlg end
@@ -177,6 +179,12 @@ end
     @test occursin("`update_coefficients` for the out-of-place form", function_docs)
     @test occursin("ODE and Discrete Function Types", function_docs)
     @test !occursin("SciMLBase.ODEFunction\n", function_docs)
+end
+
+@testset "AbstractSciMLFunction in-place trait contract" begin
+    @test SciMLBase.isinplace(GenericSciMLFunction{true}()) === true
+    @test SciMLBase.isinplace(GenericSciMLFunction{false}()) === false
+    @test Docs.doc(SciMLBase.isinplace) !== nothing
 end
 
 @testset "Problem layout marker interface" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

Documents the `AbstractSciMLFunction{iip}` trait contract at the generic `isinplace` definition, adds a rendered interface explanation, and tests a generic external subtype through the public trait.

Local verification:
- `Pkg.test()` passed.
- Runic check passed for the changed source and docs files.
- Documentation doctests and document-binding checks passed with the checkout developed into the docs environment. The final strict linkcheck currently fails on the pre-existing `Problem_Traits` stable URL regression, which is already fixed by https://github.com/SciML/SciMLBase.jl/pull/1485 without disabling link checking; this PR should follow that fix.