### PR TITLE
Release SciMLBase 3.53.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.53.0"
+version = "3.53.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLBase` 3.53.0 -> 3.53.1 (patch).

Source files changed since 3.53.0:
- `ext/SciMLBaseChainRulesCoreExt.jl`

Commits:
- Dispatch the despecialized cotangent test through a RuleConfig (#1584)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
