### PR TITLE
Run runic on docstrings and markdown files

### DIFF
--- a/docs/src/interfaces/Differentiation.md
+++ b/docs/src/interfaces/Differentiation.md
@@ -12,14 +12,16 @@ High-level `solve` methods make the differentiable inputs explicit before
 dropping into the internal solve path. A representative shape is:
 
 ```julia
-function solve(prob::AbstractDEProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, kwargs...)
+function solve(
+        prob::AbstractDEProblem, args...; sensealg = nothing,
+        u0 = nothing, p = nothing, kwargs...
+    )
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
     end
-    solve_up(prob, sensealg, u0, p, args...; kwargs...)
+    return solve_up(prob, sensealg, u0, p, args...; kwargs...)
 end
 ```
 
@@ -30,18 +32,22 @@ differentiated. Sensitivity packages then overload the internal calls with rules
 of the following form:
 
 ```julia
-function ChainRulesCore.frule(::typeof(solve_up), prob,
+function ChainRulesCore.frule(
+        ::typeof(solve_up), prob,
         sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
         u0, p, args...;
-        kwargs...)
-    _solve_forward(prob, sensealg, u0, p, args...; kwargs...)
+        kwargs...
+    )
+    return _solve_forward(prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function ChainRulesCore.rrule(::typeof(solve_up), prob::SciMLBase.AbstractDEProblem,
+function ChainRulesCore.rrule(
+        ::typeof(solve_up), prob::SciMLBase.AbstractDEProblem,
         sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
         u0, p, args...;
-        kwargs...)
-    _solve_adjoint(prob, sensealg, u0, p, args...; kwargs...)
+        kwargs...
+    )
+    return _solve_adjoint(prob, sensealg, u0, p, args...; kwargs...)
 end
 ```
 

--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -266,7 +266,7 @@ using OrdinaryDiffEq
 using SciMLBase
 prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 function prob_func(prob, ctx)
-    remake(prob, u0 = rand(ctx.rng) * prob.u0)
+    return remake(prob, u0 = rand(ctx.rng) * prob.u0)
 end
 ensemble_prob = EnsembleProblem(prob, prob_func = prob_func)
 sim = solve(ensemble_prob, Tsit5(), EnsembleThreads(), trajectories = 10)
@@ -291,7 +291,7 @@ we can index an evenly spaced `range`:
 ```@example ensemble1_3
 initial_conditions = range(0, stop = 1, length = 100)
 function prob_func(prob, ctx)
-    remake(prob, u0 = initial_conditions[ctx.sim_id])
+    return remake(prob, u0 = initial_conditions[ctx.sim_id])
 end
 ```
 
@@ -307,6 +307,7 @@ drift component:
 function f(du, u, p, t)
     du[1] = p[1] * u[1] - p[2] * u[1] * u[2]
     du[2] = -3 * u[2] + u[1] * u[2]
+    return
 end
 ```
 
@@ -316,6 +317,7 @@ For our noise function, we will use multiplicative noise:
 function g(du, u, p, t)
     du[1] = p[3] * u[1]
     du[2] = p[4] * u[2]
+    return
 end
 ```
 
@@ -378,7 +380,7 @@ to discard the rest of the data.
 
 ```@example ensemble3
 function output_func(sol, ctx)
-    last(sol), false
+    return last(sol), false
 end
 ```
 
@@ -391,7 +393,7 @@ using SciMLBase
 prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
 
 function prob_func(prob, ctx)
-    remake(prob, u0 = rand(ctx.rng) * prob.u0)
+    return remake(prob, u0 = rand(ctx.rng) * prob.u0)
 end
 ```
 
@@ -405,15 +407,16 @@ function reduction(u, batch, I)
     u = append!(u, batch)
     relative_standard_error = sqrt(var(u) / last(I)) / abs(mean(u))
     finished = relative_standard_error < 0.5
-    u, finished
+    return u, finished
 end
 ```
 
 Then we can define and solve the problem:
 
 ```@example ensemble3
-prob2 = EnsembleProblem(prob, prob_func = prob_func, output_func = output_func,
-    reduction = reduction, u_init = Vector{Float64}())
+prob2 = EnsembleProblem(
+    prob; prob_func, output_func, reduction, u_init = Vector{Float64}()
+)
 sim = solve(prob2, Tsit5(), trajectories = 10000, batch_size = 20)
 ```
 
