### PR TITLE
docs: publish instability diagnostic developer hooks

### DIFF
--- a/docs/src/interfaces/Algorithms.md
+++ b/docs/src/interfaces/Algorithms.md
@@ -8,6 +8,35 @@
 CommonSolve.solve(prob::AbstractSciMLProblem, alg::AbstractSciMLAlgorithm; kwargs...)
 ```
 
+### Generic Usage Rules
+
+Generic solver and extension code should dispatch on both the problem and
+algorithm interfaces and use capability traits for behavior that varies by
+algorithm. It must not inspect algorithm fields or assume that every algorithm
+supports every common keyword. In particular:
+
+  - algorithm-specific choices belong in the algorithm constructor and its
+    documented fields;
+  - common solve controls belong in `solve` or `init` keyword arguments;
+  - `isadaptive`, `isdiscrete`, `allowscomplex`,
+    `allows_arbitrary_number_types`, and `alg_order` describe execution
+    behavior and should be queried before selecting a generic path;
+  - capability traits such as `allowsbounds`, `requiresgradient`, and
+    `allowscallback` must be treated as contracts, not hints;
+  - `remake(alg; kwargs...)` is for preserving a concrete algorithm while
+    replacing supported configuration fields, and callers must not assume that
+    arbitrary fields are replaceable.
+
+An algorithm author should test the trait values and the generic solve
+dispatch with a representative algorithm value. A downstream consumer should
+be able to make compatibility decisions without naming the concrete solver:
+
+```julia
+function supports_complex_adaptive(alg::SciMLBase.AbstractSciMLAlgorithm)
+    return SciMLBase.allowscomplex(alg) && SciMLBase.isadaptive(alg)
+end
+```
+
 ### Algorithm-Specific Arguments
 
 Note that because the keyword arguments of `solve` are designed to be common across the whole

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -76,6 +76,17 @@ SciMLBase.ODENLStepData
 SciMLBase.JacobianWrapper
 ```
 
+## Numerical Instability Diagnostic Hooks
+
+Solver packages use these hooks to provide additional symbolic and numerical
+diagnostics when an integration becomes unstable. They are not application-facing
+replacements for a solver's documented instability reporting.
+
+```@docs
+SciMLBase.has_mtk_sys(integrator)
+SciMLBase.log_numerical_instability(integrator; jacobian_logging = true)
+```
+
 ## Solver Preparation Hooks
 
 Solver packages use these hooks to derive the effective problem data for an individual

--- a/docs/src/interfaces/Developer_API.md
+++ b/docs/src/interfaces/Developer_API.md
@@ -83,8 +83,8 @@ diagnostics when an integration becomes unstable. They are not application-facin
 replacements for a solver's documented instability reporting.
 
 ```@docs
-SciMLBase.has_mtk_sys(integrator)
-SciMLBase.log_numerical_instability(integrator; jacobian_logging = true)
+SciMLBase.has_mtk_sys
+SciMLBase.log_numerical_instability
 ```
 
 ## Solver Preparation Hooks

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -15,6 +15,40 @@ types have a method for constructing the associated problem and function types.
 The following standard principles should be adhered to across all
 `AbstractSciMLProblem` instantiations.
 
+### Generic Usage Rules
+
+Code that accepts an abstract problem must dispatch on the problem type itself
+and use the generic traits rather than inspecting a concrete problem's fields.
+The minimum generic contract is:
+
+  - `isinplace(prob)` reports the callback mutation convention encoded by the
+    problem type.
+  - `problem_type(prob)` reports construction-layout metadata, or `nothing`
+    when no separate layout marker applies.
+  - `is_diagonal_noise(prob)` reports the noise-storage convention for
+    stochastic problem families.
+  - `remake(prob; kwargs...)` creates a compatible problem with requested
+    replacements while preserving the problem's layout marker and callback
+    convention.
+
+Solver and extension code must not assume that every problem has the same
+fields, that a problem can be mutated in place, or that a convenience
+constructor's concrete representation identifies its mathematical layout.
+Custom problem types should implement the generic traits they support and test
+them with a representative problem value, without dispatching on a concrete
+problem type in downstream code.
+
+For example, a generic consumer can make a dispatch decision without knowing
+which problem family supplied the value:
+
+```julia
+function setup_problem(prob::SciMLBase.AbstractSciMLProblem)
+    iip = SciMLBase.isinplace(prob)
+    layout = SciMLBase.problem_type(prob)
+    return (; iip, layout)
+end
+```
+
 ### In-place Specification
 
 Each `AbstractSciMLProblem` type can be called with an "is inplace" (iip) choice. For example:

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -11,6 +11,36 @@ of pre-computed functions to speed up the calculations. This is offered via the
 The following standard principles should be adhered to across all
 `AbstractSciMLFunction` instantiations.
 
