### PR TITLE
Format for Runic v1.10

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -173,9 +173,9 @@ function ChainRulesCore.rrule(
     function EnsembleSolution_adjoint(p̄::AbstractArray{T, N}) where {T, N}
         arrarr = [
             [
-                    p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
+                p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
                     for j in 1:size(p̄)[end - 1]
-                ] for i in 1:size(p̄)[end]
+            ] for i in 1:size(p̄)[end]
         ]
         return (
             NoTangent(),

--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -289,10 +289,10 @@ function Makie.convert_arguments(
         if plot_analytic
             plot_analytic_timeseries = [
                 integrator.sol.prob.f.analytic(
-                        integrator.sol.prob.u0,
-                        integrator.sol.prob.p,
-                        t
-                    ) for t in plott
+                    integrator.sol.prob.u0,
+                    integrator.sol.prob.p,
+                    t
+                ) for t in plott
             ]
         end
     else
@@ -384,11 +384,11 @@ function Makie.convert_arguments(
     return if denseplot
         [
             Makie.PlotSpec(
-                    plot_type_sym,
-                    Point2f.(plot_vecs[1][idx], plot_vecs[2][idx]);
-                    label,
-                    color = Makie.Cycled(idx)
-                )
+                plot_type_sym,
+                Point2f.(plot_vecs[1][idx], plot_vecs[2][idx]);
+                label,
+                color = Makie.Cycled(idx)
+            )
                 for (idx, label) in zip(1:length(plot_vecs[1]), labels)
         ]
     else
@@ -444,16 +444,16 @@ function Makie.convert_arguments(
 
     mp = [
         PlotSpec(
-                plot_type_sym,
-                sim.u[i];
-                plot_analytic,
-                denseplot,
-                plotdensity,
-                plotat,
-                tspan,
-                tscale,
-                idxs
-            ) for i in trajectories
+            plot_type_sym,
+            sim.u[i];
+            plot_analytic,
+            denseplot,
+            plotdensity,
+            plotat,
+            tspan,
+            tscale,
+            idxs
+        ) for i in trajectories
     ]
 
     # Main.Infiltrator.@infiltrate
@@ -503,9 +503,9 @@ function Makie.convert_arguments(
                 VectorOfArray(
                     [
                         sqrt.(
-                                sim.v.u[i] /
+                            sim.v.u[i] /
                                 sim.num_monte
-                            ) .*
+                        ) .*
                             1.96
                             for i in 1:length(sim.v)
                     ]

--- a/ext/SciMLBaseZygoteExt.jl
+++ b/ext/SciMLBaseZygoteExt.jl
@@ -80,9 +80,9 @@ end
     function EnsembleSolution_adjoint(p̄::AbstractArray{T, N}) where {T, N}
         arrarr = [
             [
-                    p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
+                p̄[ntuple(x -> Colon(), Val(N - 2))..., j, i]
                     for j in 1:size(p̄)[end - 1]
-                ] for i in 1:size(p̄)[end]
+            ] for i in 1:size(p̄)[end]
         ]
         (EnsembleSolution(arrarr, 0.0, true, stats), nothing, nothing, nothing)
     end

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -219,12 +219,12 @@ function calculate_ensemble_errors(
         densetimes = collect(range(u[1].t[1], stop = u[1].t[end], length = 100))
         u_analytic = [
             [
-                    sol.prob.f.analytic(
-                        sol.prob.u0, sol.prob.p, densetimes[i],
-                        sol.W(densetimes[i])[1]
-                    )
+                sol.prob.f.analytic(
+                    sol.prob.u0, sol.prob.p, densetimes[i],
+                    sol.W(densetimes[i])[1]
+                )
                     for i in eachindex(densetimes)
-                ] for sol in u
+            ] for sol in u
         ]
 
         udense = [u[j](densetimes) for j in 1:length(u)]

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1166,10 +1166,10 @@ Base.IteratorSize(::Type{<:DEIntegrator}) = Base.SizeUnknown()
         if plot_analytic
             plot_analytic_timeseries = [
                 integrator.sol.prob.f.analytic(
-                        integrator.sol.prob.u0,
-                        integrator.sol.prob.p,
-                        t
-                    ) for t in plott
+                    integrator.sol.prob.u0,
+                    integrator.sol.prob.p,
+                    t
+                ) for t in plott
             ]
         end
     else

--- a/src/solutions/solution_interface.jl
+++ b/src/solutions/solution_interface.jl
@@ -506,9 +506,9 @@ function diffeq_to_arrays(
             if sol.prob.f isa Tuple
                 plot_analytic_timeseries = [
                     sol.prob.f[1].analytic(
-                            sol.prob.u0, sol.prob.p,
-                            t
-                        ) for t in plott
+                        sol.prob.u0, sol.prob.p,
+                        t
+                    ) for t in plott
                 ]
             else
                 plot_analytic_timeseries = [

--- a/test/ensemble_tests.jl
+++ b/test/ensemble_tests.jl
@@ -45,8 +45,8 @@ mx, my,
     vals = [[1.0, 2.0, 4.0], [2.0, 3.0, 5.0], [4.0, 7.0, 11.0]]
     sols = [
         SciMLBase.build_solution(
-                prob, :NoAlgorithm, ts, u; retcode = SciMLBase.ReturnCode.Success
-            )
+            prob, :NoAlgorithm, ts, u; retcode = SciMLBase.ReturnCode.Success
+        )
             for u in vals
     ]
     sim = EnsembleSolution(sols, 0.0, true)
@@ -84,8 +84,8 @@ end
     ]
     sols = [
         SciMLBase.build_solution(
-                prob, :NoAlgorithm, ts, u; retcode = SciMLBase.ReturnCode.Success
-            )
+            prob, :NoAlgorithm, ts, u; retcode = SciMLBase.ReturnCode.Success
+        )
             for u in vals
     ]
     sim = EnsembleSolution(sols, 0.0, true)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `603f22f2b801`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff --check
[exit 0]
$ typos ext/SciMLBaseChainRulesCoreExt.jl ext/SciMLBaseMakieExt.jl ext/SciMLBaseZygoteExt.jl src/ensemble/ensemble_solutions.jl src/integrator_interface.jl src/solutions/solution_interface.jl test/ensemble_tests.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA | 123 pass, 123 total
Testing SciMLBase tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Remake | 4605 pass, 4605 total
Testing SciMLBase tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source, extension, and test diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
