### PR TITLE
Preserve inference for ordinary NonlinearFunction calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.49.1"
+version = "3.49.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2919,7 +2919,23 @@ end
     end
 end
 
-(f::NonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
+(f::NonlinearFunction)(args...) = f.f(args...)
+
+Base.@inline function _invoke_nonlinear_function(f, args)
+    return invoke_with_despecialized_parameters(f.f, args)
+end
+
+(f::NonlinearFunction{false})(u, p::DespecializedParameters) =
+    _invoke_nonlinear_function(f, (u, p))
+
+(f::NonlinearFunction{true})(du, u, p::DespecializedParameters) =
+    _invoke_nonlinear_function(f, (du, u, p))
+
+(f::NonlinearFunction{false})(u, p::DespecializedParameters, λ) =
+    _invoke_nonlinear_function(f, (u, p, λ))
+
+(f::NonlinearFunction{true})(du, u, p::DespecializedParameters, λ) =
+    _invoke_nonlinear_function(f, (du, u, p, λ))
 (f::HomotopyNonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 (f::IntervalNonlinearFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)
 (f::IntegralFunction)(args...) = invoke_with_despecialized_parameters(f.f, args)

--- a/test/despecialized_parameters.jl
+++ b/test/despecialized_parameters.jl
@@ -11,6 +11,19 @@ struct DespecializedCallParameters
     rate::Float64
 end
 
+struct WrappedDespecializedCallable end
+
+function (::WrappedDespecializedCallable)(du, u, p::SciMLBase.DespecializedParameters)
+    du[1] = u[1] * p.rate
+    return nothing
+end
+
+function SciMLBase.invoke_with_despecialized_parameters(
+        f::WrappedDespecializedCallable, args::Tuple; kwargs...
+    )
+    return f(args...; kwargs...)
+end
+
 @testset "all callable SciMLFunction families" begin
     params = SciMLBase.DespecializedParameters(DespecializedCallParameters(2.0))
     seen = DataType[]
@@ -23,6 +36,15 @@ end
     dynamical_u = ArrayPartition([1.0], [2.0])
     calls = (
         () -> NonlinearFunction{false}((u, p) -> record_parameter_type(p))(u, params),
+        () -> NonlinearFunction{true}((du, u, p) -> record_parameter_type(p))(
+            u, u, params
+        ),
+        () -> NonlinearFunction{false}(
+            (u, p, λ) -> record_parameter_type(p); lambda_extended = true
+        )(u, params, 0.0),
+        () -> NonlinearFunction{true}(
+            (du, u, p, λ) -> record_parameter_type(p); lambda_extended = true
+        )(u, u, params, 0.0),
         () -> IntervalNonlinearFunction{false}((u, p) -> record_parameter_type(p))(
             1.0, params
         ),
@@ -104,6 +126,14 @@ end
     ) === SciMLBase.AutoDespecialize
     @test SciMLBase.AutoDespecialize !== SciMLBase.AutoRespecialize
     @test SciMLBase.specialization(OptimizationFunction) === SciMLBase.FullSpecialize
+end
+
+@testset "wrapped callable despecialization hook" begin
+    params = SciMLBase.DespecializedParameters((rate = 2.0,))
+    f = NonlinearFunction{true}(WrappedDespecializedCallable())
+    du = zeros(1)
+    f(du, [3.0], params)
+    @test du == [6.0]
 end
 
 @testset "stable container and forwarded interfaces" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Ordinary concrete-parameter calls still dispatch directly from `NonlinearFunction` to the wrapped callable, preserving inference through deep `SimpleHomotopySweep` call chains. Calls receiving `DespecializedParameters` now invoke the documented despecialization hook on the wrapped callable itself, before the parameter wrapper can be removed.

The first rebased draft head routed the barrier through the whole `NonlinearFunction`. That fixed the allocation regression but bypassed NonlinearSolveBase's wrapped-callable hook: the wrapper was unwrapped to a `NamedTuple` and then sent directly to a `FunctionWrappersWrapper`, causing the source-triggered NonlinearSolve precompile failure. This revision covers both paths and bumps SciMLBase from 3.49.1 to 3.49.2.

The original regression is tracked at https://github.com/SciML/NonlinearSolve.jl/issues/1161 and begins at https://github.com/SciML/SciMLBase.jl/commit/a932b024aa18eee6550e24182ac229eb32d2b343 (SciMLBase 3.45.0; 3.44.0 passes the focused downstream control).

## Failing before

On clean current NonlinearSolve master with released SciMLBase 3.49.1, the exact allocation group produced:

```text
Test Summary:    | Pass  Total
Allocation Tests |   18     18
Test Summary:                        | Error  Total
SimpleHomotopySweep Allocation Tests |   125    125
ERROR: Package SimpleNonlinearSolve errored during testing
```

The regression test added here also discriminates the correction to the first draft head. With the previous source and the identical test:

```text
MethodError: no method matching WrappedDespecializedCallable(
    ::Vector{Float64}, ::Vector{Float64}, ::@NamedTuple{rate::Float64})
Test Summary:              | Pass  Error  Total
Despecialized parameters   |   42      1     43
```

## Passing after

With the final hook routing:

```text
Test Summary:            | Pass  Total  Time
Despecialized parameters |   43     43  7.1s
Test Summary: | Pass  Total
Remake        | 4430   4430
Testing SciMLBase tests passed
```

The unchanged NonlinearSolve checkout then crossed both former precompile failure points:

```text
✓ NonlinearSolve
21 dependencies successfully precompiled in 250 seconds

✓ NonlinearSolve
25 dependencies successfully precompiled in 1651 seconds
```

The exact CI-style allocation group with this SciMLBase source also passed:

```text
Test Summary:    | Pass  Total     Time
Allocation Tests |   18     18  1m13.0s
Test Summary:                        | Pass  Total  Time
SimpleHomotopySweep Allocation Tests |    2      2  5.5s
Testing SimpleNonlinearSolve tests passed
```

Final local validation:

```text
Test Summary: | Pass  Total      Time
QA            |   51     51  3m06.0s
Testing SciMLBase tests passed
```

`Runic --check .`, `typos` over the diff, and `git diff --check` all exited 0 with no output.

No public API, docstring, dependency, or documentation file changes are included, so a docs build was not required. The full downstream NonlinearSolve Core test body, GPU paths, and other downstream groups were not run to completion locally.