### PR TITLE
Add a global error interface: has_global_error trait + ODESolution.global_error field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.47.0"
+version = "3.48.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Algorithms.md
+++ b/docs/src/interfaces/Algorithms.md
@@ -58,6 +58,7 @@ SciMLBase.forwarddiffs_model
 SciMLBase.forwarddiffs_model_time
 SciMLBase.forwarddiff_chunksize
 SciMLBase.has_lazy_interpolation
+SciMLBase.has_global_error
 SciMLBase.allows_late_binding_tstops
 SciMLBase.supports_opt_cache_interface
 SciMLBase.has_init

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2249,7 +2249,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # Algorithm / problem traits
 @public isadaptive, allowscomplex, allows_arbitrary_number_types, isautodifferentiable,
     problem_type, is_diagonal_noise, forwarddiffs_model, forwarddiffs_model_time,
-    forwarddiff_chunksize, has_lazy_interpolation, allows_late_binding_tstops,
+    forwarddiff_chunksize, has_lazy_interpolation, has_global_error, allows_late_binding_tstops,
     supports_opt_cache_interface, alg_order, allowsbounds, requiresbounds,
     allowsconstraints, requiresconstraints, requiresgradient, allowsfg,
     requireshessian, allowsfgh, requiresconsjac, allowsconsjvp, allowsconsvjp,

--- a/src/alg_traits.jl
+++ b/src/alg_traits.jl
@@ -124,6 +124,23 @@ The default is `false`.
 isdiscrete(alg::AbstractDEAlgorithm) = false
 
 """
+    has_global_error(alg::AbstractDEAlgorithm)
+
+Trait declaring whether an algorithm computes an estimate of the global
+(accumulated) error of the solution.
+
+Return `true` when the solver or solver wrapper populates the `global_error`
+field of the solution with a per-time-point estimate of the global error (the
+difference between the numerical and true solutions), rather than only
+controlling the local error of each step. When `true`, the solution's
+`global_error` is an array matching `u`; when `false` (the default) it is
+`nothing`.
+
+The default is `false`.
+"""
+has_global_error(alg::AbstractSciMLAlgorithm) = false
+
+"""
     has_lazy_interpolation(alg::AbstractDEAlgorithm)
 
 Trait declaring whether an algorithm constructs solution interpolation lazily.

--- a/src/solutions/ode_solutions.jl
+++ b/src/solutions/ode_solutions.jl
@@ -111,10 +111,14 @@ page of the DifferentialEquations.jl documentation.
     successfully, whether it terminated early due to a user-defined callback, or whether it
     exited due to an error. For more details, see
     [the return code documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes).
+  - `global_error`: an estimate of the global (accumulated) error of the solution, or
+    `nothing` when the algorithm does not compute one (see [`has_global_error`](@ref)).
+    When present it is an array matching `u`, with `global_error[i]` the estimated global
+    error of `u[i]` at `t[i]`.
 """
 struct ODESolution{
         T, N, uType, uType2, DType, tType, rateType, discType, P, A, IType, S,
-        AC <: Union{Nothing, Vector{Int}}, R, O, V,
+        AC <: Union{Nothing, Vector{Int}}, R, O, V, GE,
     } <:
     AbstractODESolution{T, N, uType}
     u::uType
