### PR TITLE
Format SplitFunction test constructors

### DIFF
--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -79,8 +79,8 @@ end
     f2! = (du, u, p, t) -> (du .= u)
 
     for build in (
-            (u0,) -> SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-            (u0,) -> ODEProblem(SplitFunction(f1!, f2!), u0, (0.0, 1.0)),
+            (u0) -> SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+            (u0) -> ODEProblem(SplitFunction(f1!, f2!), u0, (0.0, 1.0)),
         )
         u0 = [1.0, 2.0]
         prob = build(u0)


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Runic currently fails on upstream `master` because the SplitFunction cache regression test uses tuple-style syntax for two single-argument anonymous functions. This formatting-only change applies Runic's canonical `(u0) ->` syntax and restores the repository format check without changing test behavior.

`git bisect run` identified `8b2eb5ad29ea141890c3d222746cd8cb74241afb` as the first bad commit.

## Verification

Failure reproduced on clean upstream `master`:

```text
$ julia +1.12 --project=../tmp/runic_env -e 'using Runic; exit(Runic.main(["--check", "--diff", "test/problem_building_test.jl"]))'
-            (u0,) -> SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
-            (u0,) -> ODEProblem(SplitFunction(f1!, f2!), u0, (0.0, 1.0)),
+            (u0) -> SplitODEProblem(f1!, f2!, u0, (0.0, 1.0)),
+            (u0) -> ODEProblem(SplitFunction(f1!, f2!), u0, (0.0, 1.0)),
RUNIC_MASTER_EXIT=1
```

Passing after this change:

```text
$ julia +1.12 --project=../tmp/runic_env -e 'using Runic; println("Runic version: ", pkgversion(Runic)); exit(Runic.main(["--check", "--diff", "."]))'
Runic version: 1.9.0
RUNIC_REPOSITORY_EXIT=0

$ typos .
TYPOS_EXIT=0

$ git diff --check
GIT_DIFF_CHECK_EXIT=0

$ GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   51     51  3m17.8s
Testing SciMLBase tests passed

$ GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:          | Pass  Total  Time
Problem building tests |  135    135  6.9s
Testing SciMLBase tests passed
```

## Not verified

The docs build was not run because this mechanical-only change does not touch documentation, docstrings, or public API. `Everything`, downstream, GPU, and Julia pre-release groups were not run.

## Links

- Failing upstream job: https://github.com/SciML/SciMLBase.jl/actions/runs/32941912234/job/98094428748
- Introducing PR: https://github.com/SciML/SciMLBase.jl/pull/1520
- Introducing commit: https://github.com/SciML/SciMLBase.jl/commit/8b2eb5ad29ea141890c3d222746cd8cb74241afb

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03c36-0ac6-7311-82e4-20b12ea6f040
