### PR TITLE
Document ensemble error analysis API

### DIFF
--- a/docs/src/interfaces/Ensembles.md
+++ b/docs/src/interfaces/Ensembles.md
@@ -77,6 +77,7 @@ trajectory outputs.
 SciMLBase.EnsembleSolution
 SciMLBase.EnsembleTestSolution
 SciMLBase.WeightedEnsembleSolution
+SciMLBase.calculate_ensemble_errors
 ```
 
 ### Plot Recipe

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2387,7 +2387,8 @@ export cache_operator, concretize, has_adjoint, has_concretization, has_exp, has
 # Ensemble interface
 @public AbstractEnsembleEstimator, WeightedEnsembleProblem,
     DEFAULT_PROB_FUNC, DEFAULT_OUTPUT_FUNC, DEFAULT_REDUCTION,
-    generate_sim_seeds, default_rng_func, WeightedEnsembleSolution
+    generate_sim_seeds, default_rng_func, WeightedEnsembleSolution,
+    calculate_ensemble_errors
 
 # AD / sensitivity function wrappers
 @public TimeDerivativeWrapper, TimeGradientWrapper, UDerivativeWrapper, UJacobianWrapper,

--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -161,6 +161,22 @@ struct EnsembleSummary{T, N, Tt, S, S2, S3, S4, S5} <: AbstractEnsembleSolution{
     converged::Bool
 end
 
+"""
+    calculate_ensemble_errors(sim::AbstractEnsembleSolution; kwargs...)
+    calculate_ensemble_errors(trajectories; elapsedTime = 0.0, converged = false,
+        weak_timeseries_errors = false, weak_dense_errors = false)
+
+Collect the strong and weak errors from an ensemble whose trajectories include analytic
+reference solutions, returning an [`EnsembleTestSolution`](@ref).
+
+Strong errors are collected from each trajectory's `errors` field and summarized by their
+mean and median. The final-time weak error is always calculated. Set
+`weak_timeseries_errors = true` to calculate weak errors at the saved time steps, or
+`weak_dense_errors = true` to calculate them on a 100-point interpolation grid.
+
+When an `AbstractEnsembleSolution` is passed, its `elapsedTime` and `converged` fields are
+preserved. The trajectory-collection form accepts those values as keyword arguments.
+"""
 function calculate_ensemble_errors(sim::AbstractEnsembleSolution; kwargs...)
     calculate_ensemble_errors(
         sim.u; elapsedTime = sim.elapsedTime,

--- a/test/public_interface.jl
+++ b/test/public_interface.jl
@@ -886,6 +886,7 @@ if isdefined(Base, :ispublic)
                 :EnsembleSolution,
                 :EnsembleTestSolution,
                 :WeightedEnsembleSolution,
+                :calculate_ensemble_errors,
             )
             @test Base.ispublic(SciMLBase, name)
         end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed and why

`calculate_ensemble_errors` already implements the ensemble error-analysis functionality that AdaptiveSDE benchmarks need, but it was neither public nor documented. This makes the existing function public, documents both call forms, adds it to the rendered ensemble API, and tests its API status. There is no behavior or signature change.

This adds public API and therefore requires a minor release before downstream code should rely on it.

## Failing before

With the public-interface assertion applied to unmodified `master`:

```
Test Summary:              | Pass  Fail  Total
Ensemble manual public API |   19     1     20
Expression: Base.ispublic(SciMLBase, :calculate_ensemble_errors)
Evaluated: false
```

## Passing after

The same test after this change:

```
Test Summary:              | Pass  Total
Ensemble manual public API |   20     20
```

## Verification

```
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
Remake        | 4605   4605  4m15.2s
Testing SciMLBase tests passed
```

```
PIXI_CACHE_DIR="$PWD/.validation/pixi-cache-fresh" \
RATTLER_CACHE_DIR="$PWD/.validation/pixi-cache-fresh" \
GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |  123    123  3m10.3s
Testing SciMLBase tests passed
```

```
julia +1.11 --project=docs docs/make.jl
# exited 0

julia +1.12 --project=@runic -m Runic --check src/SciMLBase.jl src/ensemble/ensemble_solutions.jl test/public_interface.jl
typos docs/src/interfaces/Ensembles.md src/SciMLBase.jl src/ensemble/ensemble_solutions.jl test/public_interface.jl
git diff --check
# all exited 0
```

The first QA attempt exposed a corrupted machine-local Pixi package cache: 1,579 of 1,594 Python standard-library files were zero bytes. Clean `master` reproduced that environment failure. Running the unchanged dependency set with a fresh in-worktree cache produced the 123/123 result above.

## Not verified

Hosted CI has not completed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
