### PR TITLE
Compare solution parameter cotangents against the solution's own parameters

### DIFF
--- a/test/downstream/observables_autodiff.jl
+++ b/test/downstream/observables_autodiff.jl
@@ -31,6 +31,17 @@ end
 # accessor.
 _unwrap_grad(gs) = hasproperty(gs, :fields) ? getfield(gs, :fields) : gs
 
+# A solution stores the *concrete* problem it was solved with, and MTK builds
+# problems with `specialize = AutoDespecialize`, so that problem holds `p`
+# behind a `SciMLBase.DespecializedParameters` barrier even when the problem
+# handed to `solve` did not. A structural cotangent has to mirror the primal
+# (Zygote projects a cotangent that does not onto `nothing`), so the parameter
+# cotangent carries a matching `params` level. Peel it to compare against a
+# cotangent of the unwrapped parameter object.
+function _unwrap_parameter_cotangent(prob, dp)
+    return prob.p isa SciMLBase.DespecializedParameters ? dp.params : dp
+end
+
 @parameters σ ρ β
 @variables x(t) y(t) z(t) w(t)
 
@@ -116,7 +127,7 @@ end
                 p -> f(SII.state_values(iprob), p), backend, SII.parameter_values(iprob)
             )
 
-            @test gs.prob.p == gp
+            @test _unwrap_parameter_cotangent(isol.prob, gs.prob.p) == gp
         end
     end
     for backend in MOONCAKE_BACKENDS
@@ -225,7 +236,7 @@ sol_dae = solve(prob_dae, Rodas5())
                 gs = DifferentiationInterface.gradient(
                     isol -> isol[simple_dae.u_dae], backend, isol
                 )
-                gt = gs.prob.p.tunable
+                gt = _unwrap_parameter_cotangent(isol.prob, gs.prob.p).tunable
                 @test length(findall(!iszero, gt)) == 1
             end
         end


### PR DESCRIPTION
## What changed and why

With #1584 merged, `test/downstream/remake_autodiff.jl` no longer aborts the `DownstreamAD` group on Julia LTS, and the group reaches `test/downstream/observables_autodiff.jl` for the first time — where two pre-existing `AutoZygote` failures are waiting (https://github.com/SciML/SciMLBase.jl/actions/runs/34075472459/job/101609529100).

Both have one cause. A solution stores the *concrete* problem it was solved with, and MTK builds problems with `specialize = AutoDespecialize`, so `sol.prob.p` is a `SciMLBase.DespecializedParameters` even when the problem handed to `solve` held a plain `MTKParameters` — measured on the failing case: `iprob.p::MTKParameters{…}` but `isol.prob.p::SciMLBase.DespecializedParameters`. A Zygote structural cotangent has to mirror its primal, so the parameter cotangent carries a matching `params` level. The tests compared it against a gradient taken with respect to the *unwrapped* object, i.e. against a cotangent of a different object. A small helper peels exactly the level the primal actually has, so it is inert if the solver ever stops despecializing.

With this, the whole `GROUP=DownstreamAD` group passes on Julia LTS end to end for the first time.

## Why this is not fixed in the library

The obvious library fix — unwrap in `ext/SciMLBaseZygoteExt.jl` so the pullbacks emit an unwrapped parameter cotangent — is wrong, and I measured that rather than assuming it. Zygote discards a structural cotangent that does not mirror the primal:

```
raw = (u = nothing, prob = (p = (tunable = [0.0, …, 1.0, 0.0, 0.0], initials = nothing, …),))

Zygote._project(isol, unwrapped tangent) = nothing

Zygote._project(isol, wrapped tangent)   = (u = nothing, resid = nothing, prob = (f = nothing, u0 = nothing,
    p = (params = (tunable = [0.0, …, 1.0, 0.0, 0.0], initials = nothing, …),), …), …)
```

I ran that change through the file and it made things worse — `Autodiff Observable Functions | 20 passed, 1 failed, 2 errored, 1 broken`, with `gs` coming back as `nothing` and `gs isa NamedTuple` failing at line 109. The `(params = …)` shape SciMLBase already produces is the only shape Zygote accepts, so the extension is right and the tests' premise (`sol.prob.p === prob.p`) is what broke. That change is not part of this PR.

## Environment

Julia 1.10.12 (LTS). `test/downstream` resolved identically to the failing CI job: ModelingToolkit 11.41.0, ModelingToolkitBase 1.68.3, Symbolics 7.39.0, ChainRules 1.73.0, ChainRulesCore 1.26.1, Zygote 0.7.13, SciMLSensitivity 7.119.3, OrdinaryDiffEq 7.8.1, NonlinearSolve 4.29.1, Mooncake 0.5.53, Enzyme 0.13.201, DifferentiationInterface 0.7.21.

## Failing before

`GROUP=DownstreamAD julia +lts --project=. -e 'using Pkg; Pkg.test()'` with #1584 applied and this PR's change reverted reproduces the CI job's counts exactly:

