### PR TITLE
Fix stable problem-trait documentation links

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -148,7 +148,7 @@ are:
   - `tspan`: the independent-variable interval for time-dependent problems.
   - `p`: parameters, defaulting to `NullParameters` when omitted.
   - `kwargs`: keyword arguments stored on the problem and forwarded to solves.
-  - construction-layout metadata available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when
+  - construction-layout metadata available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when
     several constructors share one concrete representation.
 
 Subtypes that expose state and parameters through symbolic indexing should
@@ -365,7 +365,7 @@ function mutation convention.
 ## Interface
 
 ODE problems should provide `f`, `u0`, `tspan`, `p`, and `kwargs`. A problem that
-preserves an alternate construction layout should extend [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/).
+preserves an alternate construction layout should extend [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits).
 The function should support either `f(u, p, t)` or
 `f(du, u, p, t)` according to [`isinplace`](@ref). Stored keyword arguments such
 as callbacks or tolerances are forwarded to solvers.
@@ -477,7 +477,7 @@ $(TYPEDEF)
 
 Base interface for second-order ODE problems. These problems are represented in
 the ODE hierarchy for solver interoperability, but their constructors preserve
-second-order structure through concrete fields or [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) metadata.
+second-order structure through concrete fields or [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) metadata.
 """
 abstract type AbstractSecondOrderODEProblem{uType, tType, isinplace} <:
 AbstractODEProblem{uType, tType, isinplace} end

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -5,7 +5,7 @@ Marker for multi-point first-order BVP layouts.
 
 `StandardBVProblem()` identifies boundary value problems whose boundary
 condition is supplied as one residual function over the current solution values
-and mesh. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) for a `BVProblem` that does
+and mesh. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) for a `BVProblem` that does
 not use separate endpoint boundary-condition functions.
 """
 struct StandardBVProblem end
@@ -123,7 +123,7 @@ every solve call.
 * `ub`: The upper bounds for the solution variables. Defaults to `nothing`.
 * `lcons`: The lower bounds for the constraint residuals. Defaults to `nothing`.
 * `ucons`: The upper bounds for the constraint residuals. Defaults to `nothing`.
-* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) to obtain either
+* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) to obtain either
   `StandardBVProblem` or `TwoPointBVProblem`.
 * `singular_term`: The singular term of the problem. Defaults to `nothing`.
 * `kwargs`: The keyword arguments passed onto the solves.
@@ -314,7 +314,7 @@ Marker for multi-point second-order BVP layouts.
 
 `StandardSecondOrderBVProblem()` identifies second-order BVPs whose boundary
 condition is supplied as one residual function over derivative values, state
-values, parameters, and mesh points. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/)
+values, parameters, and mesh points. It is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
 for a `SecondOrderBVProblem` when endpoint residual functions are not used.
 """
 struct StandardSecondOrderBVProblem end
@@ -434,7 +434,7 @@ every solve call.
 * `ub`: The upper bounds for the solution variables. Defaults to `nothing`.
 * `lcons`: The lower bounds for the constraint residuals. Defaults to `nothing`.
 * `ucons`: The upper bounds for the constraint residuals. Defaults to `nothing`.
-* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) to obtain either
+* Construction layout: Query [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) to obtain either
   `StandardSecondOrderBVProblem` or `TwoPointSecondOrderBVProblem`.
 * `kwargs`: The keyword arguments passed onto the solves.
 """

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -307,7 +307,7 @@ Marker supertype for structured DDE problem layouts.
 
 Subtypes identify DDE problems constructed from partitioned first-order dynamics
 or from second-order dynamics. These markers are available through
-[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) on the common `DDEProblem` representation so solvers can
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) on the common `DDEProblem` representation so solvers can
 preserve or recover the structured interpretation when needed.
 """
 abstract type AbstractDynamicalDDEProblem end
@@ -317,7 +317,7 @@ $(TYPEDEF)
 
 Marker for partitioned dynamical DDE problem layouts.
 
-`DynamicalDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when a DDE is
+`DynamicalDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when a DDE is
 constructed from two coupled first-order components. The `iip` parameter records
 the in-place convention of the underlying `DynamicalDDEFunction`.
 """
@@ -381,7 +381,7 @@ $(TYPEDEF)
 
 Marker for second-order DDE problem layouts.
 
-`SecondOrderDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when a
+`SecondOrderDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when a
 second-order delay equation is converted to the partitioned DDE form used by
 `DDEProblem`. The `iip` parameter records the in-place convention of the
 second-derivative function.

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -6,7 +6,7 @@ Marker for standard nonlinear problem layouts.
 `StandardNonlinearProblem()` is the default `problem_type` metadata for
 nonlinear problems represented directly by a residual function and either an
 initial guess or an interval. Solver code may inspect this marker through
