### PR TITLE
Add the missing ChainRulesCore test dependency

### DIFF
--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BoundaryValueDiffEq = "764a87c0-6b3e-53db-9096-fe964310641d"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
@@ -43,6 +44,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ADTypes = "1"
 BoundaryValueDiffEq = "5"
+ChainRulesCore = "1.18"
 DataFrames = "1.6"
 DelayDiffEq = "6"
 DiffEqCallbacks = "4"


### PR DESCRIPTION
## What changed and why

`test/downstream/remake_autodiff.jl` has done `using ChainRulesCore` since
https://github.com/SciML/SciMLBase.jl/pull/1567, but `ChainRulesCore` was never added to
`test/downstream/Project.toml`. `GROUP=DownstreamAD` therefore fails on master, and because
`Autodiff Remake` is the group's first testset the error aborts the run before anything else
in the group executes.

This adds the dependency and its compat bound (`1.18`, matching the root `Project.toml`).
Two lines, nothing else.

## Verification

Pre-existing on master, not introduced by any open PR. The DownstreamAD jobs on master's own
run at `2f74543d` (https://github.com/SciML/SciMLBase.jl/actions/runs/34027316086) fail with:

```
Autodiff Remake: Error During Test at .../SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: ArgumentError: Package ChainRulesCore not found in current path.
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

Locally on unmodified master, same error, `DSAD exit=1`.

After, `GROUP=DownstreamAD julia +release --project -e 'using Pkg; Pkg.test()'` on Julia
1.12.6:

```
Autodiff Remake                       |     0            51.9s
Autodiff Observable Functions         |    13       1      14  13m13.1s
Ensemble adjoint gradient correctness |             1       1   0.3s

     Testing SciMLBase tests passed
```

**Read that `Autodiff Remake | 0` carefully.** The body of `remake_autodiff.jl` is gated
behind `if VERSION < v"1.12"`, so on 1.12 the file loads and runs zero tests. This run proves
the group no longer aborts at load; it does **not** exercise the tests this PR unblocks. The
group's other files do run and pass.

## This unblocks a test that then fails, and I have not fixed that here

On Julia LTS the gated body does run, and the testset added by #1567 — which has never
executed even once, because the missing dependency always aborted the file first — errors:

```
Despecialized parameter cotangent remake: Error During Test at test/downstream/remake_autodiff.jl:124
  Expression: cotangent.prob.p isa SciMLBase.DespecializedParameters
  type InplaceableThunk has no field prob
```

That is tracked and fixed in https://github.com/SciML/SciMLBase.jl/issues/1583 and
https://github.com/SciML/SciMLBase.jl/pull/1584, which stacks on this PR.

For the record, the cause is not what the thunk in that message suggests. The test called
`ChainRulesCore.rrule(getindex, sol, x, 1)` with no `RuleConfig`, so it never dispatched to
SciMLBase's `ODESolution` rule at all and fell through to the generic `ChainRules`
`AbstractArray` `getindex` rule, whose cotangent is an `InplaceableThunk`. Unthunking it does
not help — it then throws `ArgumentError: invalid index: x(t)`. Passing a config exposes a
genuine library bug in `SciMLBaseChainRulesCoreExt`, which #1584 fixes.

So expect the LTS DownstreamAD check on this PR to be red, on that assertion rather than on
the load error. That is the point of the change: the group can now reach its tests, and the
first thing it finds is a genuine pre-existing bug that was invisible before.

## Not verified

Julia LTS end-to-end green on this PR alone; that needs #1584 as well.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
