### PR TITLE
feat: give DAEProblem a problem_type field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.47.1"
+version = "3.48.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Differential_Equation_Problem_Types.md
+++ b/docs/src/interfaces/Differential_Equation_Problem_Types.md
@@ -38,4 +38,5 @@ SciMLBase.DynamicalSDEProblem
 
 ```@docs
 SciMLBase.DAEProblem
+SciMLBase.StandardDAEProblem
 ```

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2284,8 +2284,8 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Steady-state / problem support types
 @public AbstractSteadyStateProblem, StandardODEProblem, StandardDDEProblem,
-    StandardNonlinearProblem, StandardBVProblem, StandardSecondOrderBVProblem,
-    AbstractSplitODEProblem, AbstractDynamicalDDEProblem
+    StandardDAEProblem, StandardNonlinearProblem, StandardBVProblem,
+    StandardSecondOrderBVProblem, AbstractSplitODEProblem, AbstractDynamicalDDEProblem
 
 # Abstract solution / discretization types
 @public AbstractTimeseriesSolution, AbstractDiscretization, AbstractDiscretizationMetadata

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -1,3 +1,18 @@
+"""
+$(TYPEDEF)
+
+Marker for the standard fully implicit DAE problem representation.
+
+`StandardDAEProblem()` is the default `problem_type` metadata stored by
+`DAEProblem` when a problem is represented directly as `0 = f(du, u, p, t)`.
+
+Users normally do not need to construct this marker directly. Solver
+implementations may test `problem_type(prob) isa StandardDAEProblem` when they
+need behavior specific to the standard DAE layout; generic DAE code should
+prefer the [`AbstractDAEProblem`](@ref) interface and problem traits.
+"""
+struct StandardDAEProblem end
+
 @doc doc"""
 
 Defines an implicit ordinary differential equation (ODE) or
@@ -67,7 +82,7 @@ prob = DAEProblemLibrary.prob_dae_resrob
 sol = solve(prob,IDA())
 ```
 """
-struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
+struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D, PT} <:
     AbstractDAEProblem{uType, duType, tType, isinplace}
     f::F
     du0::duType
@@ -76,9 +91,12 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
     p::P
     kwargs::K
     differential_vars::D
+    """An internal argument for storing traits about the solving process."""
+    problem_type::PT
     @add_kwonly function DAEProblem{iip}(
             f::AbstractDAEFunction{iip},
-            du0, u0, tspan, p = NullParameters();
+            du0, u0, tspan, p = NullParameters(),
+            problem_type = StandardDAEProblem();
             differential_vars = nothing,
             kwargs...
         ) where {iip}
@@ -99,41 +117,52 @@ struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D} <:
             typeof(_u0), typeof(_du0), typeof(_tspan),
             isinplace(f), typeof(p),
             typeof(f), typeof(kwargs),
-            typeof(differential_vars),
+            typeof(differential_vars), typeof(problem_type),
         }(
             f, _du0, _u0, _tspan, p,
-            kwargs, differential_vars
+            kwargs, differential_vars, problem_type
         )
     end
 
-    function DAEProblem{iip}(f, du0, u0, tspan, p = NullParameters(); kwargs...) where {iip}
+    function DAEProblem{iip}(
+            f, du0, u0, tspan, p = NullParameters(),
+            problem_type = StandardDAEProblem(); kwargs...
+        ) where {iip}
         return DAEProblem(
-            DAEFunction{iip, DEFAULT_SPECIALIZATION}(f), du0, u0, tspan, p; kwargs...
+            DAEFunction{iip, DEFAULT_SPECIALIZATION}(f), du0, u0, tspan, p,
+            problem_type; kwargs...
         )
     end
 
     @add_kwonly function DAEProblem{iip, specialize}(
-            f, du0, u0, tspan, p = NullParameters();
+            f, du0, u0, tspan, p = NullParameters(),
+            problem_type = StandardDAEProblem();
             kwargs...
         ) where {iip, specialize}
         return DAEProblem{iip}(
-            DAEFunction{iip, specialize}(f), du0, u0, tspan, p; kwargs...
+            DAEFunction{iip, specialize}(f), du0, u0, tspan, p, problem_type; kwargs...
         )
     end
 end
 
