### PR TITLE
Bump version to 3.47.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.47.0"
+version = "3.47.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps version from 3.47.0 to 3.47.1.

### Summary of Changes since v3.47.0
There are 5 commits and 2 `src/` file changes since `v3.47.0`:
- **Compat drops:**
  - Drop older SciML and JuliaSymbolics major versions from compat (#1530)
  - Drop older SciML major versions from compat (#1529)
  - Drop [compat] majors whose successor is 2+ years old (#1528)
- **Documentation:**
  - Document `solution_new_retcode` generic (#1525)
- **Testing:**
  - Align `SciMLTesting` test environment compat (#1524)

> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.