### PR TITLE
Handle despecialized parameter cotangents in ODE solution AD

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -37,6 +37,9 @@ function ChainRulesCore.rrule(
             if dp == NoTangent()
                 dp = zero_tangent(parameter_values(VA.prob))
             end
+            if dp isa ChainRulesCore.Tangent{<:SciMLBase.DespecializedParameters}
+                dp = dp.params
+            end
             dprob = remake(VA.prob, p = dp)
             du, dprob
         else

--- a/test/downstream/remake_autodiff.jl
+++ b/test/downstream/remake_autodiff.jl
@@ -1,4 +1,5 @@
 using OrdinaryDiffEq, ModelingToolkit, SciMLSensitivity
+using ChainRulesCore
 using SymbolicIndexingInterface
 using ModelingToolkit: t_nounits as t, D_nounits as D
 using Test
@@ -117,6 +118,11 @@ if VERSION < v"1.12"
         sys = mtkcompile(lotka_volterra_sys; split)
         prob = ODEProblem(sys, [], (0.0, 10.0))
         sol = solve(prob, Tsit5(), reltol = 1.0e-6, abstol = 1.0e-6)
+        @testset "Despecialized parameter cotangent remake" begin
+            _, pullback = ChainRulesCore.rrule(getindex, sol, x, 1)
+            cotangent = pullback(one(sol[x, 1]))[2]
+            @test cotangent.prob.p isa SciMLBase.DespecializedParameters
+        end
         setter = setsym_oop(prob, [unknowns(sys); parameters(sys)])
         u0, p = setter(prob, [1.0, 1.0, 1.5, 1.0, 1.0, 1.0])
 


### PR DESCRIPTION
## What changed

ChainRulesCore returns `Tangent{DespecializedParameters}` for the parameter cotangent produced by the symbolic ODESolution pullback. Unwrap this cotangent before calling `remake`, and add a regression test at the pullback boundary. This is intentionally separate from https://github.com/SciML/SciMLBase.jl/pull/1564.

Please ignore this draft until reviewed by @ChrisRackauckas.

## Failing-before / passing-after

Environment: Julia 1.10.12 (commit d93beab124c), ModelingToolkit 11.40.0, ModelingToolkitBase 1.68.1, isolated `JULIA_DEPOT_PATH`.

Before the fix, exact command:
```bash
env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260829_113159_30815/SciMLBase-downstreamad-master/.julia_depot TMPDIR=/home/crackauc/tmp /home/crackauc/.juliaup/bin/julia +1.10.12 --project=downstream -e 'include("downstream/remake_autodiff.jl")'
```
failed (exit 1) with:
```text
MethodError: no method matching promote_type_with_nothing(::Type{Float64}, ::ChainRulesCore.Tangent{SciMLBase.DespecializedParameters, @NamedTuple{params::Vector{Float64}}})
Test Summary: | Pass Error Total
`split = false` | 4 1 5
```

After the fix, the same command passed (exit 0):
```text
`split = false` | 7 | 7
`split = true` | None | 0
Consistent gradients | Broken 1
```

## Other validation

- `GROUP=QA julia +1.10.12 --project -e 'using Pkg; Pkg.test()'`: `QA | 121 | 121`, `SciMLBase tests passed`.
- Runic 1.7.0 format check: both changed files clean.
- `typos ext/SciMLBaseChainRulesCoreExt.jl test/downstream/remake_autodiff.jl`: exit 0.
- The broader `GROUP=DownstreamAD` run still reports unrelated existing failures in `observables_autodiff.jl` (Mooncake type assertion and AutoZygote parameter equality); the focused `remake_autodiff.jl` test is green.

🤖 Generated with Codex CLI (model: gpt-5-codex). Agent session: `/home/crackauc/sandbox/tmp_20260829_113159_30815` (local session path).