### PR TITLE
Make has_symbolic_idxs public for solver packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.52.0"
+version = "3.53.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/docs/src/interfaces/Init_Solve.md
+++ b/docs/src/interfaces/Init_Solve.md
@@ -94,6 +94,7 @@ SciMLBase.AbstractSDDEIntegrator
 SciMLBase.DECache
 SciMLBase.step!
 SciMLBase.symbolic_interpolation
+SciMLBase.has_symbolic_idxs
 Base.resize!(::SciMLBase.DEIntegrator, ::Int)
 Base.deleteat!(::SciMLBase.DEIntegrator, ::Any)
 SciMLBase.addat!

--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -2325,7 +2325,8 @@ export cache_operator, concretize, has_adjoint, has_concretization, has_exp, has
 
 # Interpolation / symbolic / solution interface
 @public interp_summary, getindepsym, getindepsym_defaultt,
-    calculate_solution_errors!, initialize_dae!, symbolic_interpolation
+    calculate_solution_errors!, initialize_dae!, symbolic_interpolation,
+    has_symbolic_idxs
 @public get_saved_subsystem, SavedSubsystem, get_saved_state_idxs,
     SavedSubsystemWithFallback, get_save_idxs_and_saved_subsystem,
     create_parameter_timeseries_collection, get_saveable_values, save_discretes!,

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1153,6 +1153,22 @@ function is_independent_variable_index(integrator::DEIntegrator, idx)
 end
 
 """
+    has_symbolic_idxs(idxs)
+
+Return whether `idxs` names quantities symbolically rather than by position in the state
+vector.
+
+Solver packages use this to decide whether `integrator(t; idxs)` has to go through
+[`symbolic_interpolation`](@ref). A raw dense-output interpolant only accepts integer
+component indices, so it cannot resolve a symbolic index, which may name an observed
+equation that is not stored in the state vector at all.
+"""
+has_symbolic_idxs(idxs) = symbolic_type(idxs) !== NotSymbolic()
+function has_symbolic_idxs(idxs::Union{AbstractArray, Tuple})
+    return symbolic_type(idxs) !== NotSymbolic() || any(has_symbolic_idxs, idxs)
+end
+
+"""
     symbolic_interpolation(integrator::DEIntegrator, t, idxs, deriv = Val{0})
 
 Evaluate `idxs` on the interpolant of `integrator`'s current step at time(s) `t`.


### PR DESCRIPTION
## What changed and why

https://github.com/SciML/SciMLBase.jl/pull/1581 added `symbolic_interpolation` so solver
packages can resolve symbolic `idxs` in `integrator(t; idxs)`. Every such package also has
to *decide* whether `idxs` is symbolic before routing, since a raw dense-output interpolant
only accepts integer component indices. That predicate is one line of interface policy and
belongs next to `symbolic_interpolation` rather than being duplicated in five packages or
reached into as a SciMLBase internal.

This adds `SciMLBase.has_symbolic_idxs(idxs)` as public, documented API. It was meant to be
part of #1581 but did not make it into the merge, and 3.52.0 is already released, so it needs
its own version.

The consumers, all currently red on `UndefVarError: has_symbolic_idxs not defined` against
3.52.0:

- https://github.com/SciML/OrdinaryDiffEq.jl/pull/4469 (OrdinaryDiffEqCore, DelayDiffEq)
- https://github.com/SciML/Sundials.jl/pull/565 (CVODE, ARKODE, IDA)
- https://github.com/SciML/ODEInterfaceDiffEq.jl/pull/126

StochasticDiffEq needs nothing of its own: `SDEIntegrator` is an alias for
`ODEIntegrator{<:SDEAlgTypes}`.

## Verification

Nineteen lines, no behavior change to anything existing — a new function, an `@public` entry
and a `@docs` entry.

Docs build (`julia --project=docs docs/make.jl`, which runs `doctest = true` and
`linkcheck = true`) exits 0; that is the check that matters here, since a public name without
a `@docs` entry is a fatal `missing_docs` error in this repo.

The predicate is exercised end to end by the three PRs above. With SciMLBase `Pkg.develop`ed
to this branch, locally:

```
DelayDiffEq                                                |    9      9  12.9s
OrdinaryDiffEq                                             |   12     12   4.6s
Symbolic idxs in the current-step interpolant: CVODE_Adams |    7      7   3.5s
Symbolic idxs in the current-step interpolant: CVODE_BDF   |    7      7   1.4s
Symbolic idxs in the current-step interpolant: ARKODE      |    7      7   2.0s
Symbolic idxs on an IDAIntegrator                          |    3      3   1.7s
Symbolic idxs inside a callback (ODEInterfaceDiffEq)       |   19     19   8.2s
```

Runic `--check` and `typos` clean on the files touched.

## Things a reviewer should push back on

- New public API, so this is a minor bump (3.52.0 → 3.53.0).
- `symbolic_type(::Symbol)` and `symbolic_type(::Expr)` are both `ScalarSymbolic()`, so a
  `Symbol` or `Expr` index counts as symbolic here. That is deliberate — it is what makes
  `integrator(t; idxs = :x)` work against a `SymbolCache` — but it means solver packages that
  adopt this will start resolving `Symbol` indexes that previously threw.

## Not verified

Nothing beyond the docs build and the three downstream suites above was run; this adds a
function and touches no existing code path.

---

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