@@ -430,10 +433,9 @@ save the running summation of the endpoints:
 
 ```@example ensemble3
 function reduction(u, batch, I)
-    u + sum(batch), false
+    return u + sum(batch), false
 end
-prob2 = EnsembleProblem(prob, prob_func = prob_func, output_func = output_func,
-    reduction = reduction, u_init = 0.0)
+prob2 = EnsembleProblem(prob; prob_func, output_func, reduction, u_init = 0.0)
 sim2 = solve(prob2, Tsit5(), trajectories = 100, batch_size = 20)
 ```
 
@@ -452,11 +454,13 @@ function f(du, u, p, t)
     for i in 1:length(u)
         du[i] = 1.01 * u[i]
     end
+    return
 end
 function σ(du, u, p, t)
     for i in 1:length(u)
         du[i] = 0.87 * u[i]
     end
+    return
 end
 using StochasticDiffEq
 prob = SDEProblem(f, σ, ones(4, 2) / 2, (0.0, 1.0)) #prob_sde_2Dlinear
@@ -506,7 +510,7 @@ compute covariance matrices similarly:
 
 ```@example ensemble4
 timeseries_steps_meancov(sim) # Use the time steps, assume fixed dt
-timeseries_point_meancov(sim, 0:(1 // 2 ^ (3)):1, 0:(1 // 2 ^ (3)):1) # Use time points, interpolate
+timeseries_point_meancov(sim, 0:(1 // 2^3):1, 0:(1 // 2^3):1) # Use time points, interpolate
 ```
 
 For general analysis, we can build an `EnsembleSummary`.

--- a/docs/src/interfaces/Problems.md
+++ b/docs/src/interfaces/Problems.md
@@ -182,7 +182,8 @@ shows how to set the specialization default to `FullSpecialize`:
 ```julia
 using Preferences, UUIDs
 set_preferences!(
-    UUID("0bca4576-84f4-4d90-8ffe-ffa030f20462"), "SpecializationLevel" => "FullSpecialize")
+    UUID("0bca4576-84f4-4d90-8ffe-ffa030f20462"), "SpecializationLevel" => "FullSpecialize"
+)
 ```
 
 The default is `AutoSpecialize`.

