### PR TITLE
Release SciMLBase 3.51.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.50.2"
+version = "3.51.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## What changed and why

Bump SciMLBase from 3.50.2 to 3.51.0. This minor release makes the newly public and documented ensemble error-analysis API from https://github.com/SciML/SciMLBase.jl/pull/1572 available to downstream packages, including the AdaptiveSDE benchmarks.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Julia 1.10.12 Core test group:

```text
Test Summary: | Pass  Total     Time
Remake        | 4605   4605  4m23.2s
Testing SciMLBase tests passed
```

Julia 1.10.12 QA test group:

```text
Test Summary: | Pass  Total     Time
QA            |  121    121  1m56.0s
Testing SciMLBase tests passed
```

Pre-push checks:

```text
$ julia +1.10.12 --project=. -e 'using Runic; exit(Runic.main(["--check", "Project.toml"]))'
$ typos Project.toml
$ git diff HEAD^ --check
```

All three exited successfully with no output.

## Not verified

The documentation was not rebuilt for this mechanical version-only change. The public API and rendered documentation were added and verified in https://github.com/SciML/SciMLBase.jl/pull/1572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
