### PR TITLE
Make NonlinearSolution's retcode field type a parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.50.0"
+version = "3.51.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/retcodes.jl
+++ b/src/retcodes.jl
@@ -491,3 +491,6 @@ function successful_retcode(retcode::ReturnCode.T)
         retcode == ReturnCode.StalledSuccess
 end
 successful_retcode(sol::AbstractSciMLSolution) = successful_retcode(sol.retcode)
+# Return codes carried by other scalar types (e.g. a Reactant `ConcreteRNumber`) are
+# converted first.
+successful_retcode(retcode) = successful_retcode(convert(ReturnCode.T, retcode))

--- a/src/solutions/nonlinear_solutions.jl
+++ b/src/solutions/nonlinear_solutions.jl
@@ -62,13 +62,13 @@ or the steady state solution to a differential equation defined by a SteadyState
   - `right`: if the solver is bracketing method, this is the final right bracket value.
   - `stats`: statistics of the solver, such as the number of function evaluations required.
 """
-struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr} <:
+struct NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr, RC} <:
     AbstractNonlinearSolution{T, N}
     u::uType
     resid::R
     prob::P
     alg::A
-    retcode::ReturnCode.T
+    retcode::RC
     original::O
     left::uType2
     right::uType2
@@ -82,7 +82,7 @@ function NonlinearSolution(u, resid, prob, alg, retcode, original, left, right, 
 
     return NonlinearSolution{
         T, N, typeof(u), typeof(resid), typeof(prob), typeof(alg),
-        typeof(original), typeof(left), typeof(stats), typeof(trace),
+        typeof(original), typeof(left), typeof(stats), typeof(trace), typeof(retcode),
     }(
         u, resid, prob, alg,
         retcode, original, left, right, stats, trace

--- a/test/solution_interface.jl
+++ b/test/solution_interface.jl
@@ -265,7 +265,7 @@ end
     resid = [0.0, 0.0]
     nlsol = SciMLBase.NonlinearSolution{
         Float64, 1, typeof(u), typeof(resid), Nothing, Nothing,
-        Any, Nothing, Nothing, Nothing,
+        Any, Nothing, Nothing, Nothing, SciMLBase.ReturnCode.T,
     }(
         u, resid, nothing, nothing, SciMLBase.ReturnCode.Success, [0.1, 0.2],
         nothing, nothing, nothing, nothing


### PR DESCRIPTION
> Draft. Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

`NonlinearSolution.retcode` was declared `::ReturnCode.T`. Inside a Reactant-compiled solve the return code is a traced enum (`TracedRNumber{ReturnCode.T}`, https://github.com/EnzymeAD/Reactant.jl/pull/3232), and a concretely typed field cannot hold it: Reactant rebuilds structs with traced field types and raises `NoFieldMatchError` for fixed ones. This makes the field `retcode::RC` with `RC` appended to the type parameters. `build_solution` and the positional `NonlinearSolution(u, resid, prob, alg, retcode, ...)` constructor are unchanged for callers; on the host `RC === ReturnCode.T` exactly as before.

`successful_retcode(retcode)` gains a fallback that converts other scalar carriers of a return code (a Reactant `ConcreteRNumber{ReturnCode.T}` after the compiled call) to `ReturnCode.T` first, so `successful_retcode(sol)` keeps working on such solutions.

This is the SciMLBase half of letting NonlinearSolve solvers run under `Reactant.@jit` without a shadow solution type (SciML/NonlinearSolve.jl#1197).

## Compatibility — this is breaking for released NonlinearSolve until its constructors are released

Appending a type parameter is only visible to code that spells out all of `NonlinearSolution`'s parameters. A GitHub code search over the SciML org finds three such sites, all in NonlinearSolve.jl: `build_solution_less_specialize` (`lib/NonlinearSolveBase/src/polyalg.jl`), `SCCNonlinearSolve`, and `nonlinear_solution_new_alg` (`lib/SimpleNonlinearSolve/src/utils.jl`). The **released** versions of those packages therefore fail to precompile against this branch, which is what the red Documentation and downstream lanes here show (`MethodError: no method matching (NonlinearSolution{...10 parameters...})(...)` from `build_solution_less_specialize`).

The fix on the NonlinearSolve side is small and works with both layouts (it picks the layout at load time from `fieldtype(NonlinearSolution, :retcode)`). It was carved out as https://github.com/SciML/NonlinearSolve.jl/pull/1214, which was closed; it remains part of https://github.com/SciML/NonlinearSolve.jl/pull/1197. Until a NonlinearSolveBase/SCCNonlinearSolve/SimpleNonlinearSolve release carries it, this PR breaks the released NonlinearSolve, which is what the downstream lanes here show. Given that, whether this is a minor (3.51.0, as set) or a major bump is the reviewer's call; nothing else in the org constructs `NonlinearSolution` with explicit parameters.

## Verification

```
$ julia --project=. -e 'using Pkg; Pkg.test()'    # default group, Julia 1.12.4
     Testing SciMLBase tests passed
```
(The explicit-parameter construction in `test/solution_interface.jl` is updated and the `@inferred solution_new_original_retcode` check there passes.)

Formatted with Runic 1.10.0; `typos` clean on the changed files.

## Not verified

- Downstream packages other than NonlinearSolve.jl (the companion PR runs its Reactant group against this branch).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5) on behalf of Chris Rackauckas. Session: https://claude.ai/code/session_016LsC6pp9z6s5EABX9DnVjE
