### PR TITLE
Allow vector-backed CallbackSet storage

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -461,8 +461,9 @@ Multiple callbacks can be chained together to form a `CallbackSet`. A
     CallbackSet(cb1,cb2,cb3)
 
 You can pass as many callbacks as needed. Nested callback sets are flattened into
-two ordered tuples, `continuous_callbacks` and `discrete_callbacks`. Solvers
-should use these tuples instead of re-splitting callbacks themselves.
+two ordered collections, `continuous_callbacks` and `discrete_callbacks`. Public
+constructors use tuples; solver paths may use vectors when callback types must be
+erased to reuse compilation.
 
 When a solver encounters multiple callbacks, the following rules apply:
 
@@ -476,7 +477,10 @@ When a solver encounters multiple callbacks, the following rules apply:
     that the next callback no longer evaluates condition to `true`, its `affect`
     will not be applied.
 """
-struct CallbackSet{T1 <: Tuple, T2 <: Tuple} <: DECallback
+struct CallbackSet{
+        T1 <: Union{Tuple, AbstractVector},
+        T2 <: Union{Tuple, AbstractVector},
+    } <: DECallback
     continuous_callbacks::T1
     discrete_callbacks::T2
 end
@@ -567,6 +571,18 @@ function save_discretes!(integrator::DEIntegrator, cb::CallbackSet; kw...)
     return _save_all_discretes!(integrator, cb.continuous_callbacks..., cb.discrete_callbacks...)
 end
 
+function save_discretes!(
+        integrator::DEIntegrator,
+        cb::CallbackSet{<:AbstractVector, <:AbstractVector}; kw...
+    )
+    for callbacks in (cb.continuous_callbacks, cb.discrete_callbacks)
+        for callback in callbacks
+            save_discretes!(integrator, callback; skip_duplicates = true)
+        end
+    end
+    return
+end
+
 """
     $(TYPEDSIGNATURES)
 
@@ -592,6 +608,18 @@ _save_all_final_discretes!(::DEIntegrator) = nothing
 
 function save_final_discretes!(integrator::DEIntegrator, cb::CallbackSet; kw...)
     return _save_all_final_discretes!(integrator, cb.continuous_callbacks..., cb.discrete_callbacks...)
+end
+
+function save_final_discretes!(
+        integrator::DEIntegrator,
+        cb::CallbackSet{<:AbstractVector, <:AbstractVector}; kw...
+    )
+    for callbacks in (cb.continuous_callbacks, cb.discrete_callbacks)
+        for callback in callbacks
+            save_final_discretes!(integrator, callback)
+        end
+    end
+    return
 end
 
 """
@@ -623,4 +651,16 @@ _save_discretes_if_enabled!(::DEIntegrator; kw...) = nothing
 
 function save_discretes_if_enabled!(integrator::DEIntegrator, cb::CallbackSet; kw...)
     return _save_discretes_if_enabled!(integrator, cb.continuous_callbacks..., cb.discrete_callbacks...; kw...)
+end
+
+function save_discretes_if_enabled!(
+        integrator::DEIntegrator,
+        cb::CallbackSet{<:AbstractVector, <:AbstractVector}; kw...
+    )
+    for callbacks in (cb.continuous_callbacks, cb.discrete_callbacks)
+        for callback in callbacks
+            save_discretes_if_enabled!(integrator, callback; kw...)
+        end
+    end
+    return
 end

--- a/test/callback_constructors.jl
+++ b/test/callback_constructors.jl
@@ -1,6 +1,17 @@
 using SciMLBase
 using Test
 
+@testset "CallbackSet collection storage" begin
+    condition(u, t, integrator) = true
+    affect!(integrator) = nothing
+    callback = DiscreteCallback(condition, affect!)
+
+    callback_set = CallbackSet(Any[], Any[callback])
+    @test callback_set.continuous_callbacks isa Vector{Any}
+    @test callback_set.discrete_callbacks isa Vector{Any}
+    @test only(callback_set.discrete_callbacks) === callback
+end
+
 @testset "VectorContinuousCallback 3-arg kwarg constructor" begin
     cond(out, u, t, integ) = (out[1] = u[1])
     aff!(integ, idx) = nothing


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Allow `CallbackSet` to store its ordered continuous and discrete callbacks in either tuples or abstract vectors. Public callback-combining constructors continue to produce tuples; solver initialization paths can now use vectors to erase callback types and reuse compiled solver code. Vector-specific save traversal avoids splatting dynamically stored callbacks.

This is the SciMLBase prerequisite for despecializing callback storage in OrdinaryDiffEq. It does not change the default tuple-backed callback path.

## Verification

Failing before, using this PR's unchanged test file with clean SciMLBase `fd427fd3e`:

```text
timeout 3600 julia --startup-file=no --compiled-modules=no --project=. -e 'include("../SciMLBase.jl/test/callback_constructors.jl")'
CallbackSet collection storage | Error 1 / Total 1
MethodError: no method matching CallbackSet(::Vector{Any}, ::Vector{Any})
```

Passing after:

```text
timeout 3600 julia --startup-file=no --compiled-modules=no --project=. -e 'include("test/callback_constructors.jl")'
CallbackSet collection storage                         | 3 Pass / 3 Total
VectorContinuousCallback 3-arg kwarg constructor      | 7 Pass / 7 Total
VectorContinuousCallback rejects affect_neg!          | 2 Pass / 2 Total
```

Full relevant and QA groups on the rebased branch:

```text
GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Callback constructors | 12 Pass / 12 Total
Remake                | 4430 Pass / 4430 Total
Testing SciMLBase tests passed

GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 51 Pass / 51 Total
Testing SciMLBase tests passed
```

Documentation and static checks:

```text
julia --startup-file=no --project=docs docs/make.jl
exit 0 after doctests, cross-references, document checks, rendering, and link checking

julia --startup-file=no -m Runic --check src/callbacks.jl test/callback_constructors.jl
git diff upstream/master...HEAD | typos -
git diff --check upstream/master...HEAD
all exit 0 with no output
```

## Not verified

GPU and downstream groups were not run. The OrdinaryDiffEq integration is intentionally kept in a separate follow-up change.

## Reviewer note

The direct two-collection struct constructor now accepts vectors, while the documented variadic constructors remain tuple-backed. The intended vector use is solver-internal type erasure.
