### PR TITLE
Use Optim owner namespace in downstream tests

### DIFF
--- a/test/downstream/comprehensive_indexing.jl
+++ b/test/downstream/comprehensive_indexing.jl
@@ -1,7 +1,8 @@
 using ModelingToolkit, JumpProcesses, LinearAlgebra, NonlinearSolve, Optimization,
-    OptimizationOptimJL, OrdinaryDiffEq, RecursiveArrayTools, SciMLBase,
+    OrdinaryDiffEq, RecursiveArrayTools, SciMLBase,
     SteadyStateDiffEq, StochasticDiffEq, DelayDiffEq, SymbolicIndexingInterface,
     DiffEqCallbacks, Test, Plots
+using OptimizationOptimJL: Optim
 import Symbolics
 import SymbolicUtils as SU
 import Makie
@@ -109,7 +110,7 @@ begin
     jsol = solve(jprob, SSAStepper(); seed)
     nsol = solve(nprob, NewtonRaphson())
     sssol = solve(ssprob, DynamicSS(Tsit5()))
-    optsol = solve(optprob, GradientDescent())
+    optsol = solve(optprob, Optim.GradientDescent())
     sols = [osol, ssol, jsol, nsol, sssol, optsol]
 end
 

--- a/test/downstream/ensemble_nondes.jl
+++ b/test/downstream/ensemble_nondes.jl
@@ -1,4 +1,5 @@
-using Optimization, OptimizationOptimJL, ForwardDiff, SciMLBase, Test
+using Optimization, ForwardDiff, SciMLBase, Test
+using OptimizationOptimJL: Optim
 
 x0 = zeros(2)
 rosenbrock(x, p = nothing) = (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
@@ -6,20 +7,20 @@ l1 = rosenbrock(x0)
 
 optf = OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())
 prob = OptimizationProblem(optf, x0)
-sol1 = Optimization.solve(prob, OptimizationOptimJL.BFGS(), maxiters = 5)
+sol1 = Optimization.solve(prob, Optim.BFGS(), maxiters = 5)
 
 ensembleprob = Optimization.EnsembleProblem(
     prob, [x0, x0 .+ rand(2), x0 .+ rand(2), x0 .+ rand(2)]
 )
 
 sol = Optimization.solve(
-    ensembleprob, OptimizationOptimJL.BFGS(),
+    ensembleprob, Optim.BFGS(),
     EnsembleThreads(), trajectories = 4, maxiters = 5
 )
 @test findmin(i -> sol.u[i].objective, 1:4)[1] <= sol1.objective
 
 sol = Optimization.solve(
-    ensembleprob, OptimizationOptimJL.BFGS(),
+    ensembleprob, Optim.BFGS(),
     EnsembleDistributed(), trajectories = 4, maxiters = 5
 )
 @test findmin(i -> sol.u[i].objective, 1:4)[1] <= sol1.objective
@@ -30,13 +31,13 @@ ensembleprob = Optimization.EnsembleProblem(
 )
 
 sol = Optimization.solve(
-    ensembleprob, OptimizationOptimJL.BFGS(),
+    ensembleprob, Optim.BFGS(),
     EnsembleThreads(), trajectories = 5, maxiters = 5
 )
 @test findmin(i -> sol.u[i].objective, 1:4)[1] <= sol1.objective
 
 sol = Optimization.solve(
-    ensembleprob, OptimizationOptimJL.BFGS(),
+    ensembleprob, Optim.BFGS(),
     EnsembleDistributed(), trajectories = 5, maxiters = 5
 )
 @test findmin(i -> sol.u[i].objective, 1:4)[1] <= sol1.objective

--- a/test/downstream/ensemble_rng.jl
+++ b/test/downstream/ensemble_rng.jl
@@ -1,6 +1,7 @@
 using Test, Random, SciMLBase, Distributed
 using OrdinaryDiffEq, StochasticDiffEq, JumpProcesses, StableRNGs
-using NonlinearSolve, Optimization, OptimizationOptimJL, ForwardDiff
+using NonlinearSolve, Optimization, ForwardDiff
+using OptimizationOptimJL: Optim
 
 # ============================================================
 # Problem definitions for each solver pathway
