### PR TITLE
Handle despecialized observable parameter tangents

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -136,7 +136,9 @@ end
             end
             @test count(!iszero, gp_ref) == 1
             @test only(filter(!iszero, gp_ref)) == 1.0
-            @test _unwrap_grad(gs).prob.fields.p.fields.tunable ≈ gp_ref
+            gp = _unwrap_grad(gs).prob.fields.p
+            gp = hasproperty(gp.fields, :params) ? gp.fields.params : gp
+            @test gp.fields.tunable ≈ gp_ref
         end
     end
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Make the observable-AD fixture extract its parameter tangent through either the legacy direct `tunable` field or the current `DespecializedParameters.params` wrapper, then retain the same `tunable ≈ gp_ref` numerical contract.

This is test-only compatibility with the documented AutoDespecialize boundary. No assertion is removed or loosened, and there is no public API, dependency, docs, or version change.

## Root cause

ModelingToolkit commit https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6 from https://github.com/SciML/ModelingToolkit.jl/pull/4919 changed generated problem defaults to AutoDespecialize. The returned parameter tangent is therefore wrapped in `DespecializedParameters.params`; the existing test continued assuming the prior direct `tunable` shape.

The exact binary boundary is ModelingToolkitBase 1.65.0 → 1.66.0. Pinning ModelingToolkit root alone is insufficient because the constructor lives in ModelingToolkitBase.

## Failing before

On current ModelingToolkit 11.39.1 / ModelingToolkitBase 1.67.0, the unchanged focused file reaches:

```text
initialization | 3 pass, 1 error
FieldError: type NamedTuple has no field tunable
Available fields: params
test/downstream/observables_autodiff.jl:139
```

The true old-stack control—ModelingToolkit 11.39.0 plus ModelingToolkitBase 1.65.0—passes the original initialization assertion 4/4.

## Passing after

On the current stack after this test-only fix:

```text
observables_autodiff.jl
AutoDiff Observable Functions | 2/2
initialization                | 4/4
DAE                           | 2 pass, 1 existing broken
DAE adjoints                  | 2/2
NonlinearSolution             | 2/2
integer indexing              | 1/1
```

The final owning gates pass:

```text
GROUP=DownstreamAD
Observable summary | 13 pass, 1 existing broken
Ensemble summary   | 1 existing broken
Testing SciMLBase tests passed

GROUP=QA
QA | 51/51
Testing SciMLBase tests passed
```

Runic, typos over the diff, and `git diff --check` pass.

## Upstream prerequisite / not verified

Registered Mooncake 0.5.46 currently fails earlier in this same file at lines 82 and 123 because its tuple-copy helper asserts the concrete reconstructed NamedTuple type against an abstract-field NamedTuple. The final DownstreamAD run used a locally validated Mooncake fix to reach and prove this independent fixture regression; no Mooncake PR has been opened.

The Mooncake patch has its own standalone no-SciML fail/pass reproducer and passed Mooncake's full Julia 1.12 `basic` group (29,487 pass, 2 pre-existing broken). Until that upstream fix is released, standalone CI may stop before reaching this PR's corrected assertion.

Julia LTS/prerelease, GPU paths, and docs were not run for this test-only PR.