-function DAEProblem(f::AbstractDAEFunction, du0, u0, tspan, p = NullParameters(); kwargs...)
-    return DAEProblem{isinplace(f)}(f, du0, u0, tspan, p; kwargs...)
+function DAEProblem(
+        f::AbstractDAEFunction, du0, u0, tspan, p = NullParameters(),
+        problem_type = StandardDAEProblem(); kwargs...
+    )
+    return DAEProblem{isinplace(f)}(f, du0, u0, tspan, p, problem_type; kwargs...)
 end
 
-function DAEProblem(f, du0, u0, tspan, p = NullParameters(); kwargs...)
-    return DAEProblem(DAEFunction(f), du0, u0, tspan, p; kwargs...)
+function DAEProblem(
+        f, du0, u0, tspan, p = NullParameters(),
+        problem_type = StandardDAEProblem(); kwargs...
+    )
+    return DAEProblem(DAEFunction(f), du0, u0, tspan, p, problem_type; kwargs...)
 end
 
 function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
-    return function ctor(f, du0, u0, tspan, p, kw, dv)
+    return function ctor(f, du0, u0, tspan, p, kw, dv, pt)
         iip = isinplace(f)
-        return DAEProblem{iip}(f, du0, u0, tspan, p; differential_vars = dv, kw...)
+        return DAEProblem{iip}(f, du0, u0, tspan, p, pt; differential_vars = dv, kw...)
     end
 end
 

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -903,9 +903,9 @@ function remake(
 
     prob = if kwargs === missing
         # Splat as NamedTuples to stay off the `merge(::Any, ::Pairs)` invalidation path.
-        DAEProblem{iip}(f, du0, newu0, tspan, newp; differential_vars, (values(prob.kwargs)::NamedTuple)..., (values(_kwargs)::NamedTuple)...)
+        DAEProblem{iip}(f, du0, newu0, tspan, newp, prob.problem_type; differential_vars, (values(prob.kwargs)::NamedTuple)..., (values(_kwargs)::NamedTuple)...)
     else
-        DAEProblem{iip}(f, du0, newu0, tspan, newp; differential_vars, kwargs...)
+        DAEProblem{iip}(f, du0, newu0, tspan, newp, prob.problem_type; differential_vars, kwargs...)
     end
 
     u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)

--- a/test/pde_solutions.jl
+++ b/test/pde_solutions.jl
@@ -25,3 +25,19 @@ SciMLBase.PDENoTimeSolution(sol, metadata::TestNoTimeMetadata) =
     @test wrapped_no_time[2] === sol
     @test wrapped_no_time[3] === no_time_metadata
 end
+
+@testset "wrap_sol reaches a DAEProblem's discretization metadata" begin
+    daef(du, u, p, t) = du .- u
+    metadata = TestTimeMetadata()
+    prob = DAEProblem(daef, [1.0], [1.0], (0.0, 1.0), SciMLBase.NullParameters(), metadata)
+
+    @test SciMLBase.problem_type(prob) === metadata
+    @test SciMLBase.problem_type(remake(prob; u0 = [2.0])) === metadata
+    @test SciMLBase.problem_type(DAEProblem(daef, [1.0], [1.0], (0.0, 1.0))) isa
+        SciMLBase.StandardDAEProblem
+
+    sol = SciMLBase.build_solution(prob, nothing, [0.0, 1.0], [[1.0], [2.0]])
+    wrapped = SciMLBase.wrap_sol(sol)
+    @test wrapped[1] === :time_series
+    @test wrapped[3] === metadata
+end

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -367,6 +367,7 @@ end
         "SciMLBase.SplitSDEProblem",
         "SciMLBase.DynamicalSDEProblem",
         "SciMLBase.DAEProblem",