@@ -134,6 +138,10 @@ struct ODESolution{
     resid::R
     original::O
     saved_subsystem::V
+    # Estimate of the global (accumulated) error, populated by solvers/wrappers
+    # for which `has_global_error(alg)` is `true`; `nothing` otherwise. When
+    # present it matches `u`: a vector of per-time-point error estimates.
+    global_error::GE
 end
 
 function ConstructionBase.constructorof(::Type{O}) where {T, N, O <: ODESolution{T, N}}
@@ -153,7 +161,8 @@ function ConstructionBase.setproperties(
     return ODESolution{new_T, new_N}(
         patch.u, patch.u_analytic, patch.errors, patch.t, patch.k,
         patch.discretes, patch.prob, patch.alg, patch.interp, patch.dense, patch.tslocation, patch.stats,
-        patch.alg_choice, patch.retcode, patch.resid, patch.original, patch.saved_subsystem
+        patch.alg_choice, patch.retcode, patch.resid, patch.original, patch.saved_subsystem,
+        patch.global_error
     )
 end
 
@@ -161,16 +170,17 @@ end
 function ODESolution{T, N}(
         u, u_analytic, errors, t, k, discretes, prob, alg, interp, dense,
         tslocation, stats, alg_choice, retcode, resid,
-        original, saved_subsystem
+        original, saved_subsystem, global_error = nothing
     ) where {T, N}
     return ODESolution{
         T, N, typeof(u), typeof(u_analytic), typeof(errors), typeof(t),
         typeof(k), typeof(discretes), typeof(prob), typeof(alg), typeof(interp),
         typeof(stats), typeof(alg_choice), typeof(resid), typeof(original),
-        typeof(saved_subsystem),
+        typeof(saved_subsystem), typeof(global_error),
     }(
         u, u_analytic, errors, t, k, discretes, prob, alg, interp,
-        dense, tslocation, stats, alg_choice, retcode, resid, original, saved_subsystem
+        dense, tslocation, stats, alg_choice, retcode, resid, original,
+        saved_subsystem, global_error
     )
 end
 
@@ -540,6 +550,7 @@ function build_solution(
         retcode = ReturnCode.Default, stats = nothing,
         resid = nothing, original = nothing,
         saved_subsystem = nothing,
+        global_error = nothing,
         kwargs...
     )
     T = eltype(eltype(u))
@@ -590,7 +601,8 @@ function build_solution(
             retcode,
             resid,
             original,
-            saved_subsystem
+            saved_subsystem,
+            global_error
         )
         if calculate_error
             calculate_solution_errors!(
@@ -616,7 +628,8 @@ function build_solution(
             retcode,
             resid,
             original,
-            saved_subsystem
+            saved_subsystem,
+            global_error
         )
     end
 end
@@ -736,13 +749,14 @@ function solution_new_original_retcode(
         sol.u, sol.u_analytic, sol.errors, sol.t, sol.k,
         sol.discretes, sol.prob, sol.alg, sol.interp, sol.dense,
         sol.tslocation, sol.stats, sol.alg_choice, retcode,
-        resid, original, sol.saved_subsystem,
+        resid, original, sol.saved_subsystem, sol.global_error,
     )
 end
 
 function solution_slice(sol::ODESolution{T, N}, I) where {T, N}
     @reset sol.u = sol.u[I]
     @reset sol.u_analytic = sol.u_analytic === nothing ? nothing : sol.u_analytic[I]
+    @reset sol.global_error = sol.global_error === nothing ? nothing : sol.global_error[I]
     @reset sol.t = sol.t[I]
     @reset sol.k = sol.dense ? sol.k[I] : sol.k
     return @set sol.dense = false


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Adds a uniform interface for ODE solvers and solver wrappers to report an estimate of the **global (accumulated) error** of a solution, rather than only controlling local error per step. This is the foundation requested in the GlobalDiffEq review discussion (SciML/OrdinaryDiffEq.jl#3956): a trait for whether a method computes the global error, and a solution field (an array-of-arrays matching `u`, `nothing` when the method doesn't compute it).

- **`has_global_error(alg)`** — algorithm trait, default `false`; `true` when the algorithm/wrapper populates a global error estimate. Added next to the other algorithm traits, made `@public`, and documented in `docs/src/interfaces/Algorithms.md`.
- **`ODESolution.global_error`** — new field, default `nothing`; when present, an array matching `u` where `global_error[i]` is the estimated global error of `u[i]` at `t[i]`. Documented in the `ODESolution` docstring.

## Backward compatibility

All defaults are `nothing`, so existing solutions and constructors are structurally and behaviorally unchanged (the default `GE` type parameter is `Nothing`). The field is threaded through:

- `build_solution` — new `global_error = nothing` keyword, passed to the constructor;
- the `ODESolution{T,N}(...)` convenience constructor — optional last argument defaulting to `nothing`, so existing 17-argument positional calls still work;
- `ConstructionBase.setproperties` — so `@set`/`@reset` preserve `global_error`;
- `solution_new_original_retcode` (direct reconstruction) and `solution_slice` (slices `global_error` alongside `u`).

Only code constructing `ODESolution` through the fully type-parameterized inner constructor with an explicit 16-parameter/17-field signature would need updating; the standard `build_solution` and convenience-constructor paths are unaffected.

Minor version bump (3.47.0 → 3.48.0) for the new public API.

## How it will be used (follow-ups, not in this PR)

- OrdinaryDiffEq: the GLEE / MM5GEE global-error-estimating solvers (SciML/OrdinaryDiffEq.jl#3954) will set `has_global_error = true` and, in `savevalues!`, split their internal `(y, ε)` `ArrayPartition` so the user gets a normal `sol.u` and the `ε` register lands in `sol.global_error`.
- The `GlobalErrorTransport` / `GlobalDefectCorrection` / `GlobalAdjoint` wrappers will populate the same `sol.global_error`, so the user-facing surface is uniform across methods.

## Validation (run locally)

- Smoke test (built against this branch): trait default `false` / override `true`; `sol.global_error === nothing` by default; populated via the `build_solution` keyword; preserved through `@set`/`setproperties`; sliced correctly by `solution_slice`. All pass.
- `GROUP=Core` SciMLBase test suite: **pass** — full `GROUP=Core` suite green ("SciMLBase tests passed"), including the setproperties/@set-heavy Remake group (4430/4430).
- `Runic --check` on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)