@@ -548,14 +549,14 @@ end
 
         # Ensemble solve with seed succeeds (rng is NOT forwarded)
         sim1 = Optimization.solve(
-            opt_eprob, OptimizationOptimJL.BFGS(),
+            opt_eprob, Optim.BFGS(),
             EnsembleSerial(); seed = UInt64(42), trajectories = 4, maxiters = 10,
         )
         @test length(sim1.u) == 4
 
         # Reproducibility via TaskLocalRNG seeding
         sim2 = Optimization.solve(
-            opt_eprob, OptimizationOptimJL.BFGS(),
+            opt_eprob, Optim.BFGS(),
             EnsembleSerial(); seed = UInt64(42), trajectories = 4, maxiters = 10,
         )
         @test endpoints(sim1) == endpoints(sim2)

--- a/test/downstream/modelingtoolkit_remake.jl
+++ b/test/downstream/modelingtoolkit_remake.jl
@@ -5,7 +5,7 @@ using ModelingToolkit: t_nounits as t, D_nounits as D
 using OrdinaryDiffEq
 using DiffEqNoiseProcess
 using Optimization
-using OptimizationOptimJL
+using OptimizationOptimJL: Optim
 using ForwardDiff
 using SciMLStructures
 using Test
@@ -298,7 +298,7 @@ end
 
 f = OptimizationFunction(loss, Optimization.AutoForwardDiff())
 prob = OptimizationProblem(f, [0.5], [odeprob])
-sol = solve(prob, BFGS())
+sol = solve(prob, Optim.BFGS())
 @test sol.u[1] ≈ 2.5 rtol = 1.0e-4
 
 # Issue ModelingToolkit.jl#2637


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

OptimizationOptimJL 0.4.19 stopped exporting individual Optim algorithms and retained `Optim` as its public owner namespace. SciMLBase's SymbolicIndexingInterface downstream tests still used bare `GradientDescent` and `BFGS`, including accesses forwarded through the non-owner `OptimizationOptimJL` module. The four affected test files now import `Optim` explicitly and construct the algorithms through their public owner.

The export boundary is https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af from https://github.com/SciML/Optimization.jl/pull/1307. The clean-master failure was observed in the ModelingToolkit downstream job https://github.com/SciML/ModelingToolkit.jl/actions/runs/32902120637/job/97978099748.

## Verification

Failing before on unmodified SciMLBase master (`d3a30e5d6c5480b7b557a9e7e5f0ef69ed4a10b7`):

```text
$ GROUP=SymbolicIndexingInterface julia +release --project=. -e 'using Pkg; Pkg.test()'
Remake | 4430 pass
UndefVarError: `GradientDescent` not defined
Symbol and integer based indexing of interpolated solutions | 1 error
```

Passing after with the same full group command:

```text
Remake | 4430 pass
Symbol and integer based indexing of interpolated solutions | 3777 pass
Symbol and integer based indexing of integrators | 98 pass
Problem Indexing | 122 pass
Adjoints | 5 broken
ModelingToolkit Remake | 248 pass, 3 broken
Testing SciMLBase tests passed
```

The branch was then rebased onto current master (`d7d34ba7d79db7d7c3997f2bc8e99553a199e655`), which changed the remake implementation and added 518 remake tests, and the full group was repeated:

```text
Remake | 4605 pass
Symbol and integer based indexing of interpolated solutions | 3777 pass
Symbol and integer based indexing of integrators | 98 pass
Problem Indexing | 122 pass
Adjoints | 5 broken
ModelingToolkit Remake | 248 pass, 3 broken
Testing SciMLBase tests passed

$ GROUP=Downstream julia +release --project=. -e 'using Pkg; Pkg.test()'
Ensemble Optimization and Nonlinear problems | 4 pass
Ensemble RNG reproducibility | 170 pass
Solution Indexing | 277 pass
Initialization | 83 pass
Testing SciMLBase tests passed
```

```text
$ GROUP=QA julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   51     51  3m22.6s
Testing SciMLBase tests passed

$ julia +release -m Runic --check test/downstream/comprehensive_indexing.jl test/downstream/modelingtoolkit_remake.jl test/downstream/ensemble_nondes.jl test/downstream/ensemble_rng.jl
# exit 0

$ typos test/downstream/comprehensive_indexing.jl test/downstream/modelingtoolkit_remake.jl test/downstream/ensemble_nondes.jl test/downstream/ensemble_rng.jl
# exit 0

$ git diff --check
# exit 0
```

No package behavior, public API, documentation, or dependency changed. GPU and other downstream groups were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
