### PR TITLE
Fix SplitFunction _func_cache aliasing u0

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -234,10 +234,13 @@ end
 # In-place `SplitFunction` evaluation needs a temporary buffer (`_func_cache`).
 # `SplitODEProblem` always allocates it from `u0`; bare `ODEProblem(sf, u0, tspan)`
 # must do the same so `f(du,u,p,t)` does not call `get_tmp(nothing, du)`.
+# The buffer must be a copy: `DiffCache(u0)` keeps the passed array itself as the
+# primary buffer, so `f(du,u,p,t)` would evaluate `f1` into `u0`'s memory.
 function ODEProblem(f::SplitFunction, u0, tspan, args...; kwargs...)
     iip = isinplace(f)
     if iip && f._func_cache === nothing
-        _func_cache = typeof(u0) <: AbstractArray{<:Number} ? DiffCache(u0) : u0
+        _func_cache = typeof(u0) <: AbstractArray{<:Number} ? DiffCache(copy(u0)) :
+            copy(u0)
         f = remake(f; _func_cache)
     end
     return ODEProblem{iip}(f, u0, tspan, args...; kwargs...)
@@ -563,7 +566,10 @@ function SplitODEProblem{iip}(
         kwargs...
     ) where {iip}
     if f._func_cache === nothing && iip
-        _func_cache = typeof(u0) <: AbstractArray{<:Number} ? DiffCache(u0) : u0
+        # A copy, not `u0` itself: `DiffCache(u0)` would keep `u0` as the primary
+        # buffer and a direct `f(du,u,p,t)` would evaluate `f1` into `u0`'s memory.
+        _func_cache = typeof(u0) <: AbstractArray{<:Number} ? DiffCache(copy(u0)) :
+            copy(u0)
         f = remake(f; _func_cache)
     end
     return ODEProblem(f, u0, tspan, p, SplitODEProblem{iip}(); kwargs...)

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -71,6 +71,34 @@ end
     @test prob_oop.f(1.0, nothing, 0.0) == 0.0
 end
 
+# `_func_cache` must not alias `u0`: `f1` is evaluated into the cache, so an
+# aliased buffer overwrites the initial condition on every combined `f` call
+# and returns a wrong sum when called at `u0` itself.
+@testset "SplitFunction _func_cache does not alias u0" begin
+    f1! = (du, u, p, t) -> (du .= 2 .* u)
+    f2! = (du, u, p, t) -> (du .= u)
+
+    for build in (
+            (u0,) -> SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+            (u0,) -> ODEProblem(SplitFunction(f1!, f2!), u0, (0.0, 1.0)),
+        )
+        u0 = [1.0, 2.0]
+        prob = build(u0)
+        @test SciMLBase.get_tmp(prob.f._func_cache, u0) !== u0
+
+        # evaluation at u0 itself: f1 + f2 = 3u
+        du = zeros(2)
+        prob.f(du, u0, nothing, 0.0)
+        @test du == [3.0, 6.0]
+        @test u0 == [1.0, 2.0]
+
+        # evaluation at another state must not touch u0 either
+        prob.f(du, [5.0, 7.0], nothing, 0.0)
+        @test du == [15.0, 21.0]
+        @test u0 == [1.0, 2.0]
+    end
+end
+
 @testset "`constructorof` tests" begin
     probs = []
 


### PR DESCRIPTION
Fixes #1519.

`SplitODEProblem` and the bare `ODEProblem(::SplitFunction, ...)` path build the in-place scratch cache as `DiffCache(u0)`, and DiffCache keeps the passed array as its primary buffer, so any direct combined call `f(du, u, p, t)` evaluates `f1` into `prob.u0`'s memory. With `u === u0` the result itself is wrong (`f2` reads the state `f1` just overwrote); with any other `u` the result is right but the stored initial condition is silently replaced. Details and history in #1519.

The change is `DiffCache(copy(u0))` at both construction sites, plus `copy(u0)` in the non-number-array fallback, which was handing out `u0` itself as the buffer. Only the buffer's identity changes, so the dual-cache path that #1106 added for OrdinaryDiffEq#2719 is untouched.

Test added to problem_building_test.jl: the cache must not alias `u0`, the combined call at `u0` returns `f1 + f2` correctly, and `u0` is bit-identical after combined calls at `u0` and at a different state, for both construction paths. The new test fails on master (`du == [4.0, 8.0]` instead of `[3.0, 6.0]`, `u0` mutated) and passes with the fix. Also re-verified the #2719 downstream case (Rodas5P on a split problem, ForwardDiff Jacobian through the cache) and solve-path equivalence against the joined problem.

## AI Disclosure

Claude assisted with this work.