-[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) when it needs to distinguish the standard residual layout
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when it needs to distinguish the standard residual layout
 from specialized nonlinear problem encodings, while generic nonlinear code should rely on the
 `AbstractNonlinearProblem` fields and traits instead.
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -258,7 +258,7 @@ Marker supertype for structured ODE problem layouts.
 
 Subtypes identify ODE problems that are constructed from partitioned or
 second-order dynamics and then stored in the common `ODEProblem` representation.
-The concrete marker is available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) so solvers can
+The concrete marker is available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) so solvers can
 preserve structure when they support specialized methods.
 """
 abstract type AbstractDynamicalODEProblem end
@@ -469,7 +469,7 @@ Marker supertype for split ODE problem layouts.
 
 Subtypes identify ODEs whose right-hand side is supplied as a split function,
 usually to expose additive, linear, stiff, or nonstiff structure to solvers.
-Split constructors expose this marker through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) while using
+Split constructors expose this marker through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) while using
 the ordinary `ODEProblem` storage layout.
 """
 abstract type AbstractSplitODEProblem end
@@ -576,7 +576,7 @@ Internal supertype for incrementing ODE constructor tags. Concrete tags record
 the in-place convention while [`IncrementingODEProblem`](@ref) converts the
 input into an `ODEProblem` with an [`IncrementingODEFunction`](@ref).
 
-These tags are available from [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) on the resulting problem;
+These tags are available from [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) on the resulting problem;
 they are not standalone problem containers. Solvers that require incrementing
 evaluation may dispatch on the tag or the wrapped function, but ordinary ODE
 tooling should use the returned `ODEProblem` interface.
@@ -591,7 +591,7 @@ Construct an experimental ODE problem for a model function that can update an
 existing derivative buffer in an incrementing form.
 
 The constructor wraps `f` in an [`IncrementingODEFunction`](@ref), exposes an
-`IncrementingODEProblem{iip}` tag through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/), and returns a
+`IncrementingODEProblem{iip}` tag through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits), and returns a
 standard `ODEProblem`. The result therefore follows the ordinary ODE problem
 field, symbolic-indexing, keyword-forwarding, and solve interfaces.
 

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -260,7 +260,7 @@ Return `sol` or wrap it in a higher-level SciML solution container.
 
 Solvers call `wrap_sol(sol)` after constructing a low-level solution. When
 `sol.prob` is an [`AbstractSciMLProblem`](@ref), the default implementation
-queries [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/) and dispatches to
+queries [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) and dispatches to
 `wrap_sol(sol, problem_type_or_metadata)` when the result is not `nothing`.
 Problem-family packages extend the two-argument form when a generated solver
 solution should be returned as a more specific public solution type.


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Redirect the 16 portable `problem_type` docstring links from the undeployed stable `Problem_Traits/` route to the deployed `Problems/#Problem-Traits` section. Strict link checking remains enabled; no link is ignored or downgraded to a warning.

Current master still fails every strict documentation build on the old route. The identical prior PR, https://github.com/SciML/SciMLBase.jl/pull/1485, was closed without comments, reviews, or a recorded technical objection. GitHub refused to reopen it after its branch was refreshed onto current master, so this replacement draft is necessary.

## Failing before / passing after

On clean current master `fd427fd3e`, the full strict docs command fails:

```text
julia +1.12 --startup-file=no --project=docs docs/make.jl

HTTP 403: https://docs.sciml.ai/SciMLBase/stable/interfaces/Problem_Traits/
ERROR: makedocs encountered an error [:linkcheck]
```

With the 16 replacements applied to the same current source, the identical command exits 0 through link checking and HTML rendering. The replacement URL responds HTTP 200:

https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits

The strict docs build itself is the discriminating regression test; no failure is silenced.

## Root cause

A formal bisect identified https://github.com/SciML/SciMLBase.jl/commit/6807f7fd5e021912303d6faf6151986efffe9987 as the first bad commit. It introduced the absolute old-route links before that route was deployed in the stable documentation tree.

Fresh current-master CI reproduces the same failure:

https://github.com/SciML/SciMLBase.jl/actions/runs/32365988782/job/96415490993

## Local verification

```text
GROUP=Core julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Remake | 4430 / 4430
Testing SciMLBase tests passed

GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 51 / 51
Testing SciMLBase tests passed

julia +1.12 --startup-file=no -m Runic --check .
typos <changed files>
git diff --check
# all exit 0
```

No GPU, downstream, or prerelease-Julia groups were run locally. The full documentation, Core, and QA gates cover this docstring-link-only change.