### PR TITLE
Publish instability diagnostic hooks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.46.0"
+version = "3.47.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -69,8 +69,14 @@ SciMLBase.build_eigenvalue_solution
 
 ## Integrator Hook
 
+Solver and symbolic-system packages use these hooks to add diagnostics when an
+integration becomes unstable.
+
 ```@docs
 SciMLBase.last_step_failed
+SciMLBase.log_numerical_instability
+SciMLBase.has_mtk_sys
+SciMLBase.diagnose_symbolic_instability
 SciMLBase.AbstractDEOptions
 SciMLBase.ODENLStepData
 SciMLBase.JacobianWrapper

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2251,6 +2251,9 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Solution / integrator interface
 @public DEStats, check_error!, promote_tspan, set_ut!, get_sol, done, postamble!
 
+# Instability diagnostic extension API
+@public log_numerical_instability, has_mtk_sys, diagnose_symbolic_instability
+
 # Versioned solver-author extension API. These names are deliberately not exported:
 # application code should use the user-facing solve and solution interfaces instead.
 @public enable_interpolation_sensitivitymode, get_root_indp, has_initializeprob,

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -894,10 +894,35 @@ documented `reinit!` method. Supported optional keywords can still vary by
 problem family. The default is `false`.
 """ has_reinit
 
+"""
+    log_numerical_instability(integrator; jacobian_logging = true)
+
+Return a numerical diagnostic for an unstable integration as a string.
+
+Solver packages can extend this hook for their integrator types. If `jacobian_logging`
+is `false`, the diagnostic should omit Jacobian analysis because a symbolic diagnostic
+has already identified the instability. The default is an empty string.
+"""
 log_numerical_instability(integrator; jacobian_logging::Bool = true) = ""
 
+"""
+    has_mtk_sys(integrator)
+
+Return whether `integrator.f.sys` supports [`diagnose_symbolic_instability`](@ref).
+
+Solver packages that expose a compatible symbolic system through `integrator.f.sys`
+should extend this trait for their integrator type. The default is `false`.
+"""
 has_mtk_sys(integrator) = false
 
+"""
+    diagnose_symbolic_instability(sys, u, uprev)
+
+Return a symbolic diagnostic for an unstable integration as a string.
+
+Symbolic-system packages can extend this hook to diagnose the change from `uprev` to
+`u`. The default is an empty string.
+"""
 diagnose_symbolic_instability(sys, u, uprev) = ""
 
 ### Display

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -497,6 +497,7 @@ if isdefined(Base, :ispublic)
                 :done, :postamble!, :enable_interpolation_sensitivitymode,
                 :get_root_indp, :has_initializeprob, :late_binding_update_u0_p,
                 :strip_interpolation, :unitfulvalue, :value, :last_step_failed,
+                :log_numerical_instability, :has_mtk_sys, :diagnose_symbolic_instability,
                 Symbol("@def"), :_unwrap_val,
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,


### PR DESCRIPTION
Promote `log_numerical_instability`, `has_mtk_sys`, and
`diagnose_symbolic_instability` to SciMLBase's documented public extension API.
OrdinaryDiffEq and ModelingToolkit already extend these hooks, so keeping them
non-public causes ExplicitImports failures in downstream QA. The package version
is advanced to 3.47.0 because this adds public API.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before this change:

```console
$ julia +1.11 --startup-file=no --project=. -e 'using SciMLBase, Test; @testset "diagnostic hooks" begin; for name in (:log_numerical_instability, :has_mtk_sys, :diagnose_symbolic_instability); @test Base.ispublic(SciMLBase, name); @test Base.Docs.hasdoc(SciMLBase, name); end; end'
Test Summary:    | Fail  Total
diagnostic hooks |    6      6
```

Passing with this change:

```console
$ julia +1.11 --startup-file=no --project=. -e 'using SciMLBase, Test; @testset "diagnostic hooks" begin; for name in (:log_numerical_instability, :has_mtk_sys, :diagnose_symbolic_instability); @test Base.ispublic(SciMLBase, name); @test Base.Docs.hasdoc(SciMLBase, name); end; end'
Test Summary:    | Pass  Total
diagnostic hooks |    6      6
```

```console
$ GROUP=QA julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA            |   51     51  10m30.6s
630.765196 seconds (216.68 M allocations: 14.074 GiB, 2.25% gc time, 17 lock conflicts, 13.42% compilation time: 7% of which was recompilation)
Testing SciMLBase tests passed
```

```console
$ julia +1 --startup-file=no -m Runic --check .
$ git diff --check
$ typos Project.toml docs/src/interfaces/Developer_API.md src/SciMLBase.jl src/integrator_interface.jl test/public_interface.jl
```

The docs build completed doctests, template expansion, and cross-reference
checking, but did not finish successfully: its link checker received HTTP 403
responses for the pre-existing external `Problem_Traits` links and ended with
`makedocs encountered an error [:linkcheck]`. I did not silence that failure.

The downstream test environment listed
`SciMLBase v3.47.0 ../../sandbox/.../.scimlbase-diagnostic-api`, confirming that
the actual QA assertions used this checkout:

```console
$ JULIA_DEPOT_PATH=/path/to/isolated-depot GROUP=OrdinaryDiffEqCore_QA julia +1 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                        | Pass  Total  Time
Core Infrastructure AllocCheck Tests |    1      1  0.6s
Test Summary: | Pass  Broken  Total   Time
JET Tests     |   30       1     31  38.5s
Test Summary: | Pass  Total   Time
Aqua          |   26     26  37.7s
Testing OrdinaryDiffEqCore tests passed
Testing OrdinaryDiffEq tests passed
```

SciMLBase PR https://github.com/SciML/SciMLBase.jl/pull/1503 refactors the same
hooks, so it may produce a small nearby conflict, but it does not make them public.
