### PR TITLE
Fix Julia 1.11 docstring assertion

### DIFF
--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -190,12 +190,13 @@ end
     @test SciMLBase.isinplace(GenericSciMLFunction{true}()) === true
     @test SciMLBase.isinplace(GenericSciMLFunction{false}()) === false
     @test !occursin("No documentation found", sprint(show, @doc SciMLBase.isinplace))
+    @test (@doc SciMLBase.isinplace) !== nothing
 end
 
 @testset "AbstractSciMLAlgorithm global-error trait contract" begin
     @test !SciMLBase.has_global_error(GenericGlobalErrorAlgorithm())
     @test SciMLBase.has_global_error(GenericGlobalErrorReportingAlgorithm())
-    @test Docs.doc(SciMLBase.has_global_error) !== nothing
+    @test (@doc SciMLBase.has_global_error) !== nothing
 end
 
 @testset "Problem layout marker interface" begin

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -190,7 +190,6 @@ end
     @test SciMLBase.isinplace(GenericSciMLFunction{true}()) === true
     @test SciMLBase.isinplace(GenericSciMLFunction{false}()) === false
     @test !occursin("No documentation found", sprint(show, @doc SciMLBase.isinplace))
-    @test (@doc SciMLBase.isinplace) !== nothing
 end
 
 @testset "AbstractSciMLAlgorithm global-error trait contract" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Change

Replace the Julia-internal `Docs.doc(SciMLBase.has_global_error)` assertion with the public `@doc` form in `test/public_interface.jl`.

This is a test-only compatibility fix. It changes no SciMLBase API, runtime behavior, or documentation content. The redundant `isinplace` assertion was removed after rebasing because the existing test already checks its attached public docstring.

## Why this is still needed

On clean current master `8d9728a4d37f86381edcf0a253b7bf0076d1da48`, Julia 1.11.9 fails at the unchanged assertion:

```console
$ julia +1.11 --startup-file=no --project=. -e 'include("test/public_interface.jl")'
Expression: Docs.doc(SciMLBase.has_global_error) !== nothing
MethodError: no method matching doc(::typeof(SciMLBase.has_global_error))
Test Summary:                                      | Pass Error Total
AbstractSciMLAlgorithm global-error trait contract |    2     1     3
ERROR: LoadError: Some tests did not pass
```

The same direct test include passes on the PR head `3fbb6670955fd817ce8673146896d52c02c23d20`, with the affected testset passing 3/3.

## Verification

- `julia +1.10 --startup-file=no --project=. -e 'include("test/public_interface.jl")'` - passed.
- `julia +1.11 --startup-file=no --project=. -e 'include("test/public_interface.jl")'` - passed; all public-interface testsets passed.
- `julia +1.12 --startup-file=no --project=. -e 'include("test/public_interface.jl")'` - passed; all public-interface testsets passed.
- `typos test/public_interface.jl` - passed.
- JuliaFormatter check - no formatting changes required.
- `git diff --check` - passed.

The PR remains intentionally focused on the Julia 1.11 documentation assertion and is a draft for @ChrisRackauckas review.