### PR TITLE
Add explicit ODE function respecialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.49.2"
+version = "3.50.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/SciMLFunctions.md
+++ b/docs/src/interfaces/SciMLFunctions.md
@@ -102,6 +102,16 @@ which designates how the compiler should specialize on the model function `f`. F
 more details on specialization choices, see the [SciMLProblems](@ref scimlproblems)
 page.
 
+Use `SciMLBase.respecialize(f, specialization)` to rebuild an `ODEFunction` or
+`ODEInputFunction` at an automatic specialization level while retaining its field values.
+For `AutoSpecialize`, `AutoDespecialize`, and `AutoRespecialize`, this also widens
+initialization metadata so model-specific initialization types do not defeat compilation
+reuse.
+
+```@docs
+SciMLBase.respecialize
+```
+
 ### Specifying Jacobian Types
 
 The `jac` field of an inplace style `SciMLFunction` has the signature `jac(J,u,p,t)`,

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2191,7 +2191,7 @@ export ODEAliasSpecifier, LinearAliasSpecifier
 
 # Core functions
 @public build_solution, build_linear_solution, build_eigenvalue_solution, numargs,
-    unwrap_parameters, invoke_with_despecialized_parameters
+    unwrap_parameters, invoke_with_despecialized_parameters, respecialize
 
 # Solver problem-concretization extension API
 @public get_concrete_p, get_concrete_u0, isconcreteu0, promote_u0,

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -241,6 +241,66 @@ SciMLBase.isinplace(widened)
 end
 
 """
+    respecialize(f, specialize)
+
+Reconstruct an [`ODEFunction`](@ref) or [`ODEInputFunction`](@ref) at the requested
+automatic specialization level while preserving its field values and in-place convention.
+
+`AutoSpecialize`, `AutoDespecialize`, and `AutoRespecialize` widen the initialization
+metadata type (and, for `ODEFunction`, the nonlinear-step metadata type). This matches
+the symbolic-system layout for the first two policies and prevents model-specific
+metadata from defeating the compilation reuse promised by `AutoRespecialize`.
+The direct function constructors retain concrete metadata types because widening can
+reduce inference through code that reads or remakes those fields; `respecialize` makes
+that tradeoff explicit.
+
+For an `ODEInputFunction`, a custom initialization payload that is not
+`OverrideInitData` is widened to `Any`, since the payload type is otherwise unbounded.
+
+# Example
+
+```julia
+f = ODEFunction{false, SciMLBase.FullSpecialize}((u, p, t) -> u)
+f_auto = SciMLBase.respecialize(f, SciMLBase.AutoSpecialize)
+SciMLBase.specialization(f_auto) === SciMLBase.AutoSpecialize
+```
+"""
+@generated function respecialize(
+        f::F, ::Type{S}
+    ) where {
+        F <: Union{ODEFunction, ODEInputFunction},
+        S <: Union{AutoSpecialize, AutoDespecialize, AutoRespecialize},
+    }
+    wrapper = F.name.wrapper
+    field_names = fieldnames(F)
+    length(F.parameters) == length(field_names) + 2 ||
+        error("SciMLFunction type parameters do not match its fields")
+
+    parameter_expressions = Any[F.parameters[1], S]
+    field_expressions = Any[]
+    for (i, field_name) in enumerate(field_names)
+        field_expression = :(getfield(f, $i))
+        push!(field_expressions, field_expression)
+        if field_name === :initialization_data
+            metadata_type = if F <: ODEFunction ||
+                    fieldtype(F, i) <: Union{Nothing, OverrideInitData}
+                Union{Nothing, OverrideInitData}
+            else
+                Any
+            end
+            push!(parameter_expressions, metadata_type)
+        elseif field_name === :nlstep_data
+            push!(parameter_expressions, Union{Nothing, ODENLStepData})
+        else
+            push!(parameter_expressions, Expr(:call, :typeof, field_expression))
+        end
+    end
+
+    new_type = Expr(:curly, wrapper, parameter_expressions...)
+    return Expr(:call, new_type, field_expressions...)
+end
+
+"""
     $(TYPEDSIGNATURES)
 
 A utility function which merges two `NamedTuple`s `a` and `b`, assuming that the

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -3213,22 +3213,6 @@ function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
             f.Wfact_t, f.W_prototype, f.paramjac, f.vjp_p,
             f.observed, f.colorvec, f.sys, f.initialization_data, f.nlstep_data
         )
-    elseif specialization(f) === AutoSpecialize
-        ODEFunction{
-            isinplace(f), specialization(f), typeof(newf), typeof(f.mass_matrix),
-            typeof(f.analytic), typeof(f.tgrad),
-            typeof(f.jac), typeof(f.jvp), typeof(f.vjp), typeof(f.jac_prototype),
-            typeof(f.sparsity), typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.W_prototype),
-            typeof(f.paramjac),
-            typeof(f.vjp_p),
-            typeof(f.observed), typeof(f.colorvec),
-            typeof(f.sys), typeof(f.initialization_data), typeof(f.nlstep_data),
-        }(
-            newf, f.mass_matrix, f.analytic, f.tgrad, f.jac,
-            f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact,
-            f.Wfact_t, f.W_prototype, f.paramjac, f.vjp_p,
-            f.observed, f.colorvec, f.sys, f.initialization_data, f.nlstep_data
-        )
     else
         ODEFunction{
             isinplace(f), specialization(f), typeof(newf), typeof(f.mass_matrix),
@@ -3238,7 +3222,8 @@ function unwrapped_f(f::ODEFunction, newf = unwrapped_f(f.f))
             typeof(f.paramjac),
             typeof(f.vjp_p),
             typeof(f.observed), typeof(f.colorvec),
-            typeof(f.sys), typeof(f.initialization_data), typeof(f.nlstep_data),
+            typeof(f.sys), fieldtype(typeof(f), :initialization_data),
+            fieldtype(typeof(f), :nlstep_data),
         }(
             newf, f.mass_matrix, f.analytic, f.tgrad, f.jac,
             f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact,

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -24,6 +24,13 @@ f = Foo{1}()
 (this::Foo{T})(args...) where {T} = 1
 @test SciMLBase.isinplace(Foo{Int}(), 4)
 
+struct RespecializePreparedRHS
+    stage::Int
+end
+(f::RespecializePreparedRHS)(u, p, t) = u
+SciMLBase.prepare_function(f::RespecializePreparedRHS) =
+    RespecializePreparedRHS(f.stage + 1)
+
 @testset "isinplace for FunctionWrappersWrapper" begin
     using FunctionWrappersWrappers
 
@@ -74,6 +81,98 @@ end
     for fname in fieldnames(typeof(f))
         @test getfield(f, fname) === getfield(widened, fname)
     end
+end
+
+@testset "respecialize metadata layout" begin
+    ode_rhs = (u, p, t) -> u
+    input_rhs = (x, input, p, t) -> x
+    initprob = NonlinearProblem((u, p) -> u, [0.0])
+    initdata = SciMLBase.OverrideInitData(initprob, nothing, identity, nothing)
+    nlstep_data = SciMLBase.ODENLStepData(
+        NonlinearProblem((z, p) -> z, [1.0]), identity,
+        (gamma1, gamma2, c) -> nothing, identity, identity, identity
+    )
+    initdata_type = Union{Nothing, SciMLBase.OverrideInitData}
+    nlstep_data_type = Union{Nothing, SciMLBase.ODENLStepData}
+
+    plain = ODEFunction{false, SciMLBase.FullSpecialize}(ode_rhs)
+    with_metadata = ODEFunction{false, SciMLBase.FullSpecialize}(
+        ode_rhs; initialization_data = initdata, nlstep_data
+    )
+    plain_input = ODEInputFunction{false, SciMLBase.FullSpecialize}(input_rhs)
+    input_with_metadata = ODEInputFunction{false, SciMLBase.FullSpecialize}(
+        input_rhs; initialization_data = initdata
+    )
+
+    for specialize in (
+            SciMLBase.AutoSpecialize,
+            SciMLBase.AutoDespecialize,
+            SciMLBase.AutoRespecialize,
+        )
+        respecialized = SciMLBase.respecialize(with_metadata, specialize)
+        plain_respecialized = SciMLBase.respecialize(plain, specialize)
+
+        @test SciMLBase.specialization(respecialized) === specialize
+        @test fieldtype(typeof(respecialized), :initialization_data) === initdata_type
+        @test fieldtype(typeof(respecialized), :nlstep_data) === nlstep_data_type
+        @test typeof(respecialized) === typeof(plain_respecialized)
+        @test respecialized.initialization_data === initdata
+        @test respecialized.nlstep_data === nlstep_data
+        for field in fieldnames(typeof(with_metadata))
+            @test getfield(respecialized, field) === getfield(with_metadata, field)
+        end
+
+        unwrapped = SciMLBase.unwrapped_f(respecialized)
+        @test fieldtype(typeof(unwrapped), :initialization_data) === initdata_type
+        @test fieldtype(typeof(unwrapped), :nlstep_data) === nlstep_data_type
+        @test typeof(unwrapped) === typeof(respecialized)
+
+        remade = SciMLBase.remake(respecialized)
+        @test fieldtype(typeof(remade), :initialization_data) === initdata_type
+        @test fieldtype(typeof(remade), :nlstep_data) === nlstep_data_type
+        @test typeof(remade) === typeof(respecialized)
+
+        respecialized_input = SciMLBase.respecialize(input_with_metadata, specialize)
+        plain_respecialized_input = SciMLBase.respecialize(plain_input, specialize)
+        @test SciMLBase.specialization(respecialized_input) === specialize
+        @test fieldtype(typeof(respecialized_input), :initialization_data) === initdata_type
+        @test typeof(respecialized_input) === typeof(plain_respecialized_input)
+        @test respecialized_input.initialization_data === initdata
+        for field in fieldnames(typeof(input_with_metadata))
+            @test getfield(respecialized_input, field) === getfield(input_with_metadata, field)
+        end
+    end
+
+    auto = @inferred SciMLBase.respecialize(
+        ODEFunction{false, SciMLBase.FullSpecialize}(
+            ode_rhs; initialization_data = initdata, nlstep_data
+        ), SciMLBase.AutoSpecialize
+    )
+    @test fieldtype(typeof(auto), :initialization_data) === initdata_type
+    @test fieldtype(typeof(auto), :nlstep_data) === nlstep_data_type
+    @test @inferred(SciMLBase.unwrapped_f(auto)) isa typeof(auto)
+
+    direct_auto = ODEFunction{false, SciMLBase.AutoSpecialize}(
+        ode_rhs; initialization_data = initdata, nlstep_data
+    )
+    @test fieldtype(typeof(direct_auto), :initialization_data) === typeof(initdata)
+    @test fieldtype(typeof(direct_auto), :nlstep_data) === typeof(nlstep_data)
+    @test typeof(SciMLBase.unwrapped_f(direct_auto)) === typeof(direct_auto)
+
+    prepared = ODEFunction{false, SciMLBase.FullSpecialize}(
+        RespecializePreparedRHS(0)
+    )
+    @test prepared.f.stage == 1
+    prepared_auto = SciMLBase.respecialize(prepared, SciMLBase.AutoSpecialize)
+    @test prepared_auto.f === prepared.f
+    @test prepared_auto.f.stage == 1
+
+    custom_input = ODEInputFunction{false, SciMLBase.FullSpecialize}(
+        input_rhs; initialization_data = :custom
+    )
+    custom_auto = SciMLBase.respecialize(custom_input, SciMLBase.AutoSpecialize)
+    @test fieldtype(typeof(custom_auto), :initialization_data) === Any
+    @test custom_auto.initialization_data === :custom
 end
 
 @testset "isinplace accepts an out-of-place version with different numbers of parameters " begin

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -600,6 +600,7 @@ if isdefined(Base, :ispublic)
                 :LateBindingUpdateU0PContext, :detect_cycles,
                 :get_updated_symbolic_problem, :SymbolicLinearInterface, :get_new_A_b,
                 :widen_bounded_type_params, :prepare_initial_state, :prepare_function,
+                :respecialize,
                 :AbstractDEOptions, :ODENLStepData, :JacobianWrapper,
             )
             @test Base.ispublic(SciMLBase, name)


### PR DESCRIPTION
## Summary

- add the public, unexported `SciMLBase.respecialize` API for converting `ODEFunction` and `ODEInputFunction` values to `AutoSpecialize`, `AutoDespecialize`, or `AutoRespecialize`
- widen initialization and nonlinear-step metadata only during explicit respecialization, while preserving every stored field and avoiding a second `prepare_function` pass
- preserve widened metadata layouts through `unwrapped_f`, including custom `ODEInputFunction` metadata
- document the API, test its inference and layout behavior, and bump the minor version to 3.50.0

## Rationale

The symbolic construction path already widens bounded metadata so separately generated models can share a function type, while direct `AutoSpecialize` construction keeps concrete metadata. Changing all direct constructors would repeat the inference regression that caused #1242 to revert the earlier blanket widening behavior.

This PR therefore makes the tradeoff explicit. Callers that need compilation reuse can use `SciMLBase.respecialize(f, SciMLBase.AutoSpecialize)` instead of manually reconstructing type parameters. The same layout rule applies to `AutoDespecialize` and `AutoRespecialize`, where model-specific metadata would likewise defeat reuse.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=. -e 'using Runic; exit(Runic.main(["--check", "--diff", "."]))'`

Closes #1551.
