### PR TITLE
Fix the CommonSolve link in the reexport docs

### DIFF
--- a/docs/src/interfaces/Reexported_API.md
+++ b/docs/src/interfaces/Reexported_API.md
@@ -69,7 +69,7 @@ omissions:
 ## CommonSolve
 
 The solve verbs `solve`, `solve!`, `init` and `step!` are owned by
-[CommonSolve.jl](https://github.com/JuliaLang/CommonSolve.jl). SciMLBase defines the SciML
+[CommonSolve.jl](https://github.com/SciML/CommonSolve.jl). SciMLBase defines the SciML
 methods on them and re-exports them, since they are the SciML solve interface as users and
 solver packages write it. See [The SciML init and solve Functions](@ref) for the SciML contract on
 these functions.


### PR DESCRIPTION
This stacked PR fixes the owning-package link added by the parent reexport remediation. The parent currently links to `JuliaLang/CommonSolve.jl`, which returns 404; the corrected `SciML/CommonSolve.jl` URL returns HTTP 200.

Parent PR: https://github.com/SciML/SciMLBase.jl/pull/1550

Ignore this PR until reviewed by @ChrisRackauckas.

## Verification

- `curl -L -sS -o /dev/null -w '%{http_code}' https://github.com/SciML/CommonSolve.jl` → `200`.
- `GROUP=Core ~/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` → `Testing SciMLBase tests passed` (including `Remake | 4430 / 4430`).
- `GROUP=QA JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 ~/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` → `QA | 123 / 123`, `Testing SciMLBase tests passed`.
- `~/.juliaup/bin/julia +release --project=docs docs/make.jl` → exit 0 after doctests, cross-references, checks, and HTML rendering.
- `~/.juliaup/bin/julia +release -m Runic --check <all changed Julia files in the parent diff>` → exit 0.
- `typos <all changed files in the parent diff>` → exit 0.
- Minimal floor check: SciMLOperators 1.18.0 is missing `BlockDiagonalOperator`, `TensorSumOperator`, and `kronsum`; 1.19.0 is missing `Symbol[]`.

This PR contains only the one-line URL correction and is based directly on the current upstream head of the parent feature branch (`0136b24e`).

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