### PR TITLE
Handle abstract ODESolution cotangent containers

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -48,8 +48,8 @@ function ChainRulesCore.rrule(
             dprob = remake(VA.prob, p = dp)
             du, dprob
         end
-        T = eltype(eltype(du))
-        N = ndims(eltype(du)) + 1
+        T = eltype(first(du))
+        N = ndims(first(du)) + 1
         Δ′ = ODESolution{T, N}(
             du, nothing, nothing, VA.t, VA.k, nothing, dprob,
             VA.alg, VA.interp, VA.dense, 0, VA.stats, VA.alg_choice, VA.retcode,

--- a/test/downstream/remake_autodiff.jl
+++ b/test/downstream/remake_autodiff.jl
@@ -151,6 +151,7 @@ if VERSION < v"1.12"
             make_symbolic_indexing_observed_p(prob, u0), backend, p
         )
         @test dp1 !== nothing
+        @test all(isfinite, dp1)
         cur_ders["symbolic_indexing_observed_p"] = dp1
     end
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

Depends on the ModelingToolkitBase tangent fix in https://github.com/SciML/ModelingToolkit.jl/pull/5000.

## What changed and why

Derive an ODESolution cotangent's element type and dimensionality from `first(du)` rather than from the abstract outer container type. AutoDespecialized observed-value pullbacks can legitimately produce `du::Vector{Any}` whose elements are concrete arrays; the outer `eltype` does not describe the solution element.

The existing downstream AD test now also requires the returned parameter cotangent to be finite. No public API or dependency changes are included. SciMLBase remains at the already-unreleased 3.49.2 version on current master.

## Root cause

After https://github.com/SciML/ModelingToolkit.jl/pull/5000 handles the preceding despecialized-parameter tangent promotion, the pullback reaches ODESolution reconstruction with an abstract outer vector. The implementation calls `ndims(eltype(du))`, which becomes `ndims(Any)`, even though `first(du)` has the concrete array shape needed for reconstruction.

## Failing before

With the ModelingToolkitBase prerequisite applied and this source unchanged, the official Julia LTS file fails deterministically:

```text
MethodError: no method matching ndims(::Type{Any})
Autodiff Remake | 4 pass, 1 error
```

The upstream CI path begins with the prerequisite tangent failure here:

https://github.com/SciML/SciMLBase.jl/actions/runs/32353474895/job/96378948536

The added finite-cotangent assertion is in that same official path; unfixed execution errors before it can return a cotangent.

## Passing after

On the minimal two-PR stack, the identical official downstream file passes twice after removing the exploratory tangent-materialization code:

```text
test/downstream/remake_autodiff.jl
split=false | 7/7 | 4m34.3s
split=true  | no applicable cases
consistency | 1 pre-existing broken
```

On the exact branch rebased onto current SciMLBase master:

```text
GROUP=QA
QA | 51/51 | 3m01.7s
Testing SciMLBase tests passed
```

Runic, typos over the two-file diff, and `git diff --check` pass.

## Not verified

The full Julia 1.12 DownstreamAD group crosses both SciML source fixes and the separately developed Mooncake fix, then reaches an independent stale AutoDespecialize test-shape regression. That clean-master failure is being handled separately and was not changed here.

The full LTS downstream group, Julia prerelease, GPU paths, and docs were not run locally. Docs were not required because this changes no public declaration, signature, docstring, or documentation file.
