### PR TITLE
Invalidate integrator caches after parameter mutation

### DIFF
--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -77,7 +77,9 @@ reach into solver-specific internals.
   must update state, saved state, and non-user caches consistently.
 - Symbolic state access follows `SymbolicIndexingInterface`: `integrator[sym]`
   reads state variables, `set_u!(integrator, sym, val)` writes state variables,
-  and parameter access should go through `integrator.ps[sym]`.
+  and parameter access should go through `integrator.ps[sym]`. Assigning a parameter
+  through this interface marks the derivative as discontinuous so the solver refreshes
+  affected caches before the next step.
 
 ```@docs
 SciMLBase.DEIntegrator

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -821,6 +821,9 @@ function SymbolicIndexingInterface.set_state!(A::DEIntegrator, val, idx)
     A.u[idx] = val
     return derivative_discontinuity!(A, true)
 end
+function SymbolicIndexingInterface.finalize_parameters_hook!(A::DEIntegrator, _)
+    return derivative_discontinuity!(A, true)
+end
 
 SymbolicIndexingInterface.is_time_dependent(::DEIntegrator) = true
 

--- a/test/downstream/integrator_indexing.jl
+++ b/test/downstream/integrator_indexing.jl
@@ -82,6 +82,21 @@ integrator[population_model.s2] = 10.0
 integrator[:s1] = 1.0
 @test integrator[s1] == integrator[population_model.s1] == integrator[:s1] == 1.0
 
+@testset "Parameter mutation invalidates integrator caches" begin
+    sys = SymbolCache([:x], [:p], :t)
+    f! = ODEFunction((du, u, p, t) -> du[1] = p[1]; sys)
+    prob = ODEProblem(f!, [0.0], (0.0, 2.0), [0.0])
+    integrator = init(
+        prob, Tsit5(); adaptive = false, dt = 1.0, save_everystep = false
+    )
+
+    step!(integrator, 1.0, true)
+    integrator.ps[:p] = 1.0
+    step!(integrator, 1.0, true)
+
+    @test integrator[:x] ≈ 1.0
+end
+
 # Tests on SDEProblem
 noiseeqs = [
     0.1 * s1,

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -1,5 +1,6 @@
 using CommonSolve: step!
 using Test, SciMLBase
+import SymbolicIndexingInterface
 
 struct DummySolution
     retcode::SciMLBase.ReturnCode.T
@@ -84,6 +85,10 @@ integrator = DummyIntegrator()
 SciMLBase.set_ut!(integrator, [3.0], 2.0)
 @test integrator.u == [3.0]
 @test integrator.t == 2.0
+
+integrator.discontinuity = false
+SymbolicIndexingInterface.finalize_parameters_hook!(integrator, :p)
+@test integrator.discontinuity
 
 @test integrator.sol.retcode == ReturnCode.Default
 @test check_error(integrator) == ReturnCode.Success


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Symbolic parameter assignment through `integrator.ps[...]` now marks a `DEIntegrator`'s derivative as discontinuous when `SymbolicIndexingInterface` finishes the assignment. This makes the next `step!` refresh method caches instead of advancing with derivative data computed from the previous parameter value.

This supplies the missing integrator specialization of the existing `SymbolicIndexingInterface.finalize_parameters_hook!` extension point. It enables the single-integrator interactive workflow discussed in https://github.com/SciML/ModelingToolkit.jl/issues/5006#issuecomment-5476557277 without repeatedly calling `reinit!`.

## Regression evidence

With the new regression test present and the production change removed:

```text
$ julia --startup-file=no --project=test/downstream test/downstream/integrator_indexing.jl
Parameter mutation invalidates integrator caches: Test Failed at test/downstream/integrator_indexing.jl:97
  Expression: integrator[:x] ≈ 1.0
   Evaluated: 0.9035392331819345 ≈ 1.0
Test Summary:                                    | Fail  Total  Time
Parameter mutation invalidates integrator caches |    1      1  5.6s
ERROR: LoadError: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
```

With this change applied, rerun after rebasing onto the latest `upstream/master`:

```text
$ julia --startup-file=no --project=test/downstream test/downstream/integrator_indexing.jl
Test Summary:                                    | Pass  Total  Time
Parameter mutation invalidates integrator caches |    1      1  2.5s
Test Summary:   | Pass  Total  Time
Symbolic set_u! |    1      1  2.3s
[exit code 0]
```

## Verification

```text
$ GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:        | Pass  Total
Integrator interface |   14     14
Test Summary: | Pass  Total
Remake        | 4605   4605
Testing SciMLBase tests passed

$ GROUP=Downstream julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total
Solution Indexing |  277    277
Test Summary:  | Pass  Total
initialization |   83     83
Testing SciMLBase tests passed

$ PIXI_CACHE_DIR=/home/crackauc/sandbox/tmp_20260831_125419_177237/pythoncall-fresh-pixi-cache RATTLER_CACHE_DIR=/home/crackauc/sandbox/tmp_20260831_125419_177237/pythoncall-fresh-pixi-cache TMPDIR=/home/crackauc/sandbox/tmp_20260831_125419_177237/.tmp GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |  123    123  3m22.9s
Testing SciMLBase tests passed

$ TMPDIR=/home/crackauc/sandbox/tmp_20260831_125419_177237/.tmp julia --startup-file=no --project=docs docs/make.jl
[exit code 0; doctests, link checking, and rendering completed]

$ julia --startup-file=no -m Runic --check test/integrator_tests.jl test/downstream/integrator_indexing.jl
[exit code 0]

$ typos docs/src/interfaces/Init_Solve.md src/integrator_interface.jl test/downstream/integrator_indexing.jl test/integrator_tests.jl
[exit code 0]

$ git diff --check upstream/master...HEAD
[exit code 0]
```

The first QA attempt exposed a corrupted shared Pixi package cache: cached Python standard-library files were zero bytes. The same failure reproduced on a clean `master` worktree. Re-running against a fresh workspace-local Pixi cache produced the 123/123 result above; no repository change was needed for that machine-state failure.

## Review notes and unverified paths

No public API is added; this specializes an existing SII hook for `DEIntegrator`. `Everything`, GPU, Julia pre-release, and unrelated sublibrary/downstream jobs were not run locally.

The two failing DownstreamAD CI jobs also fail in the master run at the PR's exact base SHA, `3d95609f7dc1c86a8fded41b9d357bcf25b83ad3`: https://github.com/SciML/SciMLBase.jl/actions/runs/33443540855/job/99658026211 and https://github.com/SciML/SciMLBase.jl/actions/runs/33443540855/job/99658026315. The LTS failure is addressed by https://github.com/SciML/SciMLBase.jl/pull/1574. The Julia 1.12 Mooncake failure is reduced and tracked separately at https://github.com/SciML/SciMLBase.jl/issues/1578.

The new source hunk was formatted with Runic. A whole-file Runic check of `src/integrator_interface.jl` still detects an unrelated pre-existing formatting hunk, which this behavior-change PR deliberately does not include.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a057e2-edc7-7342-9835-8122a5c647eb).
