### PR TITLE
Qualify SciMLBase problem constructors in downstream tests

### DIFF
--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, SymbolicIndexingInterface
+import SciMLBase
 using JumpProcesses
 using ModelingToolkit: t_nounits as t, D_nounits as D
 using OrdinaryDiffEq
@@ -78,7 +79,7 @@ push!(probs, OptimizationProblem(optsys, [u0; p]))
     [0 ~ x^3 * β + y^3 * ρ - σ, 0 ~ x^2 + 2x * y + y^2, 0 ~ z^2 - 4z + 4],
     [x, y, z], [σ, β, ρ]
 )
-sccprob = SCCNonlinearProblem(sys, [u0; p])
+sccprob = SciMLBase.SCCNonlinearProblem(sys, [u0; p])
 @test_nowarn SciMLBase.initialization_status(sccprob)
 push!(syss, sys)
 push!(probs, sccprob)
@@ -427,7 +428,7 @@ end
         β => 8 / 3,
     ]
 
-    sccprob = SCCNonlinearProblem(fullsys, [u0; p])
+    sccprob = SciMLBase.SCCNonlinearProblem(fullsys, [u0; p])
 
     sccprob2 = remake(sccprob; u0 = 2ones(3))
     @test state_values(sccprob2) ≈ 2ones(3)
@@ -481,10 +482,10 @@ end
     @testset "$Problem" for (rhss, Problem, Func) in [
             (0.0, ODEProblem, ODEFunction),
             (a, SDEProblem, SDEFunction),
-            (_x(t - 0.1), DDEProblem, DDEFunction),
-            (_x(t - 0.1) + a, SDDEProblem, SDDEFunction),
+            (_x(t - 0.1), SciMLBase.DDEProblem, SciMLBase.DDEFunction),
+            (_x(t - 0.1) + a, SciMLBase.SDDEProblem, SciMLBase.SDDEFunction),
             (y + 2, NonlinearProblem, NonlinearFunction),
-            (y + 2, NonlinearLeastSquaresProblem, NonlinearFunction),
+            (y + 2, SciMLBase.NonlinearLeastSquaresProblem, NonlinearFunction),
         ]
         is_nlsolve = Func == NonlinearFunction
         D = is_nlsolve ? (v) -> v^3 : Differential(t)


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## What changed

Qualify SciMLBase-owned problem and function types through `SciMLBase` in the ModelingToolkit remake downstream test.

OrdinaryDiffEq intentionally stopped blanket-reexporting these names in https://github.com/SciML/OrdinaryDiffEq.jl/pull/3264. The downstream fixture should depend on their public owner instead of the former accidental re-export.

## Failing before the fix

On clean current SciMLBase master, the unmodified official test failed before entering the SCC testset:

```
ERROR: LoadError: UndefVarError: `SCCNonlinearProblem` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in SciMLBase.
```

A staged run with only that name qualified passed `SCCNonlinearProblem | 11/11` and then failed on `DDEProblem`; qualifying the DDE/SDDE constructors exposed the final missing `NonlinearLeastSquaresProblem`. All are from the same removed blanket re-export.

The source boundary was verified directly: after `using OrdinaryDiffEq`, `SCCNonlinearProblem` is defined at parent `afaa7915bb3502ef252e67cb2c4b4bce0c2b68ca` and is no longer defined at https://github.com/SciML/OrdinaryDiffEq.jl/commit/fff6f33819d2dca0c99eb4a961a21d3ed7bf89ea.

## Passing after the fix

The entire affected file passed:

```
SCCNonlinearProblem | 11  11
Lazy initialization | 13  13
```

The full owning group passed:

```
GROUP=SymbolicIndexingInterface julia +1.12 --startup-file=no --project -e 'using Pkg; Pkg.test()'
Remake                 | 4430  4430
Comprehensive Indexing | 3777  3777
Integrators            |   98    98
Problem Indexing       |  122   122
ModelingToolkit Remake | 248  3 broken  251
Testing SciMLBase tests passed
```

QA and mechanical checks also passed:

```
GROUP=QA julia +1.12 --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA | 51  51
Testing SciMLBase tests passed

julia +1.12 --startup-file=no --project=@runic -m Runic --check --diff test/downstream/modelingtoolkit_remake.jl
typos test/downstream/modelingtoolkit_remake.jl
git diff --check
```

No docs build was run because this only corrects an internal downstream test and changes no source, docstring, or public API. Julia LTS/pre were not run locally.