--- a/ext/SciMLBaseForwardDiffExt.jl
+++ b/ext/SciMLBaseForwardDiffExt.jl
@@ -57,7 +57,7 @@ function promote_dual(
 end
 
 """
-    promote_dual(::Type{T},::Type{T2})
+    promote_dual(::Type{T}, ::Type{T2})
 
 Is like the number promotion system, but always prefers a dual number type above
 anything else. For higher order differentiation, it returns the most dualiest of

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -40,7 +40,8 @@ end
 
 """
 ```julia
-ContinuousCallback(condition, affect!, affect_neg!;
+ContinuousCallback(
+    condition, affect!, affect_neg!;
     initialize = INITIALIZE_DEFAULT,
     finalize = FINALIZE_DEFAULT,
     idxs = nothing,
@@ -48,11 +49,13 @@ ContinuousCallback(condition, affect!, affect_neg!;
     save_positions = (true, true),
     interp_points = 10,
     abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-    initializealg = nothing, maybe_discontinuity = true)
+    initializealg = nothing, maybe_discontinuity = true
+)
 ```
 
 ```julia
-ContinuousCallback(condition, affect!;
+ContinuousCallback(
+    condition, affect!;
     initialize = INITIALIZE_DEFAULT,
     finalize = FINALIZE_DEFAULT,
     idxs = nothing,
@@ -61,7 +64,8 @@ ContinuousCallback(condition, affect!;
     affect_neg! = affect!,
     interp_points = 10,
     abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-    initializealg = nothing, maybe_discontinuity = true)
+    initializealg = nothing, maybe_discontinuity = true
+)
 ```
 
 Contains a single callback whose `condition` is a continuous function. The callback is triggered when this function evaluates to 0.
@@ -243,7 +247,8 @@ end
 
 """
 ```julia
-VectorContinuousCallback(condition, affect!, len;
+VectorContinuousCallback(
+    condition, affect!, len;
     initialize = INITIALIZE_DEFAULT,
     finalize = FINALIZE_DEFAULT,
     idxs = nothing,
@@ -251,7 +256,8 @@ VectorContinuousCallback(condition, affect!, len;
     save_positions = (true, true),
     interp_points = 10,
     abstol = 10eps(), reltol = 0, repeat_nudge = 1 // 100,
-    initializealg = nothing, maybe_discontinuity = true)
+    initializealg = nothing, maybe_discontinuity = true
+)
 ```
 
 This is also a subtype of `AbstractContinuousCallback`. `CallbackSet` is not feasible when you have many callbacks,
@@ -354,11 +360,13 @@ end
 
 """
 ```julia
-DiscreteCallback(condition, affect!;
+DiscreteCallback(
+    condition, affect!;
     initialize = INITIALIZE_DEFAULT,
     finalize = FINALIZE_DEFAULT,
     save_positions = (true, true),
-    initializealg = nothing)
+    initializealg = nothing
+)
 ```
 
 # Arguments

--- a/src/despecialized_parameters.jl
+++ b/src/despecialized_parameters.jl
@@ -140,7 +140,8 @@ Base.@noinline _invoke_with_despecialized_parameters(f, args...; kwargs...) =
 """
     invoke_with_despecialized_parameters(f, args; kwargs...)
     invoke_with_despecialized_parameters(
-        f, args, params, ::Val{parameter_index}; kwargs...)
+        f, args, params, ::Val{parameter_index}; kwargs...
+    )
 
 Call `f(args...; kwargs...)` after replacing a [`DespecializedParameters`](@ref) argument
 with its wrapped object. The two-argument form locates the wrapper in `args`; the explicit

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -14,7 +14,7 @@ function step!(d::DEIntegrator)
 end
 
 """
-    resize!(integrator::DEIntegrator,k::Int)
+    resize!(integrator::DEIntegrator, k::Int)
 
 Resize the state dimension of an integrator to length `k`.
 
@@ -28,7 +28,7 @@ function Base.resize!(i::DEIntegrator, ii::Int)
 end
 
 """
-    deleteat!(integrator::DEIntegrator,idxs)
+    deleteat!(integrator::DEIntegrator, idxs)
 
 Delete state components from a dynamic-size integrator.
 
@@ -42,7 +42,7 @@ function Base.deleteat!(i::DEIntegrator, ii)
 end
 
 """
-    addat!(integrator::DEIntegrator,idxs,val)
+    addat!(integrator::DEIntegrator, idxs, val)
 
 Insert state components into a dynamic-size integrator.
 
@@ -149,7 +149,7 @@ function full_cache(i::DEIntegrator)
 end
 
 """
-    resize_non_user_cache!(integrator::DEIntegrator,k::Int)
+    resize_non_user_cache!(integrator::DEIntegrator, k::Int)
 
 Resizes the non-user facing caches to be compatible with a DE of size `k`. This includes resizing Jacobian caches.
 
@@ -164,7 +164,7 @@ function resize_non_user_cache!(i::DEIntegrator, ii::Int)
 end
 
 """
-    deleteat_non_user_cache!(integrator::DEIntegrator,idxs)
+    deleteat_non_user_cache!(integrator::DEIntegrator, idxs)
 
 [`deleteat!`](@ref)s the non-user facing caches at indices `idxs`. This includes resizing Jacobian caches.
 
@@ -179,7 +179,7 @@ function deleteat_non_user_cache!(i::DEIntegrator, idxs)
 end
 
 """
-    addat_non_user_cache!(i::DEIntegrator,idxs)
+    addat_non_user_cache!(i::DEIntegrator, idxs)
 
 [`addat!`](@ref)s the non-user facing caches at indices `idxs`. This includes resizing Jacobian caches.
 
@@ -290,8 +290,10 @@ function set_proposed_dt!(i::DEIntegrator, dt)
 end
 
 """
-    savevalues!(integrator::DEIntegrator,
-      force_save=false) -> Tuple{Bool, Bool}
+    savevalues!(
+            integrator::DEIntegrator,
+            force_save = false
+        ) -> Tuple{Bool, Bool}
 
 Try to save the state and time variables at the current time point, or the
 `saveat` point by using interpolation when appropriate. It returns a tuple that
@@ -303,9 +305,9 @@ The saving priority/order is as follows:
 
   - `save_on`
 
-      + `saveat`
-      + `force_save`
-      + `save_everystep`
+    + `saveat`
+    + `force_save`
+    + `save_everystep`
 """
 function savevalues!(i::DEIntegrator)
     error("savevalues!: method has not been implemented for the integrator")
@@ -509,7 +511,7 @@ function set_rng!(integrator::DEIntegrator, rng)
 end
 
 """
-    reinit!(integrator::DEIntegrator,args...; kwargs...)
+    reinit!(integrator::DEIntegrator, args...; kwargs...)
 
 The reinit function lets you restart the integration at a new value.
 
@@ -536,7 +538,7 @@ function reinit!(integrator::DEIntegrator, args...; kwargs...)
 end
 
 """
-    initialize_dae!(integrator::DEIntegrator,initializealg = integrator.initializealg)
+    initialize_dae!(integrator::DEIntegrator, initializealg = integrator.initializealg)
 
 Runs the DAE initialization to find a consistent state vector. The optional
 argument `initializealg` can be used to specify a different initialization
@@ -568,7 +570,10 @@ function auto_dt_reset!(integrator::DEIntegrator)
 end
 
 """
-    change_t_via_interpolation!(integrator::DEIntegrator,t,modify_save_endpoint=Val{false},reinitialize_alg=nothing)
+    change_t_via_interpolation!(
+        integrator::DEIntegrator, t,
+        modify_save_endpoint = Val{false}, reinitialize_alg = nothing
+    )
 
 Move the integrator to time `t` using the method's local interpolation.
 
@@ -597,8 +602,10 @@ for cache construction and are not a portable user interface.
 addsteps!(i::DEIntegrator, args...) = nothing
 
 """
-    reeval_internals_due_to_modification!(integrator::DEIntegrator, continuous_modification::Bool=true;
-                                          callback_initializealg = nothing)
+    reeval_internals_due_to_modification!(
+        integrator::DEIntegrator, continuous_modification::Bool = true;
+        callback_initializealg = nothing
+    )
 
 Update an integrator after callback-driven mutation.
 

--- a/src/performance_warnings.jl
+++ b/src/performance_warnings.jl
@@ -13,7 +13,7 @@ Consider using tuples instead.
 """
 
 """
-    warn_paramtype(p, warn_performance=PERFORMANCE_WARNINGS)
+    warn_paramtype(p, warn_performance = PERFORMANCE_WARNINGS)
 
 Inspect the type of `p` and emit a warning if it could hurt
 performance when used to hold problem parameters.
@@ -24,7 +24,8 @@ To turn it off globally within the active project you can execute the following 
 ```julia
 using Preferences, UUIDs
 set_preferences!(
-    UUID("1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"), "PerformanceWarnings" => false)
+    UUID("1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"), "PerformanceWarnings" => false
+)
 ```
 """
 function warn_paramtype(p, warn_performance = PERFORMANCE_WARNINGS)

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -326,7 +326,7 @@ struct DynamicalDDEProblem{iip} <: AbstractDynamicalDDEProblem end
 # u' = f1(v,h)
 # v' = f2(t,u,h)
 """
-    DynamicalDDEProblem(f::DynamicalDDEFunction,v0,u0,tspan,p=NullParameters(),callback=CallbackSet())
+    DynamicalDDEProblem(f::DynamicalDDEFunction, v0, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define a dynamical DDE problem from a [`DynamicalDDEFunction`](@ref).
 """
@@ -355,7 +355,7 @@ function DynamicalDDEProblem(f1, f2, args...; kwargs...)
 end
 
 """
-    DynamicalDDEProblem{isinplace}(f1,f2,v0,u0,h,tspan,p=NullParameters(),callback=CallbackSet())
+    DynamicalDDEProblem{isinplace}(f1, f2, v0, u0, h, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define a dynamical DDE problem from the two functions `f1` and `f2`.
 
@@ -393,7 +393,7 @@ function SecondOrderDDEProblem(f, args...; kwargs...)
 end
 
 """
-    SecondOrderDDEProblem{isinplace}(f,du0,u0,h,tspan,p=NullParameters(),callback=CallbackSet())
+    SecondOrderDDEProblem{isinplace}(f, du0, u0, h, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define a second order DDE problem with the specified function.
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -146,7 +146,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DiscreteProblem}
 end
 
 """
-    DiscreteProblem{isinplace}(f,u0,tspan,p=NullParameters(),callback=nothing)
+    DiscreteProblem{isinplace}(f, u0, tspan, p = NullParameters(), callback = nothing)
 
 Defines a discrete problem with the specified functions.
 """

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -113,7 +113,7 @@ struct ImplicitDiscreteProblem{uType, tType, isinplace, P, F, K} <:
 end
 
 """
-    ImplicitDiscreteProblem{isinplace}(f,u0,tspan,p=NullParameters(),callback=nothing)
+    ImplicitDiscreteProblem{isinplace}(f, u0, tspan, p = NullParameters(), callback = nothing)
 
 Defines a discrete problem with the specified functions.
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -148,7 +148,7 @@ mutable struct ODEProblem{uType, tType, isinplace, P, F, K, PT} <:
     end
 
     """
-        ODEProblem{isinplace}(f,u0,tspan,p=NullParameters(),callback=CallbackSet())
+        ODEProblem{isinplace}(f, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
     Define an ODE problem with the specified function.
     `isinplace` optionally sets whether the function is inplace or not.
@@ -223,7 +223,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: ODEProblem}
 end
 
 """
-    ODEProblem(f::ODEFunction,u0,tspan,p=NullParameters(),callback=CallbackSet())
+    ODEProblem(f::ODEFunction, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define an ODE problem from an [`ODEFunction`](@ref).
 """
@@ -325,7 +325,7 @@ every solve call.
 struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
 
 """
-    DynamicalODEProblem(f::DynamicalODEFunction,v0,u0,tspan,p=NullParameters(),callback=CallbackSet())
+    DynamicalODEProblem(f::DynamicalODEFunction, v0, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define a dynamical ODE function from a [`DynamicalODEFunction`](@ref).
 """
@@ -715,7 +715,7 @@ struct ImmutableODEProblem{uType, tType, isinplace, P, F, K, PT} <:
     end
 
     """
-        ImmutableODEProblem{isinplace}(f,u0,tspan,p=NullParameters(),callback=CallbackSet())
+        ImmutableODEProblem{isinplace}(f, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
     Define an ODE problem with the specified function.
     `isinplace` optionally sets whether the function is inplace or not.
@@ -744,7 +744,7 @@ struct ImmutableODEProblem{uType, tType, isinplace, P, F, K, PT} <:
 end
 
 """
-    ImmutableODEProblem(f::ODEFunction,u0,tspan,p=NullParameters(),callback=CallbackSet())
+    ImmutableODEProblem(f::ODEFunction, u0, tspan, p = NullParameters(), callback = CallbackSet())
 
 Define an ODE problem from an [`ODEFunction`](@ref).
 """

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -72,8 +72,10 @@ function isrecompile(prob::ODEProblem{iip}) where {iip}
 end
 
 """
-    remake(prob::AbstractSciMLProblem; u0 = missing, p = missing,
-        interpret_symbolicmap = true, use_defaults = false, kwargs...)
+    remake(
+        prob::AbstractSciMLProblem; u0 = missing, p = missing,
+        interpret_symbolicmap = true, use_defaults = false, kwargs...
+    )
 
 Construct a problem of the same family as `prob`, replacing the supplied fields and
 preserving all other problem data. Extra keyword arguments are forwarded to the
@@ -357,8 +359,10 @@ function remake(
 end
 
 """
-    remake(prob::ODEProblem; f = missing, u0 = missing, tspan = missing,
-           p = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::ODEProblem; f = missing, u0 = missing, tspan = missing,
+        p = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `ODEProblem`.
 If `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
@@ -517,7 +521,8 @@ data accepted by the target SciML function constructor. It must not mutate `u0`,
 struct MyInitializationSystem end
 
 function SciMLBase.remake_initialization_data(
-        ::MyInitializationSystem, scimlfn, u0, t0, p, newu0, newp, ctx)
+        ::MyInitializationSystem, scimlfn, u0, t0, p, newu0, newp, ctx
+    )
     return (; previous = scimlfn.initialization_data, newu0, newp)
 end
 ```
@@ -534,8 +539,10 @@ function remake_initialization_data(sys, scimlfn, u0, t0, p, newu0, newp, ctx::R
 end
 
 """
-    remake(prob::BVProblem; f = missing, u0 = missing, tspan = missing,
-           p = missing, kwargs = missing, problem_type = missing, _kwargs...)
+    remake(
+        prob::BVProblem; f = missing, u0 = missing, tspan = missing,
+        p = missing, kwargs = missing, problem_type = missing, _kwargs...
+    )
 
 Remake the given `BVProblem`.
 """
@@ -603,9 +610,11 @@ function remake(
 end
 
 """
-    remake(prob::SDEProblem; f = missing, g = missing, u0 = missing, tspan = missing,
-           p = missing, noise = missing, noise_rate_prototype = missing,
-           seed = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::SDEProblem; f = missing, g = missing, u0 = missing, tspan = missing,
+        p = missing, noise = missing, noise_rate_prototype = missing,
+        seed = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `SDEProblem`.
 """
@@ -853,8 +862,10 @@ function remake(
 end
 
 """
-    remake(prob::DAEProblem; f = missing, du0 = missing, u0 = missing, tspan = missing,
-           p = missing, differential_vars = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::DAEProblem; f = missing, du0 = missing, u0 = missing, tspan = missing,
+        p = missing, differential_vars = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `DAEProblem`.
 If `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
@@ -916,9 +927,11 @@ function remake(
 end
 
 """
-    remake(prob::OptimizationProblem; f = missing, u0 = missing, p = missing,
+    remake(
+        prob::OptimizationProblem; f = missing, u0 = missing, p = missing,
         lb = missing, ub = missing, int = missing, lcons = missing, ucons = missing,
-        sense = missing, kwargs = missing, _kwargs...)
+        sense = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `OptimizationProblem`.
 If `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
@@ -981,8 +994,10 @@ function remake(
 end
 
 """
-    remake(prob::NonlinearProblem; f = missing, u0 = missing, p = missing,
-        problem_type = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::NonlinearProblem; f = missing, u0 = missing, p = missing,
+        problem_type = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `NonlinearProblem`.
 If `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
@@ -1102,8 +1117,10 @@ function remake(
 end
 
 """
-    remake(prob::NonlinearLeastSquaresProblem; f = missing, u0 = missing, p = missing,
-        kwargs = missing, _kwargs...)
+    remake(
+        prob::NonlinearLeastSquaresProblem; f = missing, u0 = missing, p = missing,
+        kwargs = missing, _kwargs...
+    )
 
 Remake the given `NonlinearLeastSquaresProblem`.
 """
@@ -1210,8 +1227,10 @@ function scc_update_subproblems(probs::Tuple, newu0, newp, ::Val{P}) where {P}
 end
 
 """
-    remake(prob::SCCNonlinearProblem; u0 = missing, p = missing, probs = missing,
-        parameters_alias = prob.parameters_alias, sys = missing, explicitfuns! = missing)
+    remake(
+        prob::SCCNonlinearProblem; u0 = missing, p = missing, probs = missing,
+        parameters_alias = prob.parameters_alias, sys = missing, explicitfuns! = missing
+    )
 
 Remake the given `SCCNonlinearProblem`. `u0` is the state vector for the entire problem,
 which will be chunked appropriately and used to `remake` the individual subproblems. `p`
@@ -1613,8 +1632,10 @@ function _updated_u0_p_symmap(prob, u0, ::Val{true}, p, ::Val{true}, t0)
 end
 
 """
-    updated_u0_p(prob, u0, p, t0 = nothing; interpret_symbolicmap = true,
-        use_defaults = false)
+    updated_u0_p(
+        prob, u0, p, t0 = nothing; interpret_symbolicmap = true,
+        use_defaults = false
+    )
 
 Resolve replacement initial conditions and parameters for a SciML problem.
 
@@ -1688,7 +1709,8 @@ unchanged. `root_indp` is supplied for dispatch and is obtained by
 # Example
 ```julia
 function SciMLBase.late_binding_update_u0_p(
-        prob::MyProblem, root::MySystem, u0, p, t0, newu0, newp, ctx)
+        prob::MyProblem, root::MySystem, u0, p, t0, newu0, newp, ctx
+    )
     return fill_missing_defaults(root, newu0, newp)
 end
 ```

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -2043,8 +2043,8 @@ struct HomotopyNonlinearFunction{iip, specialize, F, P, Q, D} <:
 
     ```julia
     function polynomialize(u, p)
-      x, y = u
-      return [sin(x^2), log(x + y)]
+        x, y = u
+        return [sin(x^2), log(x + y)]
     end
     ```
 
@@ -2066,11 +2066,11 @@ struct HomotopyNonlinearFunction{iip, specialize, F, P, Q, D} <:
 
     ```julia
     function unpolynomialize(u, p)
-      a, b = u
-      return [
-        [sqrt(asin(a)), exp(b) - sqrt(asin(a))],
-        [-sqrt(asin(a)), exp(b) + sqrt(asin(a))],
-      ]
+        a, b = u
+        return [
+            [sqrt(asin(a)), exp(b) - sqrt(asin(a))],
+            [-sqrt(asin(a)), exp(b) + sqrt(asin(a))],
+        ]
     end
     ```
 

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -31,8 +31,10 @@ struct LinearSolution{T, N, uType, R, A, C, S} <: AbstractLinearSolution{T, N}
 end
 
 """
-    build_linear_solution(alg, u, resid, cache; retcode = ReturnCode.Default, iters = 0,
-        stats = nothing) -> LinearSolution
+    build_linear_solution(
+            alg, u, resid, cache; retcode = ReturnCode.Default, iters = 0,
+            stats = nothing
+        ) -> LinearSolution
 
 Construct the `LinearSolution` returned by a solver for a linear system.
 
@@ -62,11 +64,13 @@ Construct the `LinearSolution` returned by a solver for a linear system.
 
 # Example
 
-```julia
+```julia-repl
 julia> alg = :direct;
 
-julia> build_linear_solution(alg, [2.0], nothing, nothing;
-                              retcode = ReturnCode.Success)
+julia> build_linear_solution(
+           alg, [2.0], nothing, nothing;
+           retcode = ReturnCode.Success
+       )
 retcode: Success
 ```
 """
@@ -119,8 +123,10 @@ struct EigenvalueSolution{T, N, U, V, P, A, R, S} <: AbstractEigenvalueSolution{
 end
 
 """
-    build_eigenvalue_solution(prob, alg, values, vectors; retcode = ReturnCode.Success,
-        resid = nothing, stats = nothing) -> EigenvalueSolution
+    build_eigenvalue_solution(
+            prob, alg, values, vectors; retcode = ReturnCode.Success,
+            resid = nothing, stats = nothing
+        ) -> EigenvalueSolution
 
 Construct the `EigenvalueSolution` returned by a solver for an eigenvalue problem.
 
@@ -149,7 +155,7 @@ Construct the `EigenvalueSolution` returned by a solver for an eigenvalue proble
 
 # Example
 
-```julia
+```julia-repl
 julia> prob = EigenvalueProblem([2.0 0.0; 0.0 3.0]);
 
 julia> build_eigenvalue_solution(prob, :dense, [2.0, 3.0], [1.0 0.0; 0.0 1.0]).retcode

--- a/src/solutions/save_idxs.jl
+++ b/src/solutions/save_idxs.jl
@@ -569,7 +569,7 @@ function _append_state_indices!(translated, indp, sym)
 end
 
 """
-    _invalid_save_idxs_symbol_error(indp, var; allow_timeseries_params=true)
+    _invalid_save_idxs_symbol_error(indp, var; allow_timeseries_params = true)
 
 Build the `ArgumentError` for a symbolic entry that cannot be used in
 `save_idxs`. Observed quantities get a dedicated message (DifferentialEquations.jl#1036);

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -222,7 +222,8 @@ struct MySymbolicProblem
 end
 
 function SciMLBase.get_updated_symbolic_problem(
-        ::MySolveSystem, prob::MySymbolicProblem; u0 = prob.u0, p = prob.p, kwargs...)
+        ::MySolveSystem, prob::MySymbolicProblem; u0 = prob.u0, p = prob.p, kwargs...
+    )
     return MySymbolicProblem(u0, p)
 end
 ```

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -467,16 +467,16 @@ provide every referenced local. Do not extend `@def` or use it to define user-fa
 
 ```julia
 module ExampleSolver
-using SciMLBase: @def
+    using SciMLBase: @def
 
-@def affine_preamble begin
-    shifted = x + offset
-end
+    @def affine_preamble begin
+        shifted = x + offset
+    end
 
-function evaluate(x, offset)
-    @affine_preamble
-    return shifted
-end
+    function evaluate(x, offset)
+        @affine_preamble
+        return shifted
+    end
 end
 
 ExampleSolver.evaluate(2, 3) # 5


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Ran Runic.jl's CLI app with the `--extensions=jl,md --docstrings` options. Did have to fix-up the `julia` language tag to `julia-repl` (which Runic seemed to handle nicely) and temporarily switch `@example`'s to plain `julia` blocks (which have been reverted before committing).