### PR TITLE
Opt inference fixtures into full specialization

### DIFF
--- a/test/downstream/comprehensive_indexing.jl
+++ b/test/downstream/comprehensive_indexing.jl
@@ -74,10 +74,10 @@ begin
     p_vals = [kp => 1.0, kd => 0.1, k1 => 0.25, k2 => 0.5]
 
     # Creates problems.
-    oprob = ODEProblem(osys, [u0_vals; p_vals], tspan)
-    sprob = SDEProblem(ssys, [u0_vals; p_vals], tspan)
+    oprob = ODEProblem{true, SciMLBase.FullSpecialize}(osys, [u0_vals; p_vals], tspan)
+    sprob = SDEProblem{true, SciMLBase.FullSpecialize}(ssys, [u0_vals; p_vals], tspan)
     jprob = JumpProblem(jsys, [u0_vals; p_vals], tspan; aggregator = Direct(), rng)
-    nprob = NonlinearProblem(nsys, [u0_vals; p_vals])
+    nprob = NonlinearProblem{true, SciMLBase.FullSpecialize}(nsys, [u0_vals; p_vals])
     hcprob = NonlinearProblem(HomotopyNonlinearFunction(nprob.f), nprob.u0, nprob.p)
     ssprob = SteadyStateProblem(osys, [u0_vals; p_vals])
     optprob = OptimizationProblem(optsys, [u0_vals; p_vals], grad = true, hess = true)
@@ -422,7 +422,7 @@ end
     ]
     @named sys = System(eqs, t, [sts...;], ps)
     sys = complete(sys)
-    prob = ODEProblem(sys, [], (0, 1.0))
+    prob = ODEProblem{true, SciMLBase.FullSpecialize}(sys, [], (0, 1.0))
     sol = solve(prob, Tsit5())
     # interpolation of array variables
     @test sol(1.0, idxs = x) == [sol(1.0, idxs = x[i]) for i in 1:3]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Make the four inference-sensitive ModelingToolkit problem fixtures explicitly use the documented `SciMLBase.FullSpecialize` policy. ModelingToolkit now deliberately defaults generated problems to `AutoDespecialize`, so tests whose contract is full concrete inference must opt into specialization instead of assuming the package default.

This changes test setup only. No assertion is removed or loosened, and no public API, dependency, or package version changes.

## Root cause

ModelingToolkit v11.39.0 / ModelingToolkitBase v1.65.0 passed the comprehensive indexing suite at 3777/3777. ModelingToolkit v11.39.1 / ModelingToolkitBase v1.67.0 produces 12 inference errors.

The exact source boundary is https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6 from https://github.com/SciML/ModelingToolkit.jl/pull/4919, which intentionally moved generated problem defaults from `AutoSpecialize` to `AutoDespecialize`.

## Failing before

On clean SciMLBase master with ModelingToolkit v11.39.1, the unchanged official comprehensive indexing assertions fail locally:

```text
Symbol and integer based indexing of interpolated solutions
3407 passed, 12 errors, 3419 total
```

The errors include:

```text
return type Float64 does not match inferred return type Any
```

and the vector-valued equivalent whose inferred result is abstract/`Any`.

## Passing after

With only these four constructors opting into `FullSpecialize`:

```text
comprehensive indexing | 3777/3777
Remake                | 4430/4430
integrator indexing   | 98/98
problem indexing      | 122/122
GROUP=QA              | 51/51
Testing SciMLBase tests passed
```

The final Runic check, typos check, and `git diff --check` pass on the rebased branch.

## Not verified

The full `GROUP=SymbolicIndexingInterface` command reaches the passing target testsets above, then exits on an independent clean-master `SCCNonlinearProblem` missing-import regression in `modelingtoolkit_remake.jl`. That failure is being handled separately and was not changed or silenced here.

Julia LTS and prerelease were not rerun locally. The official failing jobs show the same original inference regression on Julia 1, LTS, and prerelease. Docs were not run because this is test-only.

Official failure examples:

- https://github.com/SciML/SciMLBase.jl/actions/runs/32353474895/job/96378948495
- https://github.com/SciML/SciMLBase.jl/actions/runs/32353474895/job/96378948751
- https://github.com/SciML/SciMLBase.jl/actions/runs/32353474895/job/96378948691