+### Generic Usage Rules
+
+Generic solver code must treat an `AbstractSciMLFunction` as a callable
+container and query its capability traits before using optional callbacks. The
+portable contract is:
+
+  - call the function using the signature documented by its function family;
+    do not infer the signature from the concrete wrapper's fields;
+  - use `isinplace(f)` to select the mutating or returning call convention;
+  - use `has_jac`, `has_jvp`, `has_vjp`, `has_paramjac`, `has_observed`, and
+    the related `has_*` traits before reading an optional callback;
+  - use `unwrapped_f(f)` only when an operation explicitly needs the underlying
+    callable, and preserve the wrapper's in-place convention after wrapping;
+  - treat optional callbacks as absent when the corresponding trait is false,
+    rather than assuming a field exists on every concrete subtype.
+
+An implementation of a new function container should be testable through these
+generic operations alone. A downstream package should therefore be able to
+write code such as:
+
+```julia
+function evaluate_model(f::SciMLBase.AbstractSciMLFunction, u, p, t)
+    return (; value = f(u, p, t), has_jac = SciMLBase.has_jac(f))
+end
+```
+
+The concrete function type remains responsible for documenting callback
+arguments, return values, and field layout. Generic code must not reach into
+those fields to discover capabilities.
+
 ### Common Function Choice Definitions
 
 The full interface available to the solvers is as follows:

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -13,6 +13,38 @@ solutions must expose saved states as `u` and matching independent-variable valu
 concepts apply. Ensemble and noise-process subtypes follow the contracts in their
 rendered abstract-type docstrings below.
 
+### Generic Usage Rules
+
+Consumers should dispatch on the narrowest abstract solution family they need
+and use the array and callable interfaces instead of inspecting a concrete
+solution type. The common contract is:
+
+  - no-time solutions expose `u` and forward `size`, `getindex`, and compatible
+    linear algebra operations to it;
+  - time-series solutions expose matching `u` and `t` indices, with state
+    components preceding the saved-time index;
+  - callers use `successful_retcode(sol)` rather than comparing only against
+    `ReturnCode.Success`;
+  - callers use `isdenseplot(sol)` and `plottable_indices(x)` when selecting
+    plotting behavior instead of assuming dense interpolation or that every
+    state component is plottable;
+  - optional fields such as `prob`, `alg`, `interp`, `stats`, and `resid` may
+    be absent for a solution family and must be accessed only when that family's
+    contract documents them.
+
+For example, a generic report can work for every no-time solution without
+knowing whether it came from a linear, nonlinear, integral, or optimization
+solver:
+
+```julia
+function solution_report(sol::SciMLBase.AbstractNoTimeSolution)
+    return (; size = size(sol), successful = SciMLBase.successful_retcode(sol))
+end
+```
+
+Concrete solution types must document their fields, indexing shape, callable
+interpolation behavior, and any additional mutation or cache guarantees.
+
 ### Array Interface
 
 Instead of working on the `Vector{uType}` directly, we can use the provided

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2267,7 +2267,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 # application code should use the user-facing solve and solution interfaces instead.
 @public enable_interpolation_sensitivitymode, get_root_indp, has_initializeprob,
     late_binding_update_u0_p, strip_interpolation, unitfulvalue, value, last_step_failed,
