### PR TITLE
Handle despecialized parameter cotangents in solution AD

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -37,6 +37,9 @@ function ChainRulesCore.rrule(
             if dp == NoTangent()
                 dp = zero_tangent(parameter_values(VA.prob))
             end
+            if dp isa ChainRulesCore.Tangent{<:SciMLBase.DespecializedParameters}
+                dp = dp.params
+            end
             dprob = remake(VA.prob, p = dp)
             du, dprob
         else


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Unwrap a `ChainRulesCore.Tangent{DespecializedParameters}` before the observable `ODESolution` pullback remakes its problem. The tangent's `params` component is the cotangent for the original parameter object; passing the outer structural tangent into `remake` instead reaches ModelingToolkit initialization as if it were a primal parameter value.

This is a three-line extension fix. It adds no public API, dependency, documentation, or version change.

## Root cause

ModelingToolkit commit https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6 from https://github.com/SciML/ModelingToolkit.jl/pull/4919 changed generated problems from `AutoSpecialize` to `AutoDespecialize`. The exact registered boundary is ModelingToolkitBase 1.65.0 to 1.66.0, as independently established in https://github.com/SciML/SciMLBase.jl/pull/1545.

The observable pullback consequently receives a structural tangent around `DespecializedParameters`. SciMLBase's rrule passed that wrapper directly to `remake`, leading to:

```text
MethodError: no method matching promote_type_with_nothing(
    ::Type{Float64},
    ::ChainRulesCore.Tangent{SciMLBase.DespecializedParameters,
        @NamedTuple{params::Vector{Float64}}})
```

The ModelingToolkit error is downstream fallout: the invalid primal value is created at the SciMLBase rrule/remake boundary, so the fix belongs here.

## Failing before

On clean SciMLBase master `3d95609f7dc1c86a8fded41b9d357bcf25b83ad3`, Julia 1.10.12:

```text
GROUP=DownstreamAD julia +1.10.12 --threads=11 --project=. -e 'using Pkg; Pkg.test()'

Test Summary:   | Pass  Error  Broken  Total      Time
Autodiff Remake |    4      1       1      6  32m02.4s
ERROR: Some tests did not pass: 4 passed, 0 failed, 1 errored, 1 broken.
```

The hosted Julia LTS lane has the same method, argument types, and stack through `ODESolution_getindex_pullback`: https://github.com/SciML/SciMLBase.jl/actions/runs/33447000990/job/99668297921.

## Passing after

The same owning testset passes with the fix:

```text
Test Summary:   | Pass  Broken  Total     Time
Autodiff Remake |    7       1      8  7m14.0s
```

QA passes with the system Python selected to avoid a broken generated CondaPkg environment on this host:

```text
JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 \
  GROUP=QA julia +1.10.12 --threads=11 --project=. -e 'using Pkg; Pkg.test()'

Test Summary: | Pass  Total     Time
QA            |  121    121  1m34.4s
Testing SciMLBase tests passed
```

Runic, typos, and `git diff --check` pass for the changed file.

## Independent failures / not verified

The full local DownstreamAD group proceeds past `Autodiff Remake`, then fails in the pre-existing `observables_autodiff.jl` failures: three Mooncake `_copy_output` NamedTuple type assertions, plus two AutoZygote assertions that still assume the pre-AutoDespecialize parameter shape. Those failures do not execute the changed rrule path. The independent AutoZygote fixture assumptions are being handled separately.

The hosted Julia 1 job https://github.com/SciML/SciMLBase.jl/actions/runs/33447000990/job/99668297994 has only the three Mooncake errors; it does not contain this PR's `promote_type_with_nothing` error. This PR does not claim to fix that lane.

Docs were not built because this PR changes neither public API nor documentation. GPU paths were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
