### PR TITLE
Update observable AD fixtures for despecialized parameters

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -30,6 +30,7 @@ end
 # property access. Normalize so both backends can be tested with the same
 # accessor.
 _unwrap_grad(gs) = hasproperty(gs, :fields) ? getfield(gs, :fields) : gs
+_unwrap_parameter_gradient(gp) = hasproperty(gp, :params) ? gp.params : gp
 
 @parameters σ ρ β
 @variables x(t) y(t) z(t) w(t)
@@ -116,7 +117,7 @@ end
                 p -> f(SII.state_values(iprob), p), backend, SII.parameter_values(iprob)
             )
 
-            @test gs.prob.p == gp
+            @test _unwrap_parameter_gradient(gs.prob.p) == gp
         end
     end
     for backend in MOONCAKE_BACKENDS
@@ -225,7 +226,7 @@ sol_dae = solve(prob_dae, Rodas5())
                 gs = DifferentiationInterface.gradient(
                     isol -> isol[simple_dae.u_dae], backend, isol
                 )
-                gt = gs.prob.p.tunable
+                gt = _unwrap_parameter_gradient(gs.prob.p).tunable
                 @test length(findall(!iszero, gt)) == 1
             end
         end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Normalize AutoZygote parameter gradients through the optional `DespecializedParameters.params` structural wrapper in the two initialization-observable fixtures. The numerical contracts are unchanged: the ODE case still compares the complete inner parameter gradient, and the DAE case still requires exactly one nonzero tunable gradient.

This is a five-line test-only compatibility fix. It adds no public API, dependency, documentation, or version change.

## Root cause

ModelingToolkit commit https://github.com/SciML/ModelingToolkit.jl/commit/55856687b1c25e1b767d6834589cba26dbd0ead6 from https://github.com/SciML/ModelingToolkit.jl/pull/4919 changed generated initialization problems from `AutoSpecialize` to `AutoDespecialize`. The registered boundary is ModelingToolkitBase 1.65.0 to 1.66.0: the two tags show the default changing from `SciMLBase.AutoSpecialize` to `SciMLBase.AutoDespecialize` in `InitializationProblem`.

Zygote correctly mirrors the documented `DespecializedParameters.params` field in its structural gradient. The fixtures instead continued comparing/accessing the pre-wrapper shape directly. This is the AutoZygote counterpart of the Mooncake fixture adjustment already merged in https://github.com/SciML/SciMLBase.jl/pull/1545. That PR's full local validation used Julia 1.12, where `ZYGOTE_BACKENDS` is empty, so these Julia LTS assertions were not exercised.

## Failing before

On clean SciMLBase master `3d95609f7dc1c86a8fded41b9d357bcf25b83ad3`, ModelingToolkit 11.40.0 / ModelingToolkitBase 1.68.2, and Julia 1.10.12, focused reproductions of the unchanged assertions fail as follows:

```text
ODE initialization parameter tangent | 1 failed
Evaluated: (params = (tunable = [...], ...),) == (tunable = [...], ...)

DAE initialization parameter tangent | 1 error
type NamedTuple has no field tunable
Available fields: params
```

At the direct parent of the introducing ModelingToolkit commit (`8b337a8f0ff800c12799244a15fd805af68df5b6`), the original assertions pass 2/2:

```text
ODE initialization parameter tangent | 1/1
DAE initialization parameter tangent | 1/1
```

## Passing after

The same focused reproductions on the current dependency stack pass after this fixture update:

```text
ODE initialization parameter tangent | 1/1
DAE initialization parameter tangent | 1/1
```

Repository gates:

```text
JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 GROUP=QA \
  timeout 7200 julia +1.10.12 --threads=11 --project=. -e 'using Pkg; Pkg.test()'
QA | 121/121
Testing SciMLBase tests passed

Runic --check --diff: pass
typos: pass
git diff --check: pass
```

## Independent failures / not verified

The full Julia LTS `DownstreamAD` group was run locally and is not green on current master:

```text
GROUP=DownstreamAD timeout 10800 julia +1.10.12 --threads=11 \
  --project=. -e 'using Pkg; Pkg.test()'
Autodiff Remake | 4 pass, 1 error, 1 broken, 6 total, 24m27.5s
```

It first stops in `remake_autodiff.jl` at the independent observable-solution cotangent bug fixed by https://github.com/SciML/SciMLBase.jl/pull/1574; after that is bypassed, the registered Mooncake `_copy_output` NamedTuple type assertions fail before this file can execute the changed initialization fixtures. The hosted master failure is https://github.com/SciML/SciMLBase.jl/actions/runs/33447000990/job/99668297921.

The focused AutoZygote tests above exercise both changed assertions without disabling or weakening them. Docs were not built because this PR changes neither public API nor documentation. Julia 1.12 does not execute these AutoZygote loops; GPU paths were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
