### PR TITLE
Add ODEFunction specialization constructor route

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.49.3"
+version = "3.50.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -377,11 +377,20 @@ ODEFunction{iip,specialize}(f;
                            vjp_p = __has_vjp_p(f) ? f.vjp_p : nothing,
                            colorvec = __has_colorvec(f) ? f.colorvec : nothing,
                            sys = __has_sys(f) ? f.sys : nothing)
+
+ODEFunction{iip,specialize}(f::ODEFunction; kwargs...)
 ```
 
 Note that only the function `f` itself is required. This function should
 be given as `f!(du,u,p,t)` or `du = f(u,p,t)`. See the section on `iip`
 for more details on in-place vs out-of-place handling.
+
+The fully parameterized constructor can also change the specialization of an existing
+`ODEFunction`. It preserves the stored callable and fields, with keyword arguments taking
+priority. Converting to `AutoSpecialize`, `AutoDespecialize`, or `AutoRespecialize` widens
+the bounded initialization and nonlinear-step metadata types so model-specific metadata
+does not defeat compilation reuse. Construction from a raw callable retains concrete
+metadata types.
 
 All of the remaining functions are optional for improving or accelerating
 the usage of `f`. These include:
@@ -3086,12 +3095,14 @@ function ODEFunction{iip, specialize}(
         iip,
         specialize,
     }
-    if mass_matrix === I && f isa Tuple
-        mass_matrix = ((I for i in 1:length(f))...,)
+    callable = f isa ODEFunction ? f.f : f
+
+    if mass_matrix === I && callable isa Tuple
+        mass_matrix = ((I for i in 1:length(callable))...,)
     end
 
     if (specialize === FunctionWrapperSpecialize) &&
-            !(f isa FunctionWrappersWrappers.FunctionWrappersWrapper)
+            !(callable isa FunctionWrappersWrappers.FunctionWrappersWrapper)
         error("FunctionWrapperSpecialize must be used on the problem constructor for access to u0, p, and t types!")
     end
 
@@ -3129,7 +3140,7 @@ function ODEFunction{iip, specialize}(
         throw(NonconformingFunctionsError(functions))
     end
 
-    _f = prepare_function(f)
+    _f = f isa ODEFunction ? callable : prepare_function(callable)
 
 
     initdata = reconstruct_initialization_data(
@@ -3172,6 +3183,13 @@ function ODEFunction{iip, specialize}(
             observed, _colorvec, sys, initdata, nlstep_data
         )
     else
+        widen_metadata = f isa ODEFunction &&
+            (
+            specialize === AutoSpecialize || specialize === AutoDespecialize ||
+                specialize === AutoRespecialize
+        )
+        initdata_type = widen_metadata ? Union{Nothing, OverrideInitData} : typeof(initdata)
+        nlstep_data_type = widen_metadata ? Union{Nothing, ODENLStepData} : typeof(nlstep_data)
         ODEFunction{
             iip, specialize,
             typeof(_f), typeof(mass_matrix), typeof(analytic), typeof(tgrad),
@@ -3181,7 +3199,7 @@ function ODEFunction{iip, specialize}(
             typeof(vjp_p),
             typeof(observed),
             typeof(_colorvec),
-            typeof(sys), typeof(initdata), typeof(nlstep_data),
+            typeof(sys), initdata_type, nlstep_data_type,
         }(
             _f, mass_matrix, analytic, tgrad,
             jac, jvp, vjp, jac_prototype, sparsity, Wfact,

--- a/test/function_building_error_messages.jl
+++ b/test/function_building_error_messages.jl
@@ -24,6 +24,13 @@ f = Foo{1}()
 (this::Foo{T})(args...) where {T} = 1
 @test SciMLBase.isinplace(Foo{Int}(), 4)
 
+struct PreparedODEConstructorRHS
+    stage::Int
+end
+(f::PreparedODEConstructorRHS)(u, p, t) = u
+SciMLBase.prepare_function(f::PreparedODEConstructorRHS) =
+    PreparedODEConstructorRHS(f.stage + 1)
+
 @testset "isinplace for FunctionWrappersWrapper" begin
     using FunctionWrappersWrappers
 
@@ -74,6 +81,59 @@ end
     for fname in fieldnames(typeof(f))
         @test getfield(f, fname) === getfield(widened, fname)
     end
+end
+
+@testset "ODEFunction specialization constructor" begin
+    rhs = (u, p, t) -> u
+    initdata = SciMLBase.OverrideInitData(
+        NonlinearProblem((u, p) -> u, [0.0]), nothing, identity, nothing
+    )
+    nlstep_data = SciMLBase.ODENLStepData(
+        NonlinearProblem((z, p) -> z, [1.0]), identity,
+        (gamma1, gamma2, c) -> nothing, identity, identity, identity
+    )
+    initdata_type = Union{Nothing, SciMLBase.OverrideInitData}
+    nlstep_data_type = Union{Nothing, SciMLBase.ODENLStepData}
+    original = ODEFunction{false, SciMLBase.FullSpecialize}(
+        rhs; initialization_data = initdata, nlstep_data
+    )
+
+    for specialize in (
+            SciMLBase.AutoSpecialize,
+            SciMLBase.AutoDespecialize,
+            SciMLBase.AutoRespecialize,
+        )
+        respecialized = ODEFunction{false, specialize}(original)
+        @test SciMLBase.specialization(respecialized) === specialize
+        @test respecialized.f === rhs
+        @test fieldtype(typeof(respecialized), :initialization_data) === initdata_type
+        @test fieldtype(typeof(respecialized), :nlstep_data) === nlstep_data_type
+        for field in fieldnames(typeof(original))
+            @test getfield(respecialized, field) === getfield(original, field)
+        end
+    end
+
+    auto = SciMLBase.widen_bounded_type_params(
+        ODEFunction{false, SciMLBase.AutoSpecialize}(
+            rhs; initialization_data = initdata, nlstep_data
+        )
+    )
+    rebuilt = ODEFunction{false, SciMLBase.AutoSpecialize}(auto; sys = :replacement)
+    @test rebuilt.f === rhs
+    @test rebuilt.sys === :replacement
+    @test fieldtype(typeof(rebuilt), :initialization_data) === initdata_type
+    @test fieldtype(typeof(rebuilt), :nlstep_data) === nlstep_data_type
+
+    full = ODEFunction{false, SciMLBase.FullSpecialize}(auto)
+    @test full.f === rhs
+    @test fieldtype(typeof(full), :initialization_data) === typeof(initdata)
+    @test fieldtype(typeof(full), :nlstep_data) === typeof(nlstep_data)
+
+    prepared = ODEFunction{false, SciMLBase.FullSpecialize}(PreparedODEConstructorRHS(0))
+    @test prepared.f.stage == 1
+    prepared_auto = @inferred ODEFunction{false, SciMLBase.AutoSpecialize}(prepared)
+    @test prepared_auto.f === prepared.f
+    @test prepared_auto.f.stage == 1
 end
 
 @testset "isinplace accepts an out-of-place version with different numbers of parameters " begin


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

The fully parameterized `ODEFunction{iip, specialize}` constructor can now accept an existing `ODEFunction` as an explicit specialization-conversion route. It reuses the stored callable instead of nesting or re-preparing the wrapper, preserves fields and keyword overrides, and widens bounded initialization/nonlinear-step metadata when the target is `AutoSpecialize`, `AutoDespecialize`, or `AutoRespecialize`.

Direct construction from a raw callable remains concrete, preserving the inference behavior restored by https://github.com/SciML/SciMLBase.jl/pull/1242. The constructor route and its specialization behavior are documented, and the minor version is bumped to 3.50.0 for the public API addition. This closes https://github.com/SciML/SciMLBase.jl/issues/1551.

## Verification

### Bug discriminator: failing before

With only the new regression test applied to unmodified `master`:

```text
$ julia +1.12 --project=. test/function_building_error_messages.jl
Test Summary:                          | Pass  Fail  Total  Time
ODEFunction specialization constructor |   60    16     76  3.8s
ERROR: LoadError: Some tests did not pass: 60 passed, 16 failed, 0 errored, 0 broken.
```

The failures showed both defects: `respecialized.f` was the entire source `ODEFunction` rather than its callable, and `initialization_data`/`nlstep_data` had concrete field types instead of the bounded unions.

### Same test passing after

```text
$ julia +1.12 --project=. test/function_building_error_messages.jl
Test Summary:                          | Pass  Total  Time
ODEFunction specialization constructor |   79     79  0.6s
```

The added assertions cover all three automatic specialization targets, every preserved field by identity, keyword overrides, conversion back to `FullSpecialize`, type inference, and avoiding a second `prepare_function` call.

### Required local gates

```text
$ GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                    | Pass  Total   Time
Function Building Error Messages |  402    402  28.8s
Test Summary: | Pass  Total     Time
Remake        | 4605   4605  3m42.3s
Testing SciMLBase tests passed