+        "SciMLBase.StandardDAEProblem",
         "SciMLBase.DDEProblem",
         "SciMLBase.StandardDDEProblem",
         "SciMLBase.AbstractDynamicalDDEProblem",


### PR DESCRIPTION
## What and why

`ODEProblem`, `DDEProblem`, `BVProblem` and `NonlinearProblem` each carry a `problem_type` marker field. `problem_type(prob)` reads it, and `wrap_sol(sol)` dispatches on the result — that is the hook PDE discretizers use to turn a raw solver solution into a `PDETimeSeriesSolution`. `DAEProblem` has no such field, so `problem_type` always returned `nothing` for it and no wrapping could occur.

This matters for MethodOfLines: a discretized PDE is a residual `D(u) - f ~ 0`, which is already a `DAEProblem`. Building one directly (instead of via `mtkcompile` + `ODEProblem`) keeps array equations intact, but the resulting solution could not be wrapped, so it was indexed by discretized variables rather than by the PDE's own `u(t, x)`.

This adds `StandardDAEProblem` as the default marker and threads a `problem_type` field through `DAEProblem`'s constructors, `ConstructionBase.constructorof`, and `remake`, mirroring `ODEProblem` exactly.

## Compatibility

The new type parameter `PT` is appended last, so existing partial parameterizations (`DAEProblem{uType, duType, tType, iip}`, `DAEProblem{true}`) are unaffected. `problem_type` is a trailing positional argument with a default, as on `ODEProblem`, so every existing call site keeps working. I grepped the installed package depot for full-parameter `DAEProblem{...}` annotations and found none in the SciML ecosystem (the hits are GeometricEquations' unrelated `DAEProblem` type). Versioned as a minor bump since it adds public API.

## Verification

New tests in `test/pde_solutions.jl` cover the marker surviving construction and `remake`, the default being `StandardDAEProblem`, and `wrap_sol(sol)` reaching a `DAEProblem`'s discretization metadata.

Failing before the change (the same test file run against SciMLBase v3.47.0 from the registry — the 6-argument constructor does not exist):

```
Test Summary:                                           | Error  Total  Time
wrap_sol reaches a DAEProblem's discretization metadata |     1      1  1.9s
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

Passing after:

```
Test Summary:                                        | Pass  Total  Time
wrap_sol routes by discretization metadata time flag |    6      6  0.0s
Test Summary:                                           | Pass  Total  Time
wrap_sol reaches a DAEProblem's discretization metadata |    5      5  0.5s
```

Full `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`:

```
PDE solutions |   11     11  0.2s
Public interface declarations |  556    556  3.5s
     Testing SciMLBase tests passed
```

End-to-end, the motivating case — a MethodOfLines heat equation discretized to array form, built as a `DAEProblem` without `mtkcompile`, solved with `DFBDF` (this needs the companion ModelingToolkit change so the system's `ProblemTypeCtx` metadata reaches the new field):

```
problem_type(prob) = MOLMetadata
typeof(sol) = PDETimeSeriesSolution
sol[u(t,x)] size = (2, 21)
max|u-exact| = 0.0007565021749123546
interp at (0.1, 0.5) = 0.3734643410283503  exact = 0.37270783885343794
retcode = Success
```

`runic --check` and `typos` are clean on the diff.

## Not verified

Downstream, DownstreamAD, SymbolicIndexingInterface and Python groups were not run locally — they pull large external dependency trees. `remake` on `DAEProblem` is exercised by the new test but the broader downstream solver packages (Sundials `IDA`, DAE integrators) were not run here; CI covers them.

## Companion change

ModelingToolkit needs a one-line change to pass a system's `ProblemTypeCtx` metadata into the new field (as it already does for `ODEProblem`); that PR is gated on this release.

---

**Please ignore until reviewed by @ChrisRackauckas.**
