### PR TITLE
docs: build SciMLBase from the checkout

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,8 @@
+using Pkg
+
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+Pkg.instantiate()
+
 using Documenter, SciMLBase
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)


### PR DESCRIPTION
## What changed

Make the SciMLBase docs build develop the checkout before loading Documenter. This keeps the docs build aligned with the source being documented instead of silently using the registered SciMLBase release from `docs/Manifest.toml`.

## Verification

- Before this change: `julia --startup-file=no --project=docs docs/make.jl` loaded SciMLBase 3.48.0 and failed on undefined current bindings `SciMLBase.has_global_error` and `SciMLBase.report_integrator_failure`, plus stale problem-trait links.
- After this change: the same command resolved `/home/crackauc/sandbox/tmp_20260708_051717_3275/scimlbase-master/src/SciMLBase.jl` at version 3.49.1 and completed doctests, cross-references, document checks, rendering, and HTML generation with exit 0.
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 51/51 passed.
- `GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: all observed Core groups passed, including 560 public-interface and package tests.
- Runic check, typos, and `git diff --check` passed.

The remaining Documenter messages are existing HTML-size and local deployment warnings; no tests or documentation errors were suppressed.

Please ignore this draft until reviewed by @ChrisRackauckas.