```
Test Summary:   | Pass  Broken  Total     Time
Autodiff Remake |   13       1     14  5m53.0s

AutoZygote: Test Failed at .../test/downstream/observables_autodiff.jl:119
  Expression: gs.prob.p == gp
   Evaluated: (params = (tunable = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0], initials = nothing, discrete = nothing, constant = nothing, nonnumeric = nothing, caches = nothing),) == (tunable = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0], initials = nothing, discrete = nothing, constant = nothing, nonnumeric = nothing, caches = nothing)

AutoZygote: Error During Test at .../test/downstream/observables_autodiff.jl:222
  Got exception outside of a @test
  type NamedTuple has no field tunable
  Stacktrace:
    [1] getproperty(x::@NamedTuple{params::@NamedTuple{tunable::ChainRules.OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}, initials::Nothing, discrete::Nothing, constant::Nothing, nonnumeric::Nothing, caches::Nothing}}, f::Symbol)
      @ Base ./Base.jl:37
    [2] macro expansion
      @ .../test/downstream/observables_autodiff.jl:228 [inlined]

Test Summary:                                                        | Pass  Fail  Error  Broken  Total     Time
Autodiff Observable Functions                                        |   21     1      1       1     24  8m07.8s
  AutoDiff Observable Functions                                      |    4                           4  1m50.0s
  AD Observable Functions for Initialization                         |    6     1                     7    13.8s
    AutoZygote                                                       |    2     1                     3     4.3s
    AutoMooncake                                                     |    4                           4     9.5s
  DAE Observable function AD                                         |    3            1       1      5    44.2s
    AutoZygote                                                       |    1                           1     2.4s
    AutoMooncake                                                     |    1                           1    27.2s
    DAE Initialization Observable function AD                        |                 1       1      2    14.2s
      AutoZygote                                                     |                 1              1     4.6s
      AutoMooncake (broken)                                          |                         1      1     9.6s
  Adjoints with DAE                                                  |    4                           4  3m49.4s
  NonlinearSolution scalar getindex under AD (SciMLSensitivity#1446) |    2                           2    46.6s
  Integer time-step indexing under AD (issue #1325)                  |    2                           2    28.1s
ERROR: Package SciMLBase errored during testing
GROUP exit=1
```

The group stops there: `Ensemble adjoint gradient correctness` never ran, on CI or locally.

## Passing after

Same command, same environment, with this change:

```
Test Summary:   | Pass  Broken  Total     Time
Autodiff Remake |   13       1     14  5m45.8s

Test Summary:                 | Pass  Broken  Total     Time
Autodiff Observable Functions |   23       1     24  8m00.6s

Test Summary:                         | Pass  Total      Time
Ensemble adjoint gradient correctness |   18     18  55m20.1s

     Testing SciMLBase tests passed
GROUP exit=0
```

The two remaining `Broken` entries are pre-existing `@test_broken`s (the `split = true` block in `remake_autodiff.jl`, the Mooncake DAE-initialization case in `observables_autodiff.jl`). Nothing was skipped, disabled, or loosened.

That run was on `3c8b7d4` (this commit on top of #1584 before it merged); the only difference from this branch's tree is the `3.53.0` → `3.53.1` version bump from #1586.

## Other checks

- `julia +release -e 'using Runic; Runic.main(["--check", "test/downstream/observables_autodiff.jl"])'` — exit 0 (Runic 1.9.0).
- `typos test/downstream/observables_autodiff.jl` — exit 0.

## What I did NOT verify

- **Julia 1.12.** Both touched assertions are inside `ZYGOTE_BACKENDS`, which is empty on 1.12, so none of this executes there.
- **Any group other than `DownstreamAD`.** QA, docs and the rest were not run; this PR touches one test file and no public API.
- **Mooncake and Enzyme paths.** The helper only runs on the `AutoZygote` branches; the Mooncake branches were untouched and unchanged.

## What a reviewer should push back on

- **`_unwrap_parameter_cotangent` encodes a shape in a test.** It peels a `params` level exactly when the primal `prob.p` is a `DespecializedParameters`, so it is a no-op if the solver stops despecializing — but it is still a test acknowledging a solver-internal wrapper. If the considered position is that `sol.prob` should carry the user's own parameter object rather than the despecialized concrete one, the fix belongs in `NonlinearSolveBase.get_concrete_problem` / `_despecialize_parameters` instead and this helper should go. I did not open that upstream issue, because it turns on a design call about `AutoDespecialize` I am not in a position to make.
- **The line-119 comparison's reference is unchanged** (`gp` is still taken w.r.t. `SII.parameter_values(iprob)`); only the left side is unwrapped to match it. An alternative is to take `gp` w.r.t. `SII.parameter_values(isol)` and compare wrapped-to-wrapped. Both discriminate; I preferred keeping the reference gradient on the plain parameter object.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wKpyZHy9u4QhR4ePiVmam
