### PR TITLE
Test public abstract interface documentation

### DIFF
--- a/docs/src/interfaces/Algorithms.md
+++ b/docs/src/interfaces/Algorithms.md
@@ -8,6 +8,35 @@
 CommonSolve.solve(prob::AbstractSciMLProblem, alg::AbstractSciMLAlgorithm; kwargs...)
 ```
 
+### Generic Usage Rules
+
+Generic solver and extension code should dispatch on both the problem and
+algorithm interfaces and use capability traits for behavior that varies by
+algorithm. It must not inspect algorithm fields or assume that every algorithm
+supports every common keyword. In particular:
+
+  - algorithm-specific choices belong in the algorithm constructor and its
+    documented fields;
+  - common solve controls belong in `solve` or `init` keyword arguments;
+  - `isadaptive`, `isdiscrete`, `allowscomplex`,
+    `allows_arbitrary_number_types`, and `alg_order` describe execution
+    behavior and should be queried before selecting a generic path;
+  - capability traits such as `allowsbounds`, `requiresgradient`, and
+    `allowscallback` must be treated as contracts, not hints;
+  - `remake(alg; kwargs...)` is for preserving a concrete algorithm while
+    replacing supported configuration fields, and callers must not assume that
+    arbitrary fields are replaceable.
+
+An algorithm author should test the trait values and the generic solve
+dispatch with a representative algorithm value. A downstream consumer should
+be able to make compatibility decisions without naming the concrete solver:
+
+```julia
+function supports_complex_adaptive(alg::SciMLBase.AbstractSciMLAlgorithm)
+    return SciMLBase.allowscomplex(alg) && SciMLBase.isadaptive(alg)
+end
+```
+
 ### Algorithm-Specific Arguments
 
 Note that because the keyword arguments of `solve` are designed to be common across the whole

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -15,6 +15,40 @@ types have a method for constructing the associated problem and function types.
 The following standard principles should be adhered to across all
 `AbstractSciMLProblem` instantiations.
 
+### Generic Usage Rules
+
+Code that accepts an abstract problem must dispatch on the problem type itself
+and use the generic traits rather than inspecting a concrete problem's fields.
+The minimum generic contract is:
+
+  - `isinplace(prob)` reports the callback mutation convention encoded by the
+    problem type.
+  - `problem_type(prob)` reports construction-layout metadata, or `nothing`
+    when no separate layout marker applies.
+  - `is_diagonal_noise(prob)` reports the noise-storage convention for
+    stochastic problem families.
+  - `remake(prob; kwargs...)` creates a compatible problem with requested
+    replacements while preserving the problem's layout marker and callback
+    convention.
+
+Solver and extension code must not assume that every problem has the same
+fields, that a problem can be mutated in place, or that a convenience
+constructor's concrete representation identifies its mathematical layout.
+Custom problem types should implement the generic traits they support and test
+them with a representative problem value, without dispatching on a concrete
+problem type in downstream code.
+
+For example, a generic consumer can make a dispatch decision without knowing
+which problem family supplied the value:
+
+```julia
+function setup_problem(prob::SciMLBase.AbstractSciMLProblem)
+    iip = SciMLBase.isinplace(prob)
+    layout = SciMLBase.problem_type(prob)
+    return (; iip, layout)
+end
+```
+
 ### In-place Specification
 
 Each `AbstractSciMLProblem` type can be called with an "is inplace" (iip) choice. For example:

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -11,6 +11,36 @@ of pre-computed functions to speed up the calculations. This is offered via the
 The following standard principles should be adhered to across all
 `AbstractSciMLFunction` instantiations.
 
+### Generic Usage Rules
+
+Generic solver code must treat an `AbstractSciMLFunction` as a callable
+container and query its capability traits before using optional callbacks. The
+portable contract is:
+
+  - call the function using the signature documented by its function family;
+    do not infer the signature from the concrete wrapper's fields;
+  - use `isinplace(f)` to select the mutating or returning call convention;
+  - use `has_jac`, `has_jvp`, `has_vjp`, `has_paramjac`, `has_observed`, and
+    the related `has_*` traits before reading an optional callback;
+  - use `unwrapped_f(f)` only when an operation explicitly needs the underlying
+    callable, and preserve the wrapper's in-place convention after wrapping;
+  - treat optional callbacks as absent when the corresponding trait is false,
+    rather than assuming a field exists on every concrete subtype.
+
+An implementation of a new function container should be testable through these
+generic operations alone. A downstream package should therefore be able to
+write code such as:
+
+```julia
+function evaluate_model(f::SciMLBase.AbstractSciMLFunction, u, p, t)
+    return (; value = f(u, p, t), has_jac = SciMLBase.has_jac(f))
+end
+```
+
+The concrete function type remains responsible for documenting callback
+arguments, return values, and field layout. Generic code must not reach into
+those fields to discover capabilities.
+
 ### Common Function Choice Definitions
 
 The full interface available to the solvers is as follows:

--- a/docs/src/interfaces/Solutions.md
+++ b/docs/src/interfaces/Solutions.md
@@ -13,6 +13,38 @@ solutions must expose saved states as `u` and matching independent-variable valu
 concepts apply. Ensemble and noise-process subtypes follow the contracts in their
 rendered abstract-type docstrings below.
 
+### Generic Usage Rules
+
+Consumers should dispatch on the narrowest abstract solution family they need
+and use the array and callable interfaces instead of inspecting a concrete
+solution type. The common contract is:
+
+  - no-time solutions expose `u` and forward `size`, `getindex`, and compatible
+    linear algebra operations to it;
+  - time-series solutions expose matching `u` and `t` indices, with state
+    components preceding the saved-time index;
+  - callers use `successful_retcode(sol)` rather than comparing only against
+    `ReturnCode.Success`;
+  - callers use `isdenseplot(sol)` and `plottable_indices(x)` when selecting
+    plotting behavior instead of assuming dense interpolation or that every
+    state component is plottable;
+  - optional fields such as `prob`, `alg`, `interp`, `stats`, and `resid` may
+    be absent for a solution family and must be accessed only when that family's
+    contract documents them.
+
+For example, a generic report can work for every no-time solution without
+knowing whether it came from a linear, nonlinear, integral, or optimization
+solver:
+
+```julia
+function solution_report(sol::SciMLBase.AbstractNoTimeSolution)
+    return (; size = size(sol), successful = SciMLBase.successful_retcode(sol))
+end
+```
+
+Concrete solution types must document their fields, indexing shape, callable
+interpolation behavior, and any additional mutation or cache guarantees.
+
 ### Array Interface
 
 Instead of working on the `Vector{uType}` directly, we can use the provided

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -45,6 +45,29 @@ struct GenericGlobalErrorReportingAlgorithm <: SciMLBase.AbstractDEAlgorithm end
 
 SciMLBase.has_global_error(::GenericGlobalErrorReportingAlgorithm) = true
 
+struct GenericProblem <: SciMLBase.AbstractNonlinearProblem{Vector{Float64}, false}
+    u0::Vector{Float64}
+    p::NamedTuple
+end
+
+struct GenericFunction <: SciMLBase.AbstractSciMLFunction{false}
+    f::Function
+end
+
+(f::GenericFunction)(u, p, t) = f.f(u, p, t)
+
+struct GenericAlgorithm <: SciMLBase.AbstractODEAlgorithm end
+
+SciMLBase.isadaptive(::GenericAlgorithm) = false
+SciMLBase.isdiscrete(::GenericAlgorithm) = false
+SciMLBase.allowscomplex(::GenericAlgorithm) = true
+SciMLBase.alg_order(::GenericAlgorithm) = 2
+
+struct GenericSolution <: SciMLBase.AbstractNonlinearSolution{Float64, 1}
+    u::Vector{Float64}
+    retcode::SciMLBase.ReturnCode.T
+end
+
 struct ConcreteSolveContractProblem end
 struct ConcreteSolveContractAlgorithm end
 struct ConcreteSolveContractSenseAlg end
@@ -196,6 +219,35 @@ end
     @test !SciMLBase.has_global_error(GenericGlobalErrorAlgorithm())
     @test SciMLBase.has_global_error(GenericGlobalErrorReportingAlgorithm())
     @test Docs.doc(SciMLBase.has_global_error) !== nothing
+end
+
+@testset "Generic abstract interface contracts" begin
+    problem = GenericProblem([1.0], (; rate = 2.0))
+    @test SciMLBase.isinplace(problem) === false
+    @test SciMLBase.problem_type(problem) === nothing
+    @test SciMLBase.is_diagonal_noise(problem) === false
+
+    f = GenericFunction((u, p, t) -> p.rate .* u .+ t)
+    @test SciMLBase.isinplace(f) === false
+    @test f([1.0], (; rate = 2.0), 0.5) == [2.5]
+    @test !SciMLBase.has_analytic(f)
+    @test !SciMLBase.has_jac(f)
+    @test !SciMLBase.has_jvp(f)
+    @test !SciMLBase.has_vjp(f)
+    @test !SciMLBase.has_paramjac(f)
+    @test !SciMLBase.has_observed(f)
+
+    alg = GenericAlgorithm()
+    @test !SciMLBase.isadaptive(alg)
+    @test !SciMLBase.isdiscrete(alg)
+    @test SciMLBase.allowscomplex(alg)
+    @test SciMLBase.alg_order(alg) == 2
+
+    sol = GenericSolution([1.0, 2.0], SciMLBase.ReturnCode.Success)
+    @test size(sol) == (2,)
+    @test sol[2] == 2.0
+    @test SciMLBase.successful_retcode(sol)
+    @test SciMLBase.plottable_indices(sol.u) == 1:2
 end
 
 @testset "Problem layout marker interface" begin
@@ -463,6 +515,31 @@ end
     @test occursin("sol.tslocation != 0", solution_docs)
     @test occursin("1000 * sol.tslocation", solution_docs)
     @test occursin("`SensitivityInterpolation`", solution_docs)
+end
+
+@testset "Generic abstract interface documentation" begin
+    problem_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Problems.md"), String
+    )
+    function_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "SciMLFunctions.md"),
+        String,
+    )
+    algorithm_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Algorithms.md"), String
+    )
+    solution_docs = read(
+        joinpath(@__DIR__, "..", "docs", "src", "interfaces", "Solutions.md"), String
+    )
+
+    @test occursin("### Generic Usage Rules", problem_docs)
+    @test occursin("problem_type(prob)", problem_docs)
+    @test occursin("### Generic Usage Rules", function_docs)
+    @test occursin("has_paramjac", function_docs)
+    @test occursin("### Generic Usage Rules", algorithm_docs)
+    @test occursin("capability traits", algorithm_docs)
+    @test occursin("### Generic Usage Rules", solution_docs)
+    @test occursin("successful_retcode(sol)", solution_docs)
 end
 
 @testset "Ensemble interface documentation" begin

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -849,7 +849,18 @@ if isdefined(Base, :ispublic)
                 for (root, _, files) in walkdir(joinpath(@__DIR__, "..", "docs", "src", "interfaces"))
                 for file in files if endswith(file, ".md")
         )
-        interface_doc_lines = strip.(split(interface_docs, '\n'))
+        interface_api_bindings = String[]
+        in_docs_block = false
+        for line in strip.(split(interface_docs, '\n'))
+            if line == "```@docs"
+                in_docs_block = true
+            elseif in_docs_block && startswith(line, "```")
+                in_docs_block = false
+            elseif in_docs_block && !isempty(line)
+                push!(interface_api_bindings, line)
+            end
+        end
+        @test !in_docs_block
         abstract_public_names = filter(
             names(SciMLBase, all = true, imported = false)
         ) do name
