### PR TITLE
Add SDEProblem specialization constructor route

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.50.2"
+version = "3.51.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -129,6 +129,15 @@ struct SDEProblem{uType, tType, isinplace, P, NP, F, G, K, ND} <:
     function SDEProblem{iip}(f, g, u0, tspan, p = NullParameters(); kwargs...) where {iip}
         return SDEProblem(SDEFunction{iip}(f, g), u0, tspan, p; kwargs...)
     end
+
+    @add_kwonly function SDEProblem{iip, specialize}(
+            f, g, u0, tspan, p = NullParameters();
+            kwargs...
+        ) where {iip, specialize}
+        return SDEProblem{iip}(
+            SDEFunction{iip, specialize}(f, g), u0, tspan, p; kwargs...
+        )
+    end
 end
 
 function SDEProblem(f::AbstractSDEFunction, u0, tspan, p = NullParameters(); kwargs...)

--- a/test/problem_building_test.jl
+++ b/test/problem_building_test.jl
@@ -340,6 +340,29 @@ end
     @test SciMLBase.specialization(uf) === SciMLBase.AutoRespecialize
 end
 
+@testset "SDEProblem specialization" begin
+    f!(du, u, p, t) = (du .= p .* u; nothing)
+    g!(du, u, p, t) = (du .= p .* u; nothing)
+    f(u, p, t) = p .* u
+    g(u, p, t) = p .* u
+
+    for (iip, drift, diffusion) in ((true, f!, g!), (false, f, g))
+        for specialization in (
+                SciMLBase.FullSpecialize,
+                SciMLBase.NoSpecialize,
+                SciMLBase.AutoSpecialize,
+                SciMLBase.FunctionWrapperSpecialize,
+                SciMLBase.AutoDespecialize,
+                SciMLBase.AutoRespecialize,
+            )
+            prob = SDEProblem{iip, specialization}(
+                drift, diffusion, [1.0], (0.0, 1.0), [0.1]
+            )
+            @test SciMLBase.specialization(prob.f) === specialization
+        end
+    end
+end
+
 @testset "Nonlinear preconditioning keywords are accepted solver options" begin
     for kw in (:precondition, :postcondition)
         @test kw in SciMLBase.allowedkeywords


### PR DESCRIPTION
## What changed and why

Implement the documented `SDEProblem{isinplace, specialize}(f, g, u0, tspan, p; kwargs...)` constructor by routing through `SDEFunction{isinplace, specialize}`, matching the existing ODE constructor pattern. Regression coverage exercises both in-place and out-of-place construction for all six specialization markers. SciMLBase moves to 3.51.0 because this makes the public specialization constructor usable.

> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before the fix

On clean master `3d95609f7dc1c86a8fded41b9d357bcf25b83ad3`, the new constructor assertion cannot run:

```text
julia --project=. -e 'using Test, SciMLBase; ...; prob = SDEProblem{true, SciMLBase.AutoDespecialize}(f!, g!, [1.0], (0.0, 1.0), [0.1]); @test SciMLBase.specialization(prob.f) === SciMLBase.AutoDespecialize'
ERROR: MethodError: no method matching (SDEProblem{true, SciMLBase.AutoDespecialize})(::typeof(f!), ::typeof(g!), ::Vector{Float64}, ::Tuple{Float64, Float64}, ::Vector{Float64})
```

## Passing after the fix

The same assertion on this branch exits successfully:

```text
SDE specialization assertion passed
```

The committed regression test covers the full marker matrix:

```text
Problem building tests | 147 passed
```

## Verification

```text
GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'
Problem building tests | 147 passed
Remake | 4605 passed
Testing SciMLBase tests passed

PIXI_CACHE_DIR=/home/crackauc/sandbox/tmp_20260904_111048_68452/pixi-fresh-cache GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
QA | 123 passed
Testing SciMLBase tests passed

julia --project=docs docs/make.jl
Document checks and HTML rendering completed; exit code 0

julia --project=. -e 'using Runic; exit(Runic.main(ARGS))' -- --check src/problems/sde_problems.jl test/problem_building_test.jl
exit code 0

typos Project.toml src/problems/sde_problems.jl test/problem_building_test.jl
exit code 0
```

The first QA attempt exposed a machine-local corrupt pixi cache with zero-byte Python standard-library files. Clean master and this branch both passed 123/123 with the same fresh cache, so no source workaround was added.

Not run locally: GPU, downstream, or allowed-to-fail jobs.

Reviewer judgment: the 3.51.0 minor bump follows the repository precedent for making a new specialization constructor route public.

🤖 Generated with Codex CLI 0.153.4 (model: unknown; session: local thread 01a06c1d-564b-7ef0-ada6-d83a233b55e2; no shareable URL was exposed).
