### PR TITLE
Dispatch the despecialized cotangent test through a RuleConfig

### DIFF
--- a/ext/SciMLBaseChainRulesCoreExt.jl
+++ b/ext/SciMLBaseChainRulesCoreExt.jl
@@ -29,7 +29,7 @@ function ChainRulesCore.rrule(
     function ODESolution_getindex_pullback(Δ)
         i = symbolic_type(sym) != NotSymbolic() ? variable_index(VA, sym) : sym
         du,
-            dprob = if i === nothing
+            dp = if i === nothing
             getter = getobserved(VA)
             grz = rrule_via_ad(config, getter, sym, VA.u[j], VA.prob.p, VA.t[j])[2](Δ)
             du = [k == j ? grz[3] : zero(VA.u[1]) for k in 1:length(VA.u)]
@@ -37,20 +37,20 @@ function ChainRulesCore.rrule(
             if dp == NoTangent()
                 dp = zero_tangent(parameter_values(VA.prob))
             end
-            if dp isa ChainRulesCore.Tangent{<:SciMLBase.DespecializedParameters}
-                dp = dp.params
-            end
-            dprob = remake(VA.prob, p = dp)
-            du, dprob
+            du, dp
         else
             du = [
                 m == j ? [i == k ? Δ : zero(VA.u[1][1]) for k in 1:length(VA.u[1])] :
                     zero(VA.u[1]) for m in 1:length(VA.u)
             ]
-            dp = zero_tangent(VA.prob.p)
-            dprob = remake(VA.prob, p = dp)
-            du, dprob
+            du, zero_tangent(VA.prob.p)
         end
+        # `remake` cannot consume a `Tangent` over the despecialized container, so
+        # reduce the cotangent to the wrapped parameter object first.
+        if dp isa ChainRulesCore.Tangent{<:SciMLBase.DespecializedParameters}
+            dp = dp.params
+        end
+        dprob = remake(VA.prob, p = dp)
         T = eltype(first(du))
         N = ndims(first(du)) + 1
         Δ′ = ODESolution{T, N}(

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BoundaryValueDiffEq = "764a87c0-6b3e-53db-9096-fe964310641d"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
@@ -43,6 +44,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ADTypes = "1"
 BoundaryValueDiffEq = "5"
+ChainRulesCore = "1.18"
 DataFrames = "1.6"
 DelayDiffEq = "6"
 DiffEqCallbacks = "4"

--- a/test/downstream/remake_autodiff.jl
+++ b/test/downstream/remake_autodiff.jl
@@ -118,10 +118,19 @@ if VERSION < v"1.12"
         sys = mtkcompile(lotka_volterra_sys; split)
         prob = ODEProblem(sys, [], (0.0, 10.0))
         sol = solve(prob, Tsit5(), reltol = 1.0e-6, abstol = 1.0e-6)
-        @testset "Despecialized parameter cotangent remake" begin
-            _, pullback = ChainRulesCore.rrule(getindex, sol, x, 1)
-            cotangent = pullback(one(sol[x, 1]))[2]
-            @test cotangent.prob.p isa SciMLBase.DespecializedParameters
+        # A `RuleConfig` is required: without one the call falls through to the
+        # generic `ChainRules` `AbstractArray` `getindex` rule instead of the
+        # `ODESolution` rule under test.
+        @testset "Despecialized parameter cotangent remake ($sym)" for sym in (x, o)
+            @test sol.prob.p isa SciMLBase.DespecializedParameters
+            _, pullback = ChainRulesCore.rrule(
+                Zygote.ZygoteRuleConfig(), getindex, sol, sym, 1
+            )
+            cotangent = pullback(one(sol[sym, 1]))[2]
+            # `remake` cannot consume a `Tangent` over the despecialized container.
+            @test !(cotangent.prob.p isa ChainRulesCore.Tangent)
+            @test cotangent.prob.p isa
+                typeof(SciMLBase.unwrap_parameters(sol.prob.p))
         end
         setter = setsym_oop(prob, [unknowns(sys); parameters(sys)])
         u0, p = setter(prob, [1.0, 1.0, 1.5, 1.0, 1.0, 1.0])


### PR DESCRIPTION
> **Merged.** This PR contains only the `remake_autodiff.jl` fix described below. The `observables_autodiff.jl` failures it uncovered are handled in https://github.com/SciML/SciMLBase.jl/pull/1587.

## What changed and why

`ChainRulesCore.rrule(getindex, sol, x, 1)` in the `Despecialized parameter cotangent remake` testset passes no `RuleConfig`, so it never dispatched to SciMLBase's `rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(getindex), ::ODESolution, sym, ::Integer)` — it fell through to the generic `ChainRules` `AbstractArray` `getindex` rule, whose cotangent is an `InplaceableThunk` with no `prob` field. The test now passes `Zygote.ZygoteRuleConfig()` (what `SciMLBaseZygoteExt` itself uses), which reaches the intended rule and exposes a second, real bug: the non-observed branch of the pullback computes `dp = zero_tangent(VA.prob.p)`, which for `DespecializedParameters` is a `Tangent{DespecializedParameters}` that `remake` cannot consume. The `Tangent` unwrapping added in #1567 was inside the observed branch only, so it is hoisted to cover both.

Fixes https://github.com/SciML/SciMLBase.jl/issues/1583.

## Stacking

**This stacks on https://github.com/SciML/SciMLBase.jl/pull/1582 and cannot merge before it.** `test/downstream/Project.toml` is missing the `ChainRulesCore` entry that `remake_autodiff.jl` needs, so without #1582 the file aborts at load and none of this runs. The branch is cut from #1582's branch, so the diff here contains that commit as well.

## Environment

Julia 1.10.12 (LTS), pinned to the versions the failing CI job resolved: ModelingToolkit 11.41.0, ModelingToolkitBase 1.68.2, Symbolics 7.39.0, SymbolicUtils 4.46.2, ChainRules 1.73.0, ChainRulesCore 1.26.1, Zygote 0.7.13, SciMLSensitivity 7.119.2, OrdinaryDiffEq 7.8.1, SymbolicIndexingInterface 0.3.55, RecursiveArrayTools 4.5.1.

## Failing before

`julia +lts --project=<env> test/downstream/remake_autodiff.jl` on the unmodified tree reproduces the CI error exactly (long type parameters elided with `…`):

```
Despecialized parameter cotangent remake: Error During Test at .../test/downstream/remake_autodiff.jl:124
  Test threw exception
  Expression: cotangent.prob.p isa SciMLBase.DespecializedParameters
  type InplaceableThunk has no field prob
  Stacktrace:
   [1] getproperty(x::InplaceableThunk{Thunk{ChainRules.var"#675#677"{ODESolution{…}}}, ChainRules.var"#674#676"{ODESolution{…}}}, f::Symbol)
     @ Base ./Base.jl:37
   [3] macro expansion
     @ .../test/downstream/remake_autodiff.jl:124 [inlined]
   [5] macro expansion
     @ .../test/downstream/remake_autodiff.jl:122 [inlined]
   [7] top-level scope
     @ .../test/downstream/remake_autodiff.jl:108
Test Summary:                              | Pass  Error  Total     Time
`split = false`                            |    7      1      8  4m15.2s
  Despecialized parameter cotangent remake |           1      1     1.4s
ERROR: LoadError: Some tests did not pass: 7 passed, 0 failed, 1 errored, 0 broken.
BEFORE exit=1
```

## The test change alone is not enough

With only the test's `RuleConfig` fix applied and the extension left at master, the intended rule is reached and fails for its own reason — this is the library bug this PR also fixes:

```
Despecialized parameter cotangent remake (x(t)): Error During Test
  Got exception outside of a @test
  MethodError: no method matching promote_type_with_nothing(::Type{Float64}, ::Tangent{SciMLBase.DespecializedParameters, @NamedTuple{params::Vector{Float64}}})

  Closest candidates are:
    promote_type_with_nothing(::Type{T}, !Matched::SciMLBase.DespecializedParameters) where T
     @ ModelingToolkitBase .../src/systems/nonlinear/initializesystem.jl:718

  Stacktrace:
    [1] promote_u0_p(u0::Vector{Float64}, p::Tangent{SciMLBase.DespecializedParameters, @NamedTuple{params::Vector{Float64}}}, t0::Float64)
    [8] _remake_odeproblem(...; p::Tangent{SciMLBase.DespecializedParameters, @NamedTuple{params::Vector{Float64}}}, ...)
      @ SciMLBase .../src/remake.jl:626
   [11] ODESolution_getindex_pullback
      @ SciMLBaseChainRulesCoreExt .../ext/SciMLBaseChainRulesCoreExt.jl:51
ERROR: LoadError: Some tests did not pass: 1 passed, 0 failed, 1 errored, 0 broken.
```

## Passing after

Same command, same environment, both changes applied:

```
Test Summary:   | Pass  Total     Time
`split = false` |   13     13  4m13.9s
Test Summary:  |Time
`split = true` | None  0.0s
Test Summary:        | Broken  Total  Time
Consistent gradients |      1      1  0.1s
AFTER exit=0
```

`Consistent gradients | Broken 1` and the empty `split = true` block are pre-existing in the file, unchanged by this PR.

## No regression in the sibling AD test

`test/downstream/observables_autodiff.jl` exercises the same pullback. Run in the same environment with and without the extension change, its result is byte-identical — the `AutoZygote` `gs.prob.p == gp` failure at line 119 is pre-existing on master and is not touched here:

```
# extension at master                        # extension with this PR
Test Summary:                 | Pass Total   Test Summary:                 | Pass Total
AutoDiff Observable Functions |    4     4   AutoDiff Observable Functions |    4     4

Test Summary:                              | Pass  Fail  Total   (both runs)
AD Observable Functions for Initialization |    6     1      7
  AutoZygote                               |    2     1      3
  AutoMooncake                             |    4            4
OBS exit=1  (identical before and after)
```

## Other checks

- `julia +release -e 'using Runic; Runic.main(["--check", "ext/SciMLBaseChainRulesCoreExt.jl", "test/downstream/remake_autodiff.jl"])'` — exit 0 (Runic 1.9.0).
- `typos ext/SciMLBaseChainRulesCoreExt.jl test/downstream/remake_autodiff.jl` — exit 0.

## What I did NOT verify

- **Julia 1.12.** The whole block is gated `if VERSION < v"1.12"`, so this code does not execute there at all; a green 1.12 DownstreamAD run says nothing about it.
- **The full `GROUP=DownstreamAD` suite.** I ran `remake_autodiff.jl` and `observables_autodiff.jl` directly against a hand-pinned environment matching the CI job's resolved versions, not the whole group through `test/downstream/Project.toml`. Other files in the group were not run.
- **`split = true`.** That branch `continue`s in the file (JuliaDiff/ChainRules.jl#830), so only `split = false` executed, before and after.
- **QA / docs groups.** Not run; this PR adds no public names and touches no docstrings.

## What a reviewer should push back on

- **The assertion changed meaning.** The original `cotangent.prob.p isa SciMLBase.DespecializedParameters` is false under the intended rule in *both* branches: the pullback deliberately unwraps the despecialized container before `remake`, so `cotangent.prob.p` comes back as the wrapped object (`Vector{Float64}` here). I replaced it with what the fix actually guarantees — the cotangent is not a `Tangent`, and it matches `typeof(SciMLBase.unwrap_parameters(sol.prob.p))` — plus an explicit `sol.prob.p isa DespecializedParameters` precondition so the test still fails loudly if the solution stops carrying despecialized parameters. If the intent of #1567 was that the cotangent problem should *re-wrap* into `DespecializedParameters`, then this is a library behaviour question and my assertion codifies the wrong answer.
- **Hoisting the `Tangent` unwrap changes the non-observed branch's behaviour** (previously it errored, now it returns an unwrapped zero cotangent). That is a library fix riding along with a test fix; it can be split out if preferred, but the test cannot pass on the `x` case without it.
- The test now uses `Zygote.ZygoteRuleConfig()`, so it depends on Zygote rather than being backend-neutral. `SciMLBaseZygoteExt` does the same, so it matches real usage, but a hand-rolled `RuleConfig{>:HasReverseMode}` would decouple it.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