$ PIXI_CACHE_DIR=$PWD/../validation_cache/pixi \
  RATTLER_CACHE_DIR=$PWD/../validation_cache/pixi \
  GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |  123    123  2m45.2s
Testing SciMLBase tests passed

$ julia +1.12 --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
exit code 0

$ julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(["--check", "."]))'
Runic 1.7.0
exit code 0

$ typos Project.toml src/scimlfunctions.jl test/function_building_error_messages.jl
exit code 0
```

The first post-rebase Julia 1.12 QA attempt exposed a corrupt machine-wide CondaPkg cache containing 1,552 zero-byte CPython standard-library files. The identical 9-pass/1-error Python codec failure reproduced twice on clean `master` and in standalone PythonCall. Clean `master` and this branch both passed the full 123-test QA group with the workspace-local cache shown above; no test was skipped or weakened.

### ModelingToolkit issue reproducer

The issue's SCC-initialization system was rebuilt using the new constructor route:

```text
constructor route preserved AutoSpecialize metadata layout
Union{Nothing, SciMLBase.OverrideInitData}
Union{Nothing, SciMLBase.ODENLStepData}
```

The check also asserted that `remake(native; f = rebuilt)` preserves the rebuilt `ODEFunction` type.

## What I did not verify

- `GROUP=Everything`, downstream integration groups, Julia pre-release, and GPU jobs were not run locally.
- No Enzyme timing benchmark was repeated; this PR verifies the type layout that controls the reported compile-time behavior, not the workload-specific timing numbers.

## Reviewer judgment calls

- The route widens bounded metadata for `AutoRespecialize` as well as `AutoSpecialize` and `AutoDespecialize`. Model-specific initialization metadata would otherwise defeat the cross-parameter-type compilation reuse that `AutoRespecialize` promises.
- Calling the fully parameterized constructor with an existing `ODEFunction` now means specialization conversion instead of nesting the wrapper as the new RHS. The previous nesting behavior is the bug exposed by the regression and is not retained as a compatibility path.

## Links

- Issue: https://github.com/SciML/SciMLBase.jl/issues/1551
- Prior inference fix: https://github.com/SciML/SciMLBase.jl/pull/1242
- Closed alternate `respecialize` API: https://github.com/SciML/SciMLBase.jl/pull/1553
- Rebased implementation commit: https://github.com/SciML/SciMLBase.jl/pull/1557/commits/d40204e98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03c36-0ac6-7311-82e4-20b12ea6f040