@@ -862,7 +873,7 @@ if isdefined(Base, :ispublic)
 
         for name in abstract_public_names
             @test Base.Docs.hasdoc(SciMLBase, name)
-            @test "SciMLBase.$name" in interface_doc_lines
+            @test "SciMLBase.$name" in interface_api_bindings
         end
     end
 end

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -842,4 +842,27 @@ if isdefined(Base, :ispublic)
             @test Base.ispublic(SciMLBase, name)
         end
     end
+
+    @testset "Public abstract interface documentation" begin
+        interface_docs = join(
+            read(joinpath(root, file), String)
+                for (root, _, files) in walkdir(joinpath(@__DIR__, "..", "docs", "src", "interfaces"))
+                for file in files if endswith(file, ".md")
+        )
+        interface_doc_lines = strip.(split(interface_docs, '\n'))
+        abstract_public_names = filter(
+            names(SciMLBase, all = true, imported = false)
+        ) do name
+            Base.ispublic(SciMLBase, name) &&
+                isdefined(SciMLBase, name) &&
+                let value = getfield(SciMLBase, name)
+                value isa DataType && isabstracttype(value)
+            end
+        end
+
+        for name in abstract_public_names
+            @test Base.Docs.hasdoc(SciMLBase, name)
+            @test "SciMLBase.$name" in interface_doc_lines
+        end
+    end
 end


