### PR TITLE
Document solution_new_retcode generic

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -115,6 +115,18 @@ See also [`__solve`](@ref), which implements the direct solve path.
 """
 function __init end
 
+"""
+    solution_new_retcode(sol, retcode)
+
+Return a copy of the solution `sol` with its return code replaced by `retcode`. The
+solution is otherwise left unchanged; this is used to update the `retcode` of an existing
+solution (e.g. when an integrator finishes and the final status becomes known).
+
+Solver packages extend this generic for the solution types they own. Methods should return
+the same solution type with its return code replaced and preserve its other data.
+"""
+function solution_new_retcode end
+
 # Local alias for the `Union{Function, Type}` callable bound (mirrors the
 # unexported `Base.Callable`), so problem constructors can dispatch on it
 # without a non-public qualified access to Base.

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -711,13 +711,6 @@ function build_solution(sol::ODESolution{T, N}, u_analytic, errors) where {T, N}
     return @set sol.errors = errors
 end
 
-"""
-    solution_new_retcode(sol, retcode)
-
-Return a copy of the solution `sol` with its return code replaced by `retcode`. The
-solution is otherwise left unchanged; this is used to update the `retcode` of an existing
-solution (e.g. when an integrator finishes and the final status becomes known).
-"""
 function solution_new_retcode(sol::ODESolution{T, N}, retcode) where {T, N}
     return @set sol.retcode = retcode
 end

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -30,6 +30,27 @@ end
     @test ReturnCode.Stalled in unsuccessful
 end
 
+struct DownstreamLikeSolution
+    retcode::SciMLBase.ReturnCode.T
+    payload::Symbol
+end
+
+SciMLBase.solution_new_retcode(sol::DownstreamLikeSolution, retcode) =
+    DownstreamLikeSolution(retcode, sol.payload)
+
+@testset "solution_new_retcode extension contract" begin
+    binding = Base.Docs.Binding(SciMLBase, :solution_new_retcode)
+    @test Base.Docs.meta(SciMLBase)[binding].order == [Union{}]
+
+    doc = (@doc SciMLBase.solution_new_retcode)
+    @test occursin("Solver packages extend this generic", sprint(show, doc))
+
+    sol = DownstreamLikeSolution(ReturnCode.Default, :payload)
+    updated = SciMLBase.solution_new_retcode(sol, ReturnCode.Success)
+    @test updated.retcode === ReturnCode.Success
+    @test updated.payload === sol.payload
+end
+
 struct MockParameterTimeseriesSolution <:
     SciMLBase.AbstractODESolution{Float64, 2, Vector{Vector{Float64}}}
     discretes::ParameterTimeseriesCollection


### PR DESCRIPTION
## What changed

Move the public `solution_new_retcode` documentation from the `ODESolution` method to a direct generic declaration. Method implementations are unchanged. Add a focused contract test that verifies generic documentation metadata and a downstream-like extension.

## Verification

Failing before:

```text
julia --project -e 'using Test, SciMLBase; binding = Base.Docs.Binding(SciMLBase, :solution_new_retcode); @test Base.Docs.meta(SciMLBase)[binding].order == [Union{}]'
Evaluated: Type[Union{Tuple{N}, Tuple{T}, Tuple{ODESolution{T, N}, Any}} where {T, N}] == [Union{}]
```

Passing after:

```text
focused generic documentation and extension contract passed
```

- Julia Runic `--check --docstrings` over the edited files: passed.
- `typos --diff --format brief src/SciMLBase.jl src/solutions/ode_solutions.jl test/solution_interface.jl`: passed.
- `git diff --check`: passed.
- `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`: `CORE_EXIT=0`; Solution interface `80/80`, Remake `4430/4430`.
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`: `QA_EXIT=0`; `51/51`.
- `timeout 3600 julia --project=docs -e 'root = abspath("."); pushfirst!(LOAD_PATH, root); using SciMLBase; include("docs/make.jl")'`: loaded this checkout and reached document checks, but exited `1` only because the pre-existing `Problem_Traits` URLs on `origin/master` returned linkcheck HTTP 403. No docs configuration was weakened.

Not run: `GROUP=Everything`, downstream, and GPU groups.

Ignore until reviewed by @ChrisRackauckas.