### PR TITLE
Complete DynamicalODEProblem and SecondOrderODEProblem remake

### DIFF
--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -333,11 +333,15 @@ function DynamicalODEProblem(
         f::DynamicalODEFunction, v0, u0, tspan, p = NullParameters();
         kwargs...
     )
-    return ODEProblem(f, ArrayPartition(v0, u0), tspan, p, DynamicalODEProblem{iip}(); kwargs...)
+    iip = isinplace(f)
+    return ODEProblem(
+        f, ArrayPartition(v0, u0), tspan, p, DynamicalODEProblem{iip}(); kwargs...
+    )
 end
 function DynamicalODEProblem(f1, f2, v0, u0, tspan, p = NullParameters(); kwargs...)
-    return ODEProblem(DynamicalODEFunction(f1, f2), ArrayPartition(v0, u0), tspan, p,
-    DynamicalODEProblem{iip}(); kwargs...)
+    return DynamicalODEProblem(
+        DynamicalODEFunction(f1, f2), v0, u0, tspan, p; kwargs...
+    )
 end
 
 function DynamicalODEProblem{iip}(
@@ -427,9 +431,10 @@ function SecondOrderODEProblem(
         f::DynamicalODEFunction, du0, u0, tspan,
         p = NullParameters(); kwargs...
     )
-    iip = isinplace(f.f1, 5)
+    iip = isinplace(f)
     _u0 = ArrayPartition((du0, u0))
-    if f.f2.f === nothing
+    f2 = f.f2 isa ODEFunction ? unwrapped_f(f.f2.f) : unwrapped_f(f.f2)
+    if f2 === nothing
         if iip
             f2 = function (du, v, u, p, t)
                 return du .= v
@@ -439,28 +444,13 @@ function SecondOrderODEProblem(
                 return v
             end
         end
-        return ODEProblem(
-            DynamicalODEFunction{iip}(
-                f.f1, f2; mass_matrix = f.mass_matrix,
-                analytic = f.analytic
-            ),
-            _u0,
-            tspan,
-            p,
-            SecondOrderODEProblem{iip}(); kwargs...
-        )
+        f = remake(f; f2)
     else
-        return ODEProblem(
-            DynamicalODEFunction{iip}(
-                f.f1, f.f2; mass_matrix = f.mass_matrix,
-                analytic = f.analytic
-            ),
-            _u0,
-            tspan,
-            p,
-            SecondOrderODEProblem{iip}(); kwargs...
-        )
+        f = remake(f)
     end
+    return ODEProblem(
+        f, _u0, tspan, p, SecondOrderODEProblem{iip}(); kwargs...
+    )
 end
 
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -330,21 +330,21 @@ struct DynamicalODEProblem{iip} <: AbstractDynamicalODEProblem end
 Define a dynamical ODE function from a [`DynamicalODEFunction`](@ref).
 """
 function DynamicalODEProblem(
-        f::DynamicalODEFunction, du0, u0, tspan, p = NullParameters();
+        f::DynamicalODEFunction, v0, u0, tspan, p = NullParameters();
         kwargs...
     )
-    return ODEProblem(f, ArrayPartition(du0, u0), tspan, p; kwargs...)
+    return ODEProblem(f, ArrayPartition(v0, u0), tspan, p; kwargs...)
 end
-function DynamicalODEProblem(f1, f2, du0, u0, tspan, p = NullParameters(); kwargs...)
-    return ODEProblem(DynamicalODEFunction(f1, f2), ArrayPartition(du0, u0), tspan, p; kwargs...)
+function DynamicalODEProblem(f1, f2, v0, u0, tspan, p = NullParameters(); kwargs...)
+    return ODEProblem(DynamicalODEFunction(f1, f2), ArrayPartition(v0, u0), tspan, p; kwargs...)
 end
 
 function DynamicalODEProblem{iip}(
-        f1, f2, du0, u0, tspan, p = NullParameters();
+        f1, f2, v0, u0, tspan, p = NullParameters();
         kwargs...
     ) where {iip}
     return ODEProblem(
-        DynamicalODEFunction{iip}(f1, f2), ArrayPartition(du0, u0), tspan, p,
+        DynamicalODEFunction{iip}(f1, f2), ArrayPartition(v0, u0), tspan, p,
         DynamicalODEProblem{iip}(); kwargs...
     )
 end

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -333,10 +333,11 @@ function DynamicalODEProblem(
         f::DynamicalODEFunction, v0, u0, tspan, p = NullParameters();
         kwargs...
     )
-    return ODEProblem(f, ArrayPartition(v0, u0), tspan, p; kwargs...)
+    return ODEProblem(f, ArrayPartition(v0, u0), tspan, p, DynamicalODEProblem{iip}(); kwargs...)
 end
 function DynamicalODEProblem(f1, f2, v0, u0, tspan, p = NullParameters(); kwargs...)
-    return ODEProblem(DynamicalODEFunction(f1, f2), ArrayPartition(v0, u0), tspan, p; kwargs...)
+    return ODEProblem(DynamicalODEFunction(f1, f2), ArrayPartition(v0, u0), tspan, p,
+    DynamicalODEProblem{iip}(); kwargs...)
 end
 
 function DynamicalODEProblem{iip}(

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -334,8 +334,15 @@ function DynamicalODEProblem(
         kwargs...
     )
     iip = isinplace(f)
+    _u0 = ArrayPartition(v0, u0)
+    _tspan = tspan
+    if specialization(f) === FunctionWrapperSpecialize
+        _u0 = prepare_initial_state(_u0)
+        _tspan = promote_tspan(tspan)
+        f = _functionwrapper_specialize_dynamical(f, _u0, p, _tspan[1])
+    end
     return ODEProblem(
-        f, ArrayPartition(v0, u0), tspan, p, DynamicalODEProblem{iip}(); kwargs...
+        f, _u0, _tspan, p, DynamicalODEProblem{iip}(); kwargs...
     )
 end
 function DynamicalODEProblem(f1, f2, v0, u0, tspan, p = NullParameters(); kwargs...)
@@ -433,8 +440,7 @@ function SecondOrderODEProblem(
     )
     iip = isinplace(f)
     _u0 = ArrayPartition((du0, u0))
-    f2 = f.f2 isa ODEFunction ? unwrapped_f(f.f2.f) : unwrapped_f(f.f2)
-    if f2 === nothing
+    if _is_absent_dynamical_component(f.f2)
         if iip
             f2 = function (du, v, u, p, t)
                 return du .= v
@@ -444,12 +450,22 @@ function SecondOrderODEProblem(
                 return v
             end
         end
-        f = remake(f; f2)
-    else
+        f = if specialization(f) === FunctionWrapperSpecialize
+            _rebuild_dynamical_function(f, f.f1, f2, FunctionWrapperSpecialize)
+        else
+            remake(f; f2)
+        end
+    elseif specialization(f) !== FunctionWrapperSpecialize
         f = remake(f)
     end
+    _tspan = tspan
+    if specialization(f) === FunctionWrapperSpecialize
+        _u0 = prepare_initial_state(_u0)
+        _tspan = promote_tspan(tspan)
+        f = _functionwrapper_specialize_dynamical(f, _u0, p, _tspan[1])
+    end
     return ODEProblem(
-        f, _u0, tspan, p, SecondOrderODEProblem{iip}(); kwargs...
+        f, _u0, _tspan, p, SecondOrderODEProblem{iip}(); kwargs...
     )
 end
 

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -283,7 +283,26 @@ function remake(
     props = getproperties(func)
     forig = f
 
-    if f === missing || is_split_function(func)
+    if func isa DynamicalODEFunction
+        # Dynamical function containers retain their kind, iip, and specialization.
+        # An explicit `f` replaces the first function instead of the whole container.
+        T = parameterless_type(func)
+        if f === missing
+            f = func.f1
+        elseif f isa DynamicalODEFunction
+            isinplace(f) == iip || throw(
+                ArgumentError(
+                    "a replacement DynamicalODEFunction must have the same in-place " *
+                        "convention as the original function"
+                )
+            )
+            props = _similar_namedtuple_merge_ignore_nothing(props, getproperties(f))
+            if hasproperty(f, :f2)
+                f2 = coalesce(f2, f.f2)
+            end
+            f = f.f1
+        end
+    elseif f === missing || is_split_function(func)
         # if no `f` is provided, create the same type of SciMLFunction
         T = parameterless_type(func)
         f = isdefined(func, :f) ? func.f : func.f1
@@ -304,11 +323,12 @@ function remake(
     props = @delete props.f
     props = @delete props.f1
 
-    args = (f,)
     if is_split_function(T)
         # `f1` and `f2` are wrapped in another SciMLFunction, unless they're
         # already wrapped in the appropriate type or are an `AbstractSciMLOperator`
-        if !(f isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
+        if func isa DynamicalODEFunction
+            f = _remake_dynamical_component(f, typeof(func))
+        elseif !(f isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
             f = split_function_f_wrapper(T){iip, spec}(f)
         end
         if hasproperty(func, :f2)
@@ -318,7 +338,9 @@ function remake(
             # f2 is a part of the function. Thus, if the user provides
             # a SciMLFunction for `f` which contains `f2` we use that.
             f2 = coalesce(f2, get(props, :f2, missing), func.f2)
-            if !(f2 isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
+            if func isa DynamicalODEFunction
+                f2 = _remake_dynamical_component(f2, typeof(func))
+            elseif !(f2 isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
                 f2 = split_function_f_wrapper(T){iip, spec}(f2)
             end
 
@@ -329,8 +351,12 @@ function remake(
                 props = @insert props._func_cache = forig._func_cache
             end
 
-            args = (args..., f2)
+            args = (f, f2)
+        else
+            args = (f,)
         end
+    else
+        args = (f,)
     end
     if isdefined(func, :g)
         # For SDEs/SDDEs where `g` is not a keyword
@@ -352,10 +378,37 @@ function remake(
     # params but the original `prob.f` does not — so we must check `forig` too.
     if _has_type_erased_params(typeof(func))
         return _reconstruct_as_type(typeof(func), result)
-    elseif forig isa AbstractSciMLFunction && _has_type_erased_params(typeof(forig))
+    elseif !(result isa DynamicalODEFunction) && forig isa AbstractSciMLFunction &&
+            _has_type_erased_params(typeof(forig))
         return _reconstruct_as_type(typeof(forig), result)
     end
     return result
+end
+
+function _remake_dynamical_component(
+        f::ODEFunction{iip, spec},
+        ::Type{<:DynamicalODEFunction{iip, spec}}
+    ) where {iip, spec}
+    return f
+end
+
+function _remake_dynamical_component(
+        f, ::Type{<:DynamicalODEFunction{iip, spec}}
+    ) where {iip, spec}
+    if f isa AbstractSciMLOperator
+        return f
+    elseif f isa ODEFunction
+        isinplace(f) == iip || throw(
+            ArgumentError(
+                "a replacement ODEFunction component must have the same in-place " *
+                    "convention as its DynamicalODEFunction container"
+            )
+        )
+        props = getproperties(f)
+        props = @delete props.f
+        return ODEFunction{iip, spec}(unwrapped_f(f.f); props...)
+    end
+    return ODEFunction{iip, spec}(unwrapped_f(f))
 end
 
 """
@@ -367,7 +420,11 @@ end
 Remake the given `ODEProblem`.
 If `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
 """
-function remake(
+function remake(prob::ODEProblem; kwargs...)
+    return _remake_odeproblem(prob; kwargs...)
+end
+
+function _remake_odeproblem(
         prob::ODEProblem; f = missing,
         u0 = missing,
         tspan = missing,
@@ -379,6 +436,18 @@ function remake(
         lazy_initialization = nothing,
         _kwargs...
     )
+    if prob.f isa DynamicalODEFunction &&
+            specialization(prob.f) === FunctionWrapperSpecialize
+        throw(
+            ArgumentError(
+                "remake does not support DynamicalODEFunction with " *
+                    "FunctionWrapperSpecialize because the available wrapper hooks only " *
+                    "describe ordinary ODE call signatures; use AutoSpecialize, " *
+                    "AutoDespecialize, AutoRespecialize, FullSpecialize, or NoSpecialize"
+            )
+        )
+    end
+
     if tspan === missing
         tspan = prob.tspan
     end
@@ -388,7 +457,23 @@ function remake(
     iip = isinplace(prob)
 
     if build_initializeprob == Val{true} || build_initializeprob == true
-        if f !== missing && has_initialization_data(f)
+        if prob.f isa DynamicalODEFunction
+            full_replacement = f isa DynamicalODEFunction
+            initialization_sys = if full_replacement && f.sys !== nothing
+                f.sys
+            else
+                prob.f.sys
+            end
+            initialization_source = if full_replacement && has_initialization_data(f)
+                f
+            else
+                prob.f
+            end
+            initialization_data = remake_initialization_data(
+                initialization_sys, initialization_source, u0, tspan[1], p, newu0,
+                newp
+            )
+        elseif f !== missing && has_initialization_data(f)
             initialization_data = remake_initialization_data(
                 prob.f.sys, f, u0, tspan[1], p, newu0, newp
             )
@@ -440,52 +525,20 @@ end
            tspan = missing, p = missing, kwargs = missing, _kwargs...)
 
 Remake the given `DynamicalODEProblem`.
-If `v0`, `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
+`u0 = ArrayPartition(v0, u0)` remains supported as a full-state replacement when `v0`
+is omitted. Pair-valued symbolic state maps are forwarded to the standard `ODEProblem`
+remake machinery; component overrides must otherwise be concrete values.
+`FunctionWrapperSpecialize` is not supported because the wrapper hooks currently only
+describe ordinary ODE call signatures, not the two component signatures used here.
 """
 function remake(
-        prob::ODEProblem{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:DynamicalODEProblem};
-        f = missing,
+        prob::ODEProblem{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:DynamicalODEProblem};
         v0 = missing,
         u0 = missing,
-        tspan = missing,
-        p = missing,
-        kwargs = missing,
-        interpret_symbolicmap = true,
-        build_initializeprob = Val{true},
-        use_defaults = false,
-        lazy_initialization = nothing,
-        _kwargs...
+        kwargs...
     )
-    if v0 === missing && u0 === missing
-        return remake(
-            prob; f,
-            u0 = missing,
-            tspan,
-            p,
-            kwargs,
-            interpret_symbolicmap,
-            build_initializeprob,
-            use_defaults,
-            lazy_initialization,
-            _kwargs...
-        )
-    else
-        return remake(
-            prob; f,
-            u0 = ArrayPartition(
-                v0 === missing ? state_values(prob).x[1] : v0,
-                u0 === missing ? state_values(prob).x[2] : u0
-            ),
-            tspan,
-            p,
-            kwargs,
-            interpret_symbolicmap,
-            build_initializeprob,
-            use_defaults,
-            lazy_initialization,
-            _kwargs...
-        )
-    end
+    u0 = _partitioned_initial_values(prob, v0, u0)
+    return _remake_odeproblem(prob; u0, kwargs...)
 end
 
 """
@@ -493,52 +546,50 @@ end
           tspan = missing, p = missing, kwargs = missing, _kwargs...)
 
 Remake the given `SecondOrderODEProblem`.
-If `du0`, `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
+`u0 = ArrayPartition(du0, u0)` remains supported as a full-state replacement when `du0`
+is omitted. Pair-valued symbolic state maps are forwarded to the standard `ODEProblem`
+remake machinery; component overrides must otherwise be concrete values.
+`FunctionWrapperSpecialize` is not supported because the wrapper hooks currently only
+describe ordinary ODE call signatures, not the two component signatures used here.
 """
 function remake(
-        prob::ODEProblem{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:SecondOrderODEProblem};
-        f = missing,
+        prob::ODEProblem{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:SecondOrderODEProblem};
         du0 = missing,
         u0 = missing,
-        tspan = missing,
-        p = missing,
-        kwargs = missing,
-        interpret_symbolicmap = true,
-        build_initializeprob = Val{true},
-        use_defaults = false,
-        lazy_initialization = nothing,
-        _kwargs...
+        kwargs...
     )
-    if du0 === missing && u0 === missing
-        return remake(
-            prob; f,
-            u0 = missing,
-            tspan,
-            p,
-            kwargs,
-            interpret_symbolicmap,
-            build_initializeprob,
-            use_defaults,
-            lazy_initialization,
-            _kwargs...
-        )
-    else
-        return remake(
-            prob; f,
-            u0 = ArrayPartition(
-                du0 === missing ? state_values(prob).x[1] : du0,
-                u0 === missing ? state_values(prob).x[2] : u0
-            ),
-            tspan,
-            p,
-            kwargs,
-            interpret_symbolicmap,
-            build_initializeprob,
-            use_defaults,
-            lazy_initialization,
-            _kwargs...
+    u0 = _partitioned_initial_values(prob, du0, u0)
+    return _remake_odeproblem(prob; u0, kwargs...)
+end
+
+_is_pair_map(::Missing) = false
+_is_pair_map(value) = eltype(value) !== Union{} && eltype(value) <: Pair
+
+function _partitioned_initial_values(prob, first, second)
+    if first === missing
+        if second === missing || second isa ArrayPartition || _is_pair_map(second)
+            return second
+        end
+        return ArrayPartition(state_values(prob).x[1], second)
+    end
+
+    first_is_map = _is_pair_map(first)
+    second_is_map = _is_pair_map(second)
+    if first_is_map || second_is_map
+        if first_is_map && second === missing
+            return first
+        elseif first_is_map && second_is_map
+            return [collect(first); collect(second)]
+        end
+        throw(
+            ArgumentError(
+                "symbolic state maps cannot be mixed with concrete component overrides"
+            )
         )
     end
+
+    second = second === missing ? state_values(prob).x[2] : second
+    return ArrayPartition(first, second)
 end
 
 function SciMLBase.remake(

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -390,6 +390,28 @@ _dynamical_component_function(f::ODEFunction) = unwrapped_f(f.f)
 _dynamical_component_function(f) = unwrapped_f(f)
 _is_absent_dynamical_component(f) = _dynamical_component_function(f) === nothing
 
+function _dynamical_oop_wrapper_template(
+        args::A, output::R
+    ) where {N, A <: NTuple{N, Any}, R}
+    # This callable is never invoked. Keeping it independent of `output` lets the
+    # compiler materialize the wrapper type after the actual callable was erased.
+    return FunctionWrappersWrappers.FunctionWrappersWrapper(
+        Returns(nothing), (A, NTuple{N, Any}), (R, Any);
+        cache = FunctionWrappersWrappers.NoCache(),
+        policy = FunctionWrappersWrappers.Strict()
+    )
+end
+
+function _dynamical_iip_wrapper_template(args::A) where {N, A <: NTuple{N, Any}}
+    return FunctionWrappersWrappers.FunctionWrappersWrapper(
+        Returns(nothing), (A, NTuple{N, Any}), (Nothing, Nothing);
+        cache = FunctionWrappersWrappers.NoCache(),
+        policy = FunctionWrappersWrappers.Strict()
+    )
+end
+
+_dynamical_wrapper_typeassert(actual, ::T) where {T} = actual::T
+
 function _dynamical_component_properties(original, replacement)
     props = if original isa ODEFunction && replacement isa ODEFunction
         _similar_namedtuple_merge_ignore_nothing(
@@ -463,28 +485,26 @@ end
 function _wrap_dynamical_oop(
         @nospecialize(f), args::A, output::R
     ) where {N, A <: NTuple{N, Any}, R}
-    FW = FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper
-    exact = FW{R, A}(f)::FW{R, A}
-    fallback = FW{Any, NTuple{N, Any}}(f)::FW{Any, NTuple{N, Any}}
-    wrappers = (exact, fallback)
-    storage = FunctionWrappersWrappers.NoCacheStorage()
-    return FunctionWrappersWrappers.FunctionWrappersWrapper{
-        typeof(wrappers), FunctionWrappersWrappers.Strict, typeof(storage),
-    }(wrappers, storage)
+    template = _dynamical_oop_wrapper_template(args, output)
+    wrapped = FunctionWrappersWrappers.FunctionWrappersWrapper(
+        f, (A, NTuple{N, Any}), (R, Any);
+        cache = FunctionWrappersWrappers.NoCache(),
+        policy = FunctionWrappersWrappers.Strict()
+    )
+    return _dynamical_wrapper_typeassert(wrapped, template)
 end
 
 function _wrap_dynamical_iip(
         @nospecialize(f), args::A
     ) where {N, A <: NTuple{N, Any}}
-    FW = FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper
     void_f = Void(f)
-    exact = FW{Nothing, A}(void_f)::FW{Nothing, A}
-    fallback = FW{Nothing, NTuple{N, Any}}(void_f)::FW{Nothing, NTuple{N, Any}}
-    wrappers = (exact, fallback)
-    storage = FunctionWrappersWrappers.NoCacheStorage()
-    return FunctionWrappersWrappers.FunctionWrappersWrapper{
-        typeof(wrappers), FunctionWrappersWrappers.Strict, typeof(storage),
-    }(wrappers, storage)
+    template = _dynamical_iip_wrapper_template(args)
+    wrapped = FunctionWrappersWrappers.FunctionWrappersWrapper(
+        void_f, (A, NTuple{N, Any}), (Nothing, Nothing);
+        cache = FunctionWrappersWrappers.NoCache(),
+        policy = FunctionWrappersWrappers.Strict()
+    )
+    return _dynamical_wrapper_typeassert(wrapped, template)
 end
 
 function _functionwrapper_specialize_dynamical_component(

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -435,6 +435,112 @@ function remake(
     return prob
 end
 
+"""
+    remake(prob::DynamicalODEProblem; f = missing, v0 = missing, u0 = missing,
+           tspan = missing, p = missing, kwargs = missing, _kwargs...)
+
+Remake the given `DynamicalODEProblem`.
+If `v0`, `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
+"""
+function remake(
+        prob::ODEProblem{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:DynamicalODEProblem};
+        f = missing,
+        v0 = missing,
+        u0 = missing,
+        tspan = missing,
+        p = missing,
+        kwargs = missing,
+        interpret_symbolicmap = true,
+        build_initializeprob = Val{true},
+        use_defaults = false,
+        lazy_initialization = nothing,
+        _kwargs...
+    )
+    if v0 === missing && u0 === missing
+        return remake(
+            prob; f,
+            u0 = missing,
+            tspan,
+            p,
+            kwargs,
+            interpret_symbolicmap,
+            build_initializeprob,
+            use_defaults,
+            lazy_initialization,
+            _kwargs...
+        )
+    else
+        return remake(
+            prob; f,
+            u0 = ArrayPartition(
+                v0 === missing ? state_values(prob).x[1] : v0,
+                u0 === missing ? state_values(prob).x[2] : u0
+            ),
+            tspan,
+            p,
+            kwargs,
+            interpret_symbolicmap,
+            build_initializeprob,
+            use_defaults,
+            lazy_initialization,
+            _kwargs...
+        )
+    end
+end
+
+"""
+    remake(prob::SecondOrderODEProblem; f = missing, du0 = missing, u0 = missing,
+          tspan = missing, p = missing, kwargs = missing, _kwargs...)
+
+Remake the given `SecondOrderODEProblem`.
+If `du0`, `u0` or `p` are given as symbolic maps `ModelingToolkit.jl` has to be loaded.
+"""
+function remake(
+        prob::ODEProblem{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:SecondOrderODEProblem};
+        f = missing,
+        du0 = missing,
+        u0 = missing,
+        tspan = missing,
+        p = missing,
+        kwargs = missing,
+        interpret_symbolicmap = true,
+        build_initializeprob = Val{true},
+        use_defaults = false,
+        lazy_initialization = nothing,
+        _kwargs...
+    )
+    if du0 === missing && u0 === missing
+        return remake(
+            prob; f,
+            u0 = missing,
+            tspan,
+            p,
+            kwargs,
+            interpret_symbolicmap,
+            build_initializeprob,
+            use_defaults,
+            lazy_initialization,
+            _kwargs...
+        )
+    else
+        return remake(
+            prob; f,
+            u0 = ArrayPartition(
+                du0 === missing ? state_values(prob).x[1] : du0,
+                u0 === missing ? state_values(prob).x[2] : u0
+            ),
+            tspan,
+            p,
+            kwargs,
+            interpret_symbolicmap,
+            build_initializeprob,
+            use_defaults,
+            lazy_initialization,
+            _kwargs...
+        )
+    end
+end
+
 function SciMLBase.remake(
         prob::AbstractDynamicOptProblem; f = missing,
         u0 = missing,

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -296,10 +296,11 @@ function remake(
                         "convention as the original function"
                 )
             )
-            props = _similar_namedtuple_merge_ignore_nothing(props, getproperties(f))
-            if hasproperty(f, :f2)
-                f2 = coalesce(f2, f.f2)
+            replacement_props = getproperties(f)
+            if _is_absent_dynamical_component(f.f2)
+                replacement_props = merge(replacement_props, (; f2 = nothing))
             end
+            props = _similar_namedtuple_merge_ignore_nothing(props, replacement_props)
             f = f.f1
         end
     elseif f === missing || is_split_function(func)
@@ -327,7 +328,7 @@ function remake(
         # `f1` and `f2` are wrapped in another SciMLFunction, unless they're
         # already wrapped in the appropriate type or are an `AbstractSciMLOperator`
         if func isa DynamicalODEFunction
-            f = _remake_dynamical_component(f, typeof(func))
+            f = _remake_dynamical_component(func.f1, f, typeof(func))
         elseif !(f isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
             f = split_function_f_wrapper(T){iip, spec}(f)
         end
@@ -339,7 +340,7 @@ function remake(
             # a SciMLFunction for `f` which contains `f2` we use that.
             f2 = coalesce(f2, get(props, :f2, missing), func.f2)
             if func isa DynamicalODEFunction
-                f2 = _remake_dynamical_component(f2, typeof(func))
+                f2 = _remake_dynamical_component(func.f2, f2, typeof(func))
             elseif !(f2 isa Union{AbstractSciMLOperator, split_function_f_wrapper(T)})
                 f2 = split_function_f_wrapper(T){iip, spec}(f2)
             end
@@ -385,30 +386,192 @@ function remake(
     return result
 end
 
-function _remake_dynamical_component(
-        f::ODEFunction{iip, spec},
-        ::Type{<:DynamicalODEFunction{iip, spec}}
-    ) where {iip, spec}
-    return f
+_dynamical_component_function(f::ODEFunction) = unwrapped_f(f.f)
+_dynamical_component_function(f) = unwrapped_f(f)
+_is_absent_dynamical_component(f) = _dynamical_component_function(f) === nothing
+
+function _dynamical_component_properties(original, replacement)
+    props = if original isa ODEFunction && replacement isa ODEFunction
+        _similar_namedtuple_merge_ignore_nothing(
+            getproperties(original), getproperties(replacement)
+        )
+    elseif replacement isa ODEFunction
+        getproperties(replacement)
+    elseif original isa ODEFunction
+        getproperties(original)
+    else
+        (; f = replacement)
+    end
+    return @delete props.f
+end
+
+function _dynamical_component_erasure_source(original, replacement)
+    if replacement isa ODEFunction && _has_type_erased_params(typeof(replacement))
+        return replacement
+    elseif original isa ODEFunction && _has_type_erased_params(typeof(original))
+        return original
+    end
+    return nothing
 end
 
 function _remake_dynamical_component(
-        f, ::Type{<:DynamicalODEFunction{iip, spec}}
+        original, replacement, ::Type{<:DynamicalODEFunction{iip, spec}}
     ) where {iip, spec}
-    if f isa AbstractSciMLOperator
-        return f
-    elseif f isa ODEFunction
-        isinplace(f) == iip || throw(
+    if replacement === original &&
+            replacement isa Union{AbstractSciMLOperator, ODEFunction{iip, spec}}
+        return replacement
+    elseif replacement isa AbstractSciMLOperator
+        return replacement
+    elseif replacement isa ODEFunction
+        isinplace(replacement) == iip || throw(
             ArgumentError(
                 "a replacement ODEFunction component must have the same in-place " *
                     "convention as its DynamicalODEFunction container"
             )
         )
-        props = getproperties(f)
-        props = @delete props.f
-        return ODEFunction{iip, spec}(unwrapped_f(f.f); props...)
     end
-    return ODEFunction{iip, spec}(unwrapped_f(f))
+
+    props = _dynamical_component_properties(original, replacement)
+    callable = if spec === FunctionWrapperSpecialize && replacement isa ODEFunction &&
+            replacement.f isa FunctionWrappersWrappers.FunctionWrappersWrapper
+        replacement.f
+    else
+        _dynamical_component_function(replacement)
+    end
+    result = ODEFunction{iip, spec}(callable; props...)
+
+    erasure_source = _dynamical_component_erasure_source(original, replacement)
+    if erasure_source isa ODEFunction
+        return _reconstruct_as_type(typeof(erasure_source), result)
+    end
+    return result
+end
+
+function _rebuild_dynamical_function(
+        original::DynamicalODEFunction, f1, f2, ::Type{spec}
+    ) where {spec}
+    props = getproperties(original)
+    props = @delete props.f1
+    props = @delete props.f2
+    result = DynamicalODEFunction{isinplace(original), spec}(f1, f2; props...)
+    if _has_type_erased_params(typeof(original))
+        return _reconstruct_as_type(typeof(original), result)
+    end
+    return result
+end
+
+function _wrap_dynamical_oop(
+        @nospecialize(f), args::A, output::R
+    ) where {N, A <: NTuple{N, Any}, R}
+    FW = FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper
+    exact = FW{R, A}(f)::FW{R, A}
+    fallback = FW{Any, NTuple{N, Any}}(f)::FW{Any, NTuple{N, Any}}
+    wrappers = (exact, fallback)
+    storage = FunctionWrappersWrappers.NoCacheStorage()
+    return FunctionWrappersWrappers.FunctionWrappersWrapper{
+        typeof(wrappers), FunctionWrappersWrappers.Strict, typeof(storage),
+    }(wrappers, storage)
+end
+
+function _wrap_dynamical_iip(
+        @nospecialize(f), args::A
+    ) where {N, A <: NTuple{N, Any}}
+    FW = FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper
+    void_f = Void(f)
+    exact = FW{Nothing, A}(void_f)::FW{Nothing, A}
+    fallback = FW{Nothing, NTuple{N, Any}}(void_f)::FW{Nothing, NTuple{N, Any}}
+    wrappers = (exact, fallback)
+    storage = FunctionWrappersWrappers.NoCacheStorage()
+    return FunctionWrappersWrappers.FunctionWrappersWrapper{
+        typeof(wrappers), FunctionWrappersWrappers.Strict, typeof(storage),
+    }(wrappers, storage)
+end
+
+function _functionwrapper_specialize_dynamical_component(
+        original, replacement, args, output, ::Val{iip}
+    ) where {iip}
+    if replacement isa ODEFunction
+        isinplace(replacement) == iip || throw(
+            ArgumentError(
+                "a DynamicalODEFunction component must have the same in-place " *
+                    "convention as its container"
+            )
+        )
+    end
+
+    raw = _dynamical_component_function(replacement)
+    wrapped = if iip
+        _wrap_dynamical_iip(raw, args)
+    else
+        _wrap_dynamical_oop(raw, args, output)
+    end
+    props = _dynamical_component_properties(original, replacement)
+    result = ODEFunction{iip, FunctionWrapperSpecialize}(wrapped; props...)
+    erasure_source = _dynamical_component_erasure_source(original, replacement)
+    if erasure_source isa ODEFunction
+        return _reconstruct_as_type(typeof(erasure_source), result)
+    end
+    return result
+end
+
+function _functionwrapper_specialize_dynamical_replacement(
+        original::DynamicalODEFunction{iip}, replacement, u0, p, t
+    ) where {iip}
+    v, u = u0.x
+    if replacement isa DynamicalODEFunction
+        isinplace(replacement) == iip || throw(
+            ArgumentError(
+                "a replacement DynamicalODEFunction must have the same in-place " *
+                    "convention as the original function"
+            )
+        )
+        replacement_f1 = replacement.f1
+        replacement_f2 = if _is_absent_dynamical_component(replacement.f2)
+            original.f2
+        else
+            replacement.f2
+        end
+        metadata_source = replacement
+    else
+        replacement_f1 = replacement
+        replacement_f2 = original.f2
+        metadata_source = original
+    end
+
+    if iip
+        f1 = _functionwrapper_specialize_dynamical_component(
+            original.f1, replacement_f1, (v, v, u, p, t), v, Val(true)
+        )
+        f2 = _functionwrapper_specialize_dynamical_component(
+            original.f2, replacement_f2, (u, v, u, p, t), u, Val(true)
+        )
+    else
+        args = (v, u, p, t)
+        f1 = _functionwrapper_specialize_dynamical_component(
+            original.f1, replacement_f1, args, v, Val(false)
+        )
+        f2 = _functionwrapper_specialize_dynamical_component(
+            original.f2, replacement_f2, args, u, Val(false)
+        )
+    end
+    return _rebuild_dynamical_function(
+        metadata_source, f1, f2, FunctionWrapperSpecialize
+    )
+end
+
+function _functionwrapper_specialize_dynamical(
+        f::DynamicalODEFunction, u0, p, t
+    )
+    return _functionwrapper_specialize_dynamical_replacement(f, f, u0, p, t)
+end
+
+function _remake_functionwrapper_dynamical(
+        original::DynamicalODEFunction, replacement, initialization_data, u0, p, t
+    )
+    prepared = _functionwrapper_specialize_dynamical_replacement(
+        original, replacement, u0, p, t
+    )
+    return remake(original; f = prepared, initialization_data)
 end
 
 """
@@ -436,18 +599,6 @@ function _remake_odeproblem(
         lazy_initialization = nothing,
         _kwargs...
     )
-    if prob.f isa DynamicalODEFunction &&
-            specialization(prob.f) === FunctionWrapperSpecialize
-        throw(
-            ArgumentError(
-                "remake does not support DynamicalODEFunction with " *
-                    "FunctionWrapperSpecialize because the available wrapper hooks only " *
-                    "describe ordinary ODE call signatures; use AutoSpecialize, " *
-                    "AutoDespecialize, AutoRespecialize, FullSpecialize, or NoSpecialize"
-            )
-        )
-    end
-
     if tspan === missing
         tspan = prob.tspan
     end
@@ -487,9 +638,18 @@ function _remake_odeproblem(
     end
 
     f = coalesce(f, prob.f)
-    f = remake(prob.f; f, initialization_data)
+    f = if prob.f isa DynamicalODEFunction &&
+            specialization(prob.f) === FunctionWrapperSpecialize
+        ptspan = promote_tspan(tspan)
+        _remake_functionwrapper_dynamical(
+            prob.f, f, initialization_data, newu0, newp, ptspan[1]
+        )
+    else
+        remake(prob.f; f, initialization_data)
+    end
 
-    if specialization(f) === FunctionWrapperSpecialize
+    if specialization(f) === FunctionWrapperSpecialize &&
+            !(f isa DynamicalODEFunction)
         ptspan = promote_tspan(tspan)
         if iip
             f = remake(
@@ -516,6 +676,13 @@ function _remake_odeproblem(
     u0, p = maybe_eager_initialize_problem(prob, initialization_data, lazy_initialization)
     @reset prob.u0 = u0
     @reset prob.p = p
+    if prob.f isa DynamicalODEFunction &&
+            specialization(prob.f) === FunctionWrapperSpecialize
+        ptspan = promote_tspan(prob.tspan)
+        @reset prob.f = _functionwrapper_specialize_dynamical(
+            prob.f, prob.u0, prob.p, ptspan[1]
+        )
+    end
 
     return prob
 end
@@ -528,8 +695,6 @@ Remake the given `DynamicalODEProblem`.
 `u0 = ArrayPartition(v0, u0)` remains supported as a full-state replacement when `v0`
 is omitted. Pair-valued symbolic state maps are forwarded to the standard `ODEProblem`
 remake machinery; component overrides must otherwise be concrete values.
-`FunctionWrapperSpecialize` is not supported because the wrapper hooks currently only
-describe ordinary ODE call signatures, not the two component signatures used here.
 """
 function remake(
         prob::ODEProblem{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:DynamicalODEProblem};
@@ -549,8 +714,6 @@ Remake the given `SecondOrderODEProblem`.
 `u0 = ArrayPartition(du0, u0)` remains supported as a full-state replacement when `du0`
 is omitted. Pair-valued symbolic state maps are forwarded to the standard `ODEProblem`
 remake machinery; component overrides must otherwise be concrete values.
-`FunctionWrapperSpecialize` is not supported because the wrapper hooks currently only
-describe ordinary ODE call signatures, not the two component signatures used here.
 """
 function remake(
         prob::ODEProblem{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:SecondOrderODEProblem};

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -704,13 +704,21 @@ end
         @test SciMLBase.problem_type(remade) === SciMLBase.problem_type(prob)
     end
 
-    unsupported_func = DynamicalODEFunction{
+    wrapped_func = DynamicalODEFunction{
         false, SciMLBase.FunctionWrapperSpecialize,
     }(f1, f2)
-    unsupported_prob = DynamicalODEProblem(
-        unsupported_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    wrapped_prob = DynamicalODEProblem(
+        wrapped_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
     )
-    @test_throws ArgumentError remake(unsupported_prob)
+    wrapped_remade = @inferred remake(wrapped_prob; v0 = [5.0])
+    @test SciMLBase.specialization(wrapped_remade.f) ===
+        SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.specialization(wrapped_remade.f.f1) ===
+        SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.specialization(wrapped_remade.f.f2) ===
+        SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.unwrapped_f(wrapped_remade.f.f1.f) === f1
+    @test SciMLBase.unwrapped_f(wrapped_remade.f.f2.f) === f2
 
     old_analytic(u0, p, t) = :old
     new_analytic(u0, p, t) = :new
@@ -746,6 +754,13 @@ end
     @test SciMLBase.specialization(fully_replaced.f.f2) === SciMLBase.FullSpecialize
     @test SciMLBase.problem_type(fully_replaced) === SciMLBase.problem_type(prob)
 
+    replacement_without_f2 = DynamicalODEFunction(newf1)
+    fallback_replaced = remake(prob; f = replacement_without_f2)
+    fallback_result = fallback_replaced.f(
+        fallback_replaced.u0, fallback_replaced.p, 0.0
+    )
+    @test fallback_result == ArrayPartition([11.0], [4.0])
+
     component_jac(u, p, t) = fill(-p[1], length(u))
     component_f1 = ODEFunction{false, SciMLBase.FullSpecialize}(
         f1; jac = component_jac
@@ -759,6 +774,15 @@ end
     metadata_remade = remake(metadata_prob)
     @test metadata_remade.f.f1.jac === component_jac
     @test SciMLBase.has_jac(metadata_remade.f)
+    metadata_raw_replaced = remake(metadata_prob; f = newf1)
+    @test metadata_raw_replaced.f.f1.jac === component_jac
+    @test SciMLBase.has_jac(metadata_raw_replaced.f)
+    metadata_wrapped_replaced = remake(
+        metadata_prob;
+        f = ODEFunction{false, SciMLBase.NoSpecialize}(newf1)
+    )
+    @test metadata_wrapped_replaced.f.f1.jac === component_jac
+    @test SciMLBase.has_jac(metadata_wrapped_replaced.f)
 
     widened_component_f1 = SciMLBase.widen_bounded_type_params(component_f1)
     widened_func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
@@ -770,6 +794,10 @@ end
     widened_remade = remake(widened_prob)
     @test typeof(widened_remade.f.f1) === typeof(widened_component_f1)
     @test typeof(widened_remade.f.f1).parameters[end - 1] ===
+        Union{Nothing, SciMLBase.OverrideInitData}
+    widened_replaced = remake(widened_prob; f = newf1)
+    @test widened_replaced.f.f1.jac === component_jac
+    @test typeof(widened_replaced.f.f1).parameters[end - 1] ===
         Union{Nothing, SciMLBase.OverrideInitData}
 
     auto_func = DynamicalODEFunction{false, SciMLBase.AutoSpecialize}(f1, f2)
@@ -815,6 +843,95 @@ end
     second_result = second_remade.f(second_remade.u0, second_remade.p, 0.0)
     @test second_result.x[1] == [13.0]
     @test second_result.x[2] == [5.0]
+    second_full_replacement = remake(
+        second_order; f = DynamicalODEFunction(new_acceleration)
+    )
+    second_full_result = second_full_replacement.f(
+        second_full_replacement.u0, second_full_replacement.p, 0.0
+    )
+    @test second_full_result.x[1] == [13.0]
+    @test second_full_result.x[2] == [1.0]
+end
+
+@testset "structured `FunctionWrapperSpecialize` remake" begin
+    f1(v, u, p, t) = v .* p[1]
+    f2(v, u, p, t) = u .* p[2]
+    v0 = Float32[1]
+    u0 = Int[2]
+    p = (Float32(3), 2)
+    func = DynamicalODEFunction{false, SciMLBase.FunctionWrapperSpecialize}(f1, f2)
+    prob = @inferred DynamicalODEProblem(func, v0, u0, (0.0, 1.0), p)
+
+    @test SciMLBase.specialization(prob.f) === SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.specialization(prob.f.f1) === SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.specialization(prob.f.f2) === SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.unwrapped_f(prob.f.f1.f) === f1
+    @test SciMLBase.unwrapped_f(prob.f.f2.f) === f2
+    result = @inferred prob.f(prob.u0, prob.p, 0.0)
+    @test result == ArrayPartition(Float32[3], Int[4])
+    @test result.x[1] isa Vector{Float32}
+    @test result.x[2] isa Vector{Int}
+
+    derivative = ForwardDiff.derivative(1.0) do x
+        value = prob.f(ArrayPartition([x], prob.u0.x[2]), prob.p, 0.0)
+        return only(value.x[1])
+    end
+    @test derivative == 3.0
+
+    newf1(v, u, p, t) = v .+ p[1]
+    newf2(v, u, p, t) = u .+ p[2]
+    replacement = DynamicalODEFunction{
+        false, SciMLBase.FunctionWrapperSpecialize,
+    }(newf1, newf2)
+    remade = @inferred remake(prob; f = replacement, v0 = Float32[5])
+    @test typeof(remade.f.f1.f) === typeof(prob.f.f1.f)
+    @test typeof(remade.f.f2.f) === typeof(prob.f.f2.f)
+    @test SciMLBase.unwrapped_f(remade.f.f1.f) === newf1
+    @test SciMLBase.unwrapped_f(remade.f.f2.f) === newf2
+    @test remade.f(remade.u0, remade.p, 0.0) ==
+        ArrayPartition(Float32[8], Int[4])
+
+    raw_remade = @inferred remake(prob; f = newf1, v0 = Float32[6])
+    @test SciMLBase.unwrapped_f(raw_remade.f.f1.f) === newf1
+    @test SciMLBase.unwrapped_f(raw_remade.f.f2.f) === f2
+    @test raw_remade.f(raw_remade.u0, raw_remade.p, 0.0) ==
+        ArrayPartition(Float32[9], Int[4])
+
+    component_jac(u, p, t) = fill(p[1], length(u))
+    component = ODEFunction{false, SciMLBase.FullSpecialize}(f1; jac = component_jac)
+    metadata_func = DynamicalODEFunction{
+        false, SciMLBase.FunctionWrapperSpecialize,
+    }(component, f2)
+    metadata_prob = DynamicalODEProblem(metadata_func, v0, u0, (0.0, 1.0), p)
+    metadata_remade = remake(metadata_prob; f = newf1)
+    @test metadata_remade.f.f1.jac === component_jac
+    @test SciMLBase.has_jac(metadata_remade.f)
+
+    f1!(dv, v, u, p, t) = dv .= p[1] .* u
+    f2!(du, v, u, p, t) = du .= p[2] .* v
+    ifunc = DynamicalODEFunction{true, SciMLBase.FunctionWrapperSpecialize}(f1!, f2!)
+    iprob = @inferred DynamicalODEProblem(
+        ifunc, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    iremade = @inferred remake(iprob; v0 = [5.0])
+    du = ArrayPartition(zeros(1), zeros(1))
+    @test iremade.f(du, iremade.u0, iremade.p, 0.0) === nothing
+    @test du == ArrayPartition([6.0], [20.0])
+
+    acceleration(du, u, p, t) = -p[1] .* u
+    second_func = DynamicalODEFunction{
+        false, SciMLBase.FunctionWrapperSpecialize,
+    }(acceleration, nothing)
+    second = @inferred SecondOrderODEProblem(
+        second_func, [1.0], [2.0], (0.0, 1.0), [3.0]
+    )
+    second_remade = @inferred remake(second; du0 = [4.0])
+    @test second_remade.f(second_remade.u0, second_remade.p, 0.0) ==
+        ArrayPartition([-6.0], [4.0])
+    @test SciMLBase.specialization(second_remade.f.f1) ===
+        SciMLBase.FunctionWrapperSpecialize
+    @test SciMLBase.specialization(second_remade.f.f2) ===
+        SciMLBase.FunctionWrapperSpecialize
 end
 
 struct StructuredRemakeInitSystem

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -528,6 +528,7 @@ end
     end
     prob = DynamicalODEProblem(f1!, f2!, [1.0], [2.0], 3.0, [4.0, 5.0])
     @test prob.u0 == ArrayPartition([1.0], [2.0])
+    @test SciMLBase.problem_type(prob) isa DynamicalODEProblem{true}
 
     # `remake` with no initial values override
     prob2 = remake(prob; p = [6.0, 7.0])
@@ -553,6 +554,7 @@ end
     end
     prob = SecondOrderODEProblem(f!, [1.0], [2.0], 3.0, [4.0])
     @test prob.u0 == ArrayPartition([1.0], [2.0])
+    @test SciMLBase.problem_type(prob) isa SecondOrderODEProblem{true}
 
     # `remake` with no initial values override
     prob2 = remake(prob; p = [5.0])
@@ -570,4 +572,350 @@ end
     # `remake` du0 and u0 override
     prob5 = remake(prob; du0 = [5.0], u0 = [6.0])
     @test prob5.u0 == ArrayPartition([5.0], [6.0])
+end
+
+@testset "`DynamicalODEProblem` constructors retain the problem type" begin
+    f1!(dv, v, u, p, t) = dv .= -p[1] .* u
+    f2!(du, v, u, p, t) = du .= p[2] .* v
+    wrapped! = DynamicalODEFunction(f1!, f2!)
+    iip_probs = (
+        DynamicalODEProblem(wrapped!, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+        DynamicalODEProblem(f1!, f2!, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+        DynamicalODEProblem{true}(f1!, f2!, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+    )
+    for prob in iip_probs
+        @test SciMLBase.isinplace(prob)
+        @test SciMLBase.problem_type(prob) isa DynamicalODEProblem{true}
+    end
+
+    f1(v, u, p, t) = -p[1] .* u
+    f2(v, u, p, t) = p[2] .* v
+    wrapped = DynamicalODEFunction(f1, f2)
+    oop_probs = (
+        DynamicalODEProblem(wrapped, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+        DynamicalODEProblem(f1, f2, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+        DynamicalODEProblem{false}(f1, f2, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]),
+    )
+    for prob in oop_probs
+        @test !SciMLBase.isinplace(prob)
+        @test SciMLBase.problem_type(prob) isa DynamicalODEProblem{false}
+    end
+end
+
+@testset "wrapped `SecondOrderODEProblem` constructors preserve specialization" begin
+    acceleration(du, u, p, t) = -p[1] .* u
+    analytic(u0, p, t) = :analytic
+    for spec in (
+            SciMLBase.AutoSpecialize, SciMLBase.AutoDespecialize,
+            SciMLBase.AutoRespecialize, SciMLBase.FullSpecialize,
+            SciMLBase.NoSpecialize,
+        )
+        func = DynamicalODEFunction{false, spec}(
+            acceleration, nothing; analytic
+        )
+        prob = SecondOrderODEProblem(
+            func, [1.0], [2.0], (0.0, 1.0), [3.0]
+        )
+        @test SciMLBase.specialization(prob.f) === spec
+        @test SciMLBase.specialization(prob.f.f1) === spec
+        @test SciMLBase.specialization(prob.f.f2) === spec
+        @test prob.f.analytic === analytic
+        @test SciMLBase.problem_type(prob) isa SecondOrderODEProblem{false}
+        @test prob.f(prob.u0, prob.p, 0.0) == ArrayPartition([-6.0], [1.0])
+    end
+
+    kinematic(du, u, p, t) = 2 .* du
+    raw_func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        acceleration, kinematic
+    )
+    raw_prob = SecondOrderODEProblem(
+        raw_func, [1.0], [2.0], (0.0, 1.0), [3.0]
+    )
+    @test SciMLBase.specialization(raw_prob.f) === SciMLBase.FullSpecialize
+    @test SciMLBase.specialization(raw_prob.f.f1) === SciMLBase.FullSpecialize
+    @test SciMLBase.specialization(raw_prob.f.f2) === SciMLBase.FullSpecialize
+    @test raw_prob.f(raw_prob.u0, raw_prob.p, 0.0) ==
+        ArrayPartition([-6.0], [2.0])
+end
+
+@testset "structured `ODEProblem` remake uses the full ODE pipeline" begin
+    f1(v, u, p, t) = -p[1] .* u
+    f2(v, u, p, t) = p[2] .* v
+    prob = DynamicalODEProblem(
+        f1, f2, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]; saveat = 0.1
+    )
+
+    same = @inferred remake(prob)
+    @test same.u0 === prob.u0
+    @test same.f === prob.f
+    @test same.p === prob.p
+    @test same.tspan === prob.tspan
+    @test SciMLBase.problem_type(same) === SciMLBase.problem_type(prob)
+
+    newv0 = [5.0]
+    vprob = @inferred remake(prob; v0 = newv0)
+    @test vprob.u0.x[1] === newv0
+    @test vprob.u0.x[2] === prob.u0.x[2]
+
+    newu0 = [6.0]
+    uprob = @inferred remake(prob; u0 = newu0)
+    @test uprob.u0.x[1] === prob.u0.x[1]
+    @test uprob.u0.x[2] === newu0
+
+    both = @inferred remake(prob; v0 = newv0, u0 = newu0)
+    @test both.u0 == ArrayPartition(newv0, newu0)
+
+    packed = ArrayPartition([7.0], [8.0])
+    packed_prob = @inferred remake(prob; u0 = packed)
+    @test packed_prob.u0 === packed
+    nested_prob = remake(prob; v0 = [9.0], u0 = packed)
+    @test nested_prob.u0.x[1] == [9.0]
+    @test nested_prob.u0.x[2] === packed
+
+    newp = [9.0, 10.0]
+    forwarded = remake(
+        prob; v0 = newv0, p = newp, tspan = (1.0, 2.0), abstol = 1.0e-8,
+        build_initializeprob = false, lazy_initialization = true
+    )
+    @test forwarded.p === newp
+    @test forwarded.tspan == (1.0, 2.0)
+    @test values(forwarded.kwargs) == (; saveat = 0.1, abstol = 1.0e-8)
+    @test SciMLBase.problem_type(forwarded) === SciMLBase.problem_type(prob)
+
+    replaced_kwargs = remake(prob; kwargs = (; reltol = 1.0e-7))
+    @test values(replaced_kwargs.kwargs) == (; reltol = 1.0e-7)
+end
+
+@testset "structured ODE function replacement and specialization" begin
+    f1(v, u, p, t) = -p[1] .* u
+    f2(v, u, p, t) = p[2] .* v
+    newf1(v, u, p, t) = fill(11.0, length(v))
+    newf2(v, u, p, t) = fill(12.0, length(u))
+
+    for spec in (
+            SciMLBase.AutoSpecialize, SciMLBase.AutoDespecialize,
+            SciMLBase.AutoRespecialize, SciMLBase.FullSpecialize,
+            SciMLBase.NoSpecialize,
+        )
+        func = DynamicalODEFunction{false, spec}(f1, f2)
+        prob = DynamicalODEProblem(func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0])
+        remade = remake(prob; v0 = [5.0])
+        @test SciMLBase.specialization(remade.f) === spec
+        @test SciMLBase.problem_type(remade) === SciMLBase.problem_type(prob)
+    end
+
+    unsupported_func = DynamicalODEFunction{
+        false, SciMLBase.FunctionWrapperSpecialize,
+    }(f1, f2)
+    unsupported_prob = DynamicalODEProblem(
+        unsupported_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    @test_throws ArgumentError remake(unsupported_prob)
+
+    old_analytic(u0, p, t) = :old
+    new_analytic(u0, p, t) = :new
+    oldfunc = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        f1, f2; analytic = old_analytic
+    )
+    prob = DynamicalODEProblem(oldfunc, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0])
+
+    first_replaced = remake(prob; f = newf1)
+    first_result = first_replaced.f(first_replaced.u0, first_replaced.p, 0.0)
+    @test first_result.x[1] == [11.0]
+    @test first_result.x[2] == [4.0]
+    @test first_replaced.f.analytic === old_analytic
+    @test SciMLBase.specialization(first_replaced.f) === SciMLBase.FullSpecialize
+    @test SciMLBase.problem_type(first_replaced) === SciMLBase.problem_type(prob)
+
+    erased_first = ODEFunction{false, SciMLBase.NoSpecialize}(newf1)
+    erased_first_replaced = remake(prob; f = erased_first)
+    @test SciMLBase.specialization(erased_first_replaced.f) ===
+        SciMLBase.FullSpecialize
+    @test SciMLBase.specialization(erased_first_replaced.f.f1) ===
+        SciMLBase.FullSpecialize
+
+    newfunc = DynamicalODEFunction{false, SciMLBase.NoSpecialize}(
+        newf1, newf2; analytic = new_analytic
+    )
+    fully_replaced = remake(prob; f = newfunc)
+    full_result = fully_replaced.f(fully_replaced.u0, fully_replaced.p, 0.0)
+    @test full_result == ArrayPartition([11.0], [12.0])
+    @test fully_replaced.f.analytic === new_analytic
+    @test SciMLBase.specialization(fully_replaced.f) === SciMLBase.FullSpecialize
+    @test SciMLBase.specialization(fully_replaced.f.f1) === SciMLBase.FullSpecialize
+    @test SciMLBase.specialization(fully_replaced.f.f2) === SciMLBase.FullSpecialize
+    @test SciMLBase.problem_type(fully_replaced) === SciMLBase.problem_type(prob)
+
+    component_jac(u, p, t) = fill(-p[1], length(u))
+    component_f1 = ODEFunction{false, SciMLBase.FullSpecialize}(
+        f1; jac = component_jac
+    )
+    metadata_func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        component_f1, f2
+    )
+    metadata_prob = DynamicalODEProblem(
+        metadata_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    metadata_remade = remake(metadata_prob)
+    @test metadata_remade.f.f1.jac === component_jac
+    @test SciMLBase.has_jac(metadata_remade.f)
+
+    widened_component_f1 = SciMLBase.widen_bounded_type_params(component_f1)
+    widened_func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        widened_component_f1, f2
+    )
+    widened_prob = DynamicalODEProblem(
+        widened_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    widened_remade = remake(widened_prob)
+    @test typeof(widened_remade.f.f1) === typeof(widened_component_f1)
+    @test typeof(widened_remade.f.f1).parameters[end - 1] ===
+        Union{Nothing, SciMLBase.OverrideInitData}
+
+    auto_func = DynamicalODEFunction{false, SciMLBase.AutoSpecialize}(f1, f2)
+    auto_prob = DynamicalODEProblem(
+        auto_func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    full_func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(newf1, newf2)
+    auto_replaced = remake(auto_prob; f = full_func)
+    @test SciMLBase.specialization(auto_replaced.f) === SciMLBase.AutoSpecialize
+    @test SciMLBase.specialization(auto_replaced.f.f1) === SciMLBase.AutoSpecialize
+    @test SciMLBase.specialization(auto_replaced.f.f2) === SciMLBase.AutoSpecialize
+
+    newf1!(dv, v, u, p, t) = dv .= 14.0
+    newf2!(du, v, u, p, t) = du .= 15.0
+    inplace_func = DynamicalODEFunction{true, SciMLBase.FullSpecialize}(newf1!, newf2!)
+    @test_throws ArgumentError remake(prob; f = inplace_func)
+    inplace_component = ODEFunction{true, SciMLBase.FullSpecialize}(newf1!)
+    @test_throws ArgumentError remake(prob; f = inplace_component)
+    @test_throws ArgumentError remake(prob.f; f2 = inplace_component)
+
+    oldf1!(dv, v, u, p, t) = dv .= -p[1] .* u
+    oldf2!(du, v, u, p, t) = du .= p[2] .* v
+    inplace_prob = DynamicalODEProblem(
+        oldf1!, oldf2!, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+    inplace_replaced = remake(inplace_prob; f = newf1!)
+    derivative = ArrayPartition(zeros(1), zeros(1))
+    inplace_replaced.f(derivative, inplace_replaced.u0, inplace_replaced.p, 0.0)
+    @test derivative == ArrayPartition([14.0], [4.0])
+    @test SciMLBase.problem_type(inplace_replaced) ===
+        SciMLBase.problem_type(inplace_prob)
+
+    acceleration(du, u, p, t) = -p[1] .* u
+    new_acceleration(du, u, p, t) = fill(13.0, length(u))
+    second_order = SecondOrderODEProblem(
+        acceleration, [1.0], [2.0], (0.0, 1.0), [3.0]
+    )
+    second_same = @inferred remake(second_order)
+    @test SciMLBase.problem_type(second_same) === SciMLBase.problem_type(second_order)
+    second_packed = ArrayPartition([6.0], [7.0])
+    @test remake(second_order; u0 = second_packed).u0 === second_packed
+    second_remade = @inferred remake(second_order; du0 = [5.0], f = new_acceleration)
+    second_result = second_remade.f(second_remade.u0, second_remade.p, 0.0)
+    @test second_result.x[1] == [13.0]
+    @test second_result.x[2] == [5.0]
+end
+
+struct StructuredRemakeInitSystem
+    name::Symbol
+end
+
+function SciMLBase.remake_initialization_data(
+        sys::StructuredRemakeInitSystem, scimlfn, u0, t0, p, newu0, newp,
+        ::SciMLBase.RemakeInitializationDataContext
+    )
+    initdata = scimlfn.initialization_data
+    return SciMLBase.OverrideInitData(
+        initdata.initializeprob, initdata.update_initializeprob!,
+        initdata.initializeprobmap, initdata.initializeprobpmap; metadata = sys
+    )
+end
+
+@testset "structured ODE initialization data follows full-function replacements" begin
+    f1(v, u, p, t) = -p[1] .* u
+    f2(v, u, p, t) = p[2] .* v
+    newf1(v, u, p, t) = fill(11.0, length(v))
+    newf2(v, u, p, t) = fill(12.0, length(u))
+
+    global_initprob = NonlinearProblem(Returns(nothing), nothing, [1.0])
+    component_initprob = NonlinearProblem(Returns(nothing), nothing, [2.0])
+    replacement_initprob = NonlinearProblem(Returns(nothing), nothing, [3.0])
+    global_initdata = SciMLBase.OverrideInitData(
+        global_initprob, nothing, nothing, nothing
+    )
+    component_initdata = SciMLBase.OverrideInitData(
+        component_initprob, nothing, nothing, nothing
+    )
+    replacement_initdata = SciMLBase.OverrideInitData(
+        replacement_initprob, nothing, nothing, nothing
+    )
+
+    original_sys = StructuredRemakeInitSystem(:original)
+    replacement_sys = StructuredRemakeInitSystem(:replacement)
+    component_f1 = ODEFunction{false, SciMLBase.FullSpecialize}(
+        f1; initialization_data = component_initdata
+    )
+    func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        component_f1, f2; sys = original_sys, initialization_data = global_initdata
+    )
+    prob = DynamicalODEProblem(
+        func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0]
+    )
+
+    same = remake(prob)
+    @test same.f.initialization_data.initializeprob === global_initprob
+    @test same.f.initialization_data.metadata === original_sys
+    @test same.f.f1.initialization_data.initializeprob === component_initprob
+
+    incoming_component = ODEFunction{false, SciMLBase.FullSpecialize}(
+        newf1; initialization_data = component_initdata
+    )
+    component_replaced = remake(prob; f = incoming_component)
+    @test component_replaced.f.initialization_data.initializeprob === global_initprob
+    @test component_replaced.f.initialization_data.metadata === original_sys
+    @test component_replaced.f.f1.initialization_data.initializeprob ===
+        component_initprob
+
+    replacement = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        newf1, newf2; sys = replacement_sys, initialization_data = replacement_initdata
+    )
+    fully_replaced = remake(prob; f = replacement)
+    @test fully_replaced.f.initialization_data.initializeprob === replacement_initprob
+    @test fully_replaced.f.initialization_data.metadata === replacement_sys
+
+    replacement_without_sys = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        newf1, newf2; initialization_data = replacement_initdata
+    )
+    replaced_without_sys = remake(prob; f = replacement_without_sys)
+    @test replaced_without_sys.f.sys === original_sys
+    @test replaced_without_sys.f.initialization_data.initializeprob ===
+        replacement_initprob
+    @test replaced_without_sys.f.initialization_data.metadata === original_sys
+
+    replacement_without_init = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(
+        newf1, newf2; sys = replacement_sys
+    )
+    replaced_without_init = remake(prob; f = replacement_without_init)
+    @test replaced_without_init.f.sys === replacement_sys
+    @test replaced_without_init.f.initialization_data.initializeprob === global_initprob
+    @test replaced_without_init.f.initialization_data.metadata === replacement_sys
+
+    disabled = remake(prob; build_initializeprob = false)
+    @test disabled.f.initialization_data === nothing
+end
+
+@testset "structured ODE symbolic remake forwarding" begin
+    f1(v, u, p, t) = -p[1] .* u
+    f2(v, u, p, t) = p[2] .* v
+    sys = SymbolCache([:v, :u], [:a, :b], :t)
+    func = DynamicalODEFunction{false, SciMLBase.FullSpecialize}(f1, f2; sys)
+    prob = DynamicalODEProblem(func, [1.0], [2.0], (0.0, 1.0), [3.0, 4.0])
+
+    @test remake(prob; v0 = [:v => 5.0]).u0 == ArrayPartition([5.0], [2.0])
+    @test remake(prob; u0 = [:u => 6.0]).u0 == ArrayPartition([1.0], [6.0])
+    @test remake(prob; v0 = [:v => 5.0], u0 = [:u => 6.0]).u0 ==
+        ArrayPartition([5.0], [6.0])
+    @test remake(prob; p = [:a => 7.0]).p == [7.0, 4.0]
+    @test_throws ArgumentError remake(prob; v0 = [5.0], u0 = [:u => 6.0])
 end

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -518,3 +518,56 @@ end
         @test prob4.ub === nothing
     end
 end
+
+@testset "`remake` `DynamicalODEProblem` with the additional argument" begin
+    f1! = function (dv, v, u, p, t)
+        dv[1] = -p[1] * u[1]
+    end
+    f2! = function (du, v, u, p, t)
+        du[1] = p[2] * v[1]
+    end
+    prob = DynamicalODEProblem(f1!, f2!, [1.0], [2.0], 3.0, [4.0, 5.0])
+    @test prob.u0 == ArrayPartition([1.0], [2.0])
+
+    # `remake` with no initial values override
+    prob2 = remake(prob; p = [6.0, 7.0])
+    @test prob2.u0 == ArrayPartition([1.0], [2.0])
+    @test prob2.p == [6.0, 7.0]
+
+    # `remake` v0 override
+    prob3 = remake(prob; v0 = [6.0])
+    @test prob3.u0 == ArrayPartition([6.0], [2.0])
+
+    # `remake` u0 override
+    prob4 = remake(prob; u0 = [6.0])
+    @test prob4.u0 == ArrayPartition([1.0], [6.0])
+
+    # `remake` v0 and u0 override
+    prob5 = remake(prob; v0 = [6.0], u0 = [7.0])
+    @test prob5.u0 == ArrayPartition([6.0], [7.0])
+end
+
+@testset "`remake` `SecondOrderODEProblem` with the additional argument" begin
+    f! = function (ddu, du, u, p, t)
+        ddu[1] = -p[1] * sin(u[1])
+    end
+    prob = SecondOrderODEProblem(f!, [1.0], [2.0], 3.0, [4.0])
+    @test prob.u0 == ArrayPartition([1.0], [2.0])
+
+    # `remake` with no initial values override
+    prob2 = remake(prob; p = [5.0])
+    @test prob2.u0 == ArrayPartition([1.0], [2.0])
+    @test prob2.p == [5.0]
+
+    # `remake` du0 override
+    prob3 = remake(prob; du0 = [5.0])
+    @test prob3.u0 == ArrayPartition([5.0], [2.0])
+
+    # `remake` u0 override
+    prob4 = remake(prob; u0 = [5.0])
+    @test prob4.u0 == ArrayPartition([1.0], [5.0])
+
+    # `remake` du0 and u0 override
+    prob5 = remake(prob; du0 = [5.0], u0 = [6.0])
+    @test prob5.u0 == ArrayPartition([5.0], [6.0])
+end


### PR DESCRIPTION
## Summary

This follows up #1548 and completes its structured ODE remake implementation.

- route DynamicalODEProblem and SecondOrderODEProblem remakes through the full ODEProblem remake pipeline
- preserve problem markers, in-place convention, specialization policy, nested ODEFunction metadata, widened type erasure, problem traits, kwargs, and initialization data
- support component initial-value changes, legacy packed ArrayPartition state, symbolic maps, parameter and tspan changes, raw component replacement, and full DynamicalODEFunction replacement
- preserve the existing second dynamics component when a full replacement omits it, including a wrapped nothing component
- normalize wrapped SecondOrderODEProblem constructors without resetting specialization or discarding metadata
- reject incompatible in-place replacements with an explicit ArgumentError

## Specialization coverage

The implementation covers AutoSpecialize, AutoDespecialize, AutoRespecialize, FullSpecialize, NoSpecialize, and FunctionWrapperSpecialize for both the outer DynamicalODEFunction and its component ODEFunctions.

FunctionWrapperSpecialize now has structured signature handling for both out-of-place and in-place components. Each component gets an exact wrapper for inference and a boxed fallback for valid state type changes such as automatic differentiation, without conflating the distinct component output types. Construction, no-op remake, raw component replacement, full replacement, heterogeneous state components, metadata preservation, and synthesized SecondOrder kinematics are covered. Wrapper construction uses the public FunctionWrappersWrappers v1 API.

## Attribution

This branch includes all three commits from #1548 with their original authorship retained for @PositroniumJS. The three completion commits build on that work to cover ordinary ODEProblem remake behavior, every specialization policy, metadata and type-erasure preservation, initialization, public wrapper construction, and regression cases.

## Validation

- GROUP=SII_Remake julia --project=. --startup-file=no -e "using Pkg; Pkg.test()": 4,605 passed
- GROUP=QA julia --project=. --startup-file=no -e "using Pkg; Pkg.test()": 51 passed
- julia --project=. --startup-file=no -e "using Pkg; Pkg.test()": full SciMLBase suite passed, including Remake 4,605 / 4,605
- Runic.jl 1.9.0 across the repository: clean
- git diff --check: clean
- independent Julia 1.10 focused audit: 4,605 / 4,605, with no method ambiguities detected

## Process

I audited #1548, #1523, #106, the relevant historical remake changes, current constructor and remake internals, and downstream specialization behavior. I used the original commits as the base, then added focused regression coverage before completing the implementation.

Closes #106
Closes #1523