### PR DESCRIPTION
## What changed

Extend the public abstract-interface regression coverage with explicit generic usage rules for problems, algorithms, SciML functions, and solutions. Each representative abstract contract now has a generic test, and every Julia-public abstract SciMLBase type must have a docstring plus an exact binding in the rendered interface docs. The existing strict SciMLTesting QA configuration remains at compat 2.6, with no repo-specific public-doc QA override.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Verification

- GROUP=Core julia --startup-file=no --project=. -e using Pkg; Pkg.test()
  - Public interface declarations | 674 674
  - Remake | 4430 4430
  - Testing SciMLBase tests passed
- GROUP=QA julia --startup-file=no --project=. -e using Pkg; Pkg.test()
  - QA | 51 51
  - Testing SciMLBase tests passed
- timeout 3600 julia --startup-file=no --project=docs docs/make.jl
  - exit 0; 26 HTML pages rendered
  - 0 rendered pages containing No documentation found
- julia --startup-file=no --project=@runic -m Runic --check --diff test/public_interface.jl
  - passed
- typos docs/src/interfaces/Algorithms.md docs/src/interfaces/Problems.md docs/src/interfaces/SciMLFunctions.md docs/src/interfaces/Solutions.md test/public_interface.jl
  - passed
- git diff --check upstream/master...HEAD
  - passed

PR 1546 was inspected separately; its existing downstream import qualification fix is self-contained and its body reports targeted and QA tests passing. It is not changed by this PR.