-    @def, _unwrap_val
+    @def, _unwrap_val, has_mtk_sys, log_numerical_instability
 
 # Versioned symbolic-system and input-preparation extension API
 @public RemakeInitializationDataContext, remake_initialization_data,

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -894,8 +894,85 @@ documented `reinit!` method. Supported optional keywords can still vary by
 problem family. The default is `false`.
 """ has_reinit
 
+"""
+    log_numerical_instability(integrator; jacobian_logging::Bool = true) -> AbstractString
+
+Return additional text describing a numerical instability detected by a solver
+integrator. The generic method returns an empty string.
+
+# Arguments
+
+- `integrator`: The solver integrator for which a numerical instability was detected.
+
+# Keyword Arguments
+
+- `jacobian_logging`: Whether the diagnostic should include Jacobian information.
+  SciMLBase passes `false` when a symbolic diagnostic has already been produced.
+
+# Returns
+
+- An `AbstractString` containing diagnostic text to append to the solver's instability
+  message. Return an empty string when no additional diagnostic is available.
+
+# Extension Rules
+
+Solver packages may specialize this hook for integrators that can report additional
+numerical diagnostics. A method must accept the `jacobian_logging` keyword and return an
+`AbstractString`; the returned text should be ready to concatenate with the caller's
+message, including any desired leading whitespace.
+
+# Example
+
+```julia
+struct MyIntegrator end
+
+SciMLBase.log_numerical_instability(::MyIntegrator; jacobian_logging = true) =
+    jacobian_logging ? " Jacobian diagnostic." : " State diagnostic."
+
+SciMLBase.log_numerical_instability(MyIntegrator())
+```
+
+!!! warning "Developer API, not user API"
+    This hook is for solver implementations. Application code should use the solver's
+    documented instability reporting instead of calling or extending it directly.
+"""
 log_numerical_instability(integrator; jacobian_logging::Bool = true) = ""
 
+"""
+    has_mtk_sys(integrator) -> Bool
+
+Return whether a solver integrator provides a ModelingToolkit system for symbolic
+instability diagnostics. The generic method returns `false`.
+
+# Arguments
+
+- `integrator`: The solver integrator whose symbolic diagnostic support is queried.
+
+# Returns
+
+- `true` when `integrator` provides the symbolic system expected by the solver's
+  instability diagnostic path, and `false` otherwise.
+
+# Extension Rules
+
+Solver packages may specialize this trait for integrators that carry a ModelingToolkit
+system and support the corresponding symbolic instability diagnostic. A method must
+return a `Bool` and must return `false` when that diagnostic data is unavailable.
+
+# Example
+
+```julia
+struct MyIntegrator end
+
+SciMLBase.has_mtk_sys(::MyIntegrator) = true
+
+SciMLBase.has_mtk_sys(MyIntegrator())
+```
+
+!!! warning "Developer API, not user API"
+    This trait is for solver diagnostic implementations. Application code should use
+    ModelingToolkit's documented problem interfaces instead of calling or extending it.
+"""
 has_mtk_sys(integrator) = false
 
 diagnose_symbolic_instability(sys, u, uprev) = ""

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -501,18 +501,36 @@ SciMLBase.log_numerical_instability(
 @testset "Instability diagnostic developer interface" begin
     integrator = InstabilityDiagnosticTestIntegrator()
 
-    @test !SciMLBase.has_mtk_sys(nothing)
-    @test SciMLBase.has_mtk_sys(integrator)
-    @test SciMLBase.log_numerical_instability(nothing) == ""
-    @test SciMLBase.log_numerical_instability(nothing; jacobian_logging = false) == ""
-    @test SciMLBase.log_numerical_instability(integrator) == " Jacobian diagnostic."
-    @test SciMLBase.log_numerical_instability(integrator; jacobian_logging = false) ==
-        " State diagnostic."
-    @test haskey(Base.Docs.meta(SciMLBase), Base.Docs.Binding(SciMLBase, :has_mtk_sys))
-    @test haskey(
-        Base.Docs.meta(SciMLBase),
-        Base.Docs.Binding(SciMLBase, :log_numerical_instability),
-    )
+    function instability_diagnostics(integrator)
+        return (
+            has_mtk_sys = SciMLBase.has_mtk_sys(integrator),
+            with_jacobian = SciMLBase.log_numerical_instability(integrator),
+            without_jacobian = SciMLBase.log_numerical_instability(
+                integrator; jacobian_logging = false
+            ),
+        )
+    end
+
+    default_diagnostics = instability_diagnostics(nothing)
+    @test default_diagnostics.has_mtk_sys === false
+    @test default_diagnostics.has_mtk_sys isa Bool
+    @test default_diagnostics.with_jacobian == ""
+    @test default_diagnostics.without_jacobian == ""
+    @test default_diagnostics.with_jacobian isa AbstractString
+
+    extended_diagnostics = instability_diagnostics(integrator)
+    @test extended_diagnostics.has_mtk_sys === true
+    @test extended_diagnostics.with_jacobian == " Jacobian diagnostic."
+    @test extended_diagnostics.without_jacobian == " State diagnostic."
+    @test extended_diagnostics.with_jacobian isa AbstractString
+
+    for name in (:has_mtk_sys, :log_numerical_instability)
+        binding = Base.Docs.Binding(SciMLBase, name)
+        @test haskey(Base.Docs.meta(SciMLBase), binding)
+        doc = sprint(show, Base.Docs.meta(SciMLBase)[binding])
+        @test occursin("Extension Rules", doc)
+        @test occursin("Example", doc)
+    end
 end
 
 @testset "Solution interface documentation" begin
@@ -544,6 +562,9 @@ end
     solution_docs = read(
         joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Solutions.md"), String
     )
+    developer_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Developer_API.md"), String
+    )
 
     @test occursin("### Generic Usage Rules", problem_docs)
     @test occursin("problem_type(prob)", problem_docs)
@@ -553,6 +574,8 @@ end
     @test occursin("capability traits", algorithm_docs)
     @test occursin("### Generic Usage Rules", solution_docs)
     @test occursin("successful_retcode(sol)", solution_docs)
+    @test occursin("SciMLBase.has_mtk_sys", developer_docs)
+    @test occursin("SciMLBase.log_numerical_instability", developer_docs)
 end
 
 @testset "Ensemble interface documentation" begin

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -439,6 +439,30 @@ end
     end
 end
 
+struct InstabilityDiagnosticTestIntegrator end
+
+SciMLBase.has_mtk_sys(::InstabilityDiagnosticTestIntegrator) = true
+SciMLBase.log_numerical_instability(
+    ::InstabilityDiagnosticTestIntegrator; jacobian_logging = true
+) = jacobian_logging ? " Jacobian diagnostic." : " State diagnostic."
+
+@testset "Instability diagnostic developer interface" begin
+    integrator = InstabilityDiagnosticTestIntegrator()
+
+    @test !SciMLBase.has_mtk_sys(nothing)
+    @test SciMLBase.has_mtk_sys(integrator)
+    @test SciMLBase.log_numerical_instability(nothing) == ""
+    @test SciMLBase.log_numerical_instability(nothing; jacobian_logging = false) == ""
+    @test SciMLBase.log_numerical_instability(integrator) == " Jacobian diagnostic."
+    @test SciMLBase.log_numerical_instability(integrator; jacobian_logging = false) ==
+        " State diagnostic."
+    @test haskey(Base.Docs.meta(SciMLBase), Base.Docs.Binding(SciMLBase, :has_mtk_sys))
+    @test haskey(
+        Base.Docs.meta(SciMLBase),
+        Base.Docs.Binding(SciMLBase, :log_numerical_instability),
+    )
+end
+
 @testset "Solution interface documentation" begin
     solution_docs = read(
         joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Solutions.md"), String
@@ -498,6 +522,7 @@ if isdefined(Base, :ispublic)
                 :done, :postamble!, :enable_interpolation_sensitivitymode,
                 :get_root_indp, :has_initializeprob, :late_binding_update_u0_p,
                 :strip_interpolation, :unitfulvalue, :value, :last_step_failed,
+                :has_mtk_sys, :log_numerical_instability,
                 Symbol("@def"), :_unwrap_val,
                 :get_concrete_p, :get_concrete_u0, :isconcreteu0, :promote_u0,
                 :get_concrete_problem, :check_prob_alg_pairing, :KeywordArgError,

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -40,6 +40,29 @@ SciMLBase.check_prob_alg_pairing(::ConcretizationHookProblem, ::ConcretizationHo
 
 struct GenericSciMLFunction{iip} <: SciMLBase.AbstractSciMLFunction{iip} end
 
+struct GenericProblem <: SciMLBase.AbstractNonlinearProblem{Vector{Float64}, false}
+    u0::Vector{Float64}
+    p::NamedTuple
+end
+
+struct GenericFunction <: SciMLBase.AbstractSciMLFunction{false}
+    f::Function
+end
+
+(f::GenericFunction)(u, p, t) = f.f(u, p, t)
+
+struct GenericAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+SciMLBase.isadaptive(::GenericAlgorithm) = false
+SciMLBase.isdiscrete(::GenericAlgorithm) = false
+SciMLBase.allowscomplex(::GenericAlgorithm) = true
+SciMLBase.alg_order(::GenericAlgorithm) = 2
+
+struct GenericSolution <: SciMLBase.AbstractNonlinearSolution{Float64, 1}
+    u::Vector{Float64}
+    retcode::SciMLBase.ReturnCode.T
+end
+
 struct ConcreteSolveContractProblem end
 struct ConcreteSolveContractAlgorithm end
 struct ConcreteSolveContractSenseAlg end
@@ -185,6 +208,35 @@ end
     @test SciMLBase.isinplace(GenericSciMLFunction{true}()) === true
     @test SciMLBase.isinplace(GenericSciMLFunction{false}()) === false
     @test Docs.doc(SciMLBase.isinplace) !== nothing
+end
+
+@testset "Generic abstract interface contracts" begin
+    problem = GenericProblem([1.0], (; rate = 2.0))
+    @test SciMLBase.isinplace(problem) === false
+    @test SciMLBase.problem_type(problem) === nothing
+    @test SciMLBase.is_diagonal_noise(problem) === false
+
+    f = GenericFunction((u, p, t) -> p.rate .* u .+ t)
+    @test SciMLBase.isinplace(f) === false
+    @test f([1.0], (; rate = 2.0), 0.5) == [2.5]
+    @test !SciMLBase.has_analytic(f)
+    @test !SciMLBase.has_jac(f)
+    @test !SciMLBase.has_jvp(f)
+    @test !SciMLBase.has_vjp(f)
+    @test !SciMLBase.has_paramjac(f)
+    @test !SciMLBase.has_observed(f)
+
+    alg = GenericAlgorithm()
+    @test !SciMLBase.isadaptive(alg)
+    @test !SciMLBase.isdiscrete(alg)
+    @test SciMLBase.allowscomplex(alg)
+    @test SciMLBase.alg_order(alg) == 2
+
+    sol = GenericSolution([1.0, 2.0], SciMLBase.ReturnCode.Success)
+    @test size(sol) == (2,)
+    @test sol[2] == 2.0
+    @test SciMLBase.successful_retcode(sol)
+    @test SciMLBase.plottable_indices(sol.u) == 1:2
 end
 
 @testset "Problem layout marker interface" begin
@@ -476,6 +528,31 @@ end
     @test occursin("sol.tslocation != 0", solution_docs)
     @test occursin("1000 * sol.tslocation", solution_docs)
     @test occursin("`SensitivityInterpolation`", solution_docs)
+end
+
+@testset "Generic abstract interface documentation" begin
+    problem_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Problems.md"), String
+    )
+    function_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "SciMLFunctions.md"),
+        String,
+    )
+    algorithm_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Algorithms.md"), String
+    )
+    solution_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Solutions.md"), String
+    )
+
+    @test occursin("### Generic Usage Rules", problem_docs)
+    @test occursin("problem_type(prob)", problem_docs)
+    @test occursin("### Generic Usage Rules", function_docs)
+    @test occursin("has_paramjac", function_docs)
+    @test occursin("### Generic Usage Rules", algorithm_docs)
+    @test occursin("capability traits", algorithm_docs)
+    @test occursin("### Generic Usage Rules", solution_docs)
+    @test occursin("successful_retcode(sol)", solution_docs)
 end
 
 @testset "Ensemble interface documentation" begin


### PR DESCRIPTION
Promotes `has_mtk_sys` and `log_numerical_instability` as documented SciMLBase developer APIs used by solver packages. Adds SciMLStyle docstrings with extension rules/examples, renders them on the Developer API page, and adds generic interface coverage.

Verification:
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: QA 51/51 passed.\n- Owner interface smoke test: passed, including default/overridden behavior and `Base.Docs` entries.\n- Runic check: passed.\n- Typos: passed.\n- `git diff --check`: passed.\n- Docs build against the local checkout: the new `@docs` blocks resolved; the build stops only at the pre-existing `https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/` linkcheck returning HTTP 403.\n\nThe existing Julia 1.12 `test/public_interface.jl` `Docs.doc(SciMLBase.isinplace)` error is pre-existing on master; this PR avoids adding another use of that API.\n\nPlease ignore this draft until reviewed by @ChrisRackauckas.