### PR TITLE
Make Makie timeseries recipes Observable-aware

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -10,6 +10,26 @@ using Makie: Makie, Lines, Plot, PlotSpec
 
 import Makie.SpecApi as S
 
+# Scalar ODESolution <: AbstractVector{<:Real}; skip PointBased index expansion.
+Makie.expand_dimensions(::Makie.PointBased, ::SciMLBase.AbstractTimeseriesSolution) = nothing
+Makie.expand_dimensions(::Makie.PointBased, ::SciMLBase.DEIntegrator) = nothing
+
+# `step!` replaces the solution wrapper with an isequal copy; still reconvert.
+if isdefined(Makie, :ComputePipeline)
+    function Makie.ComputePipeline.is_same(
+            ::SciMLBase.AbstractTimeseriesSolution,
+            ::SciMLBase.AbstractTimeseriesSolution
+        )
+        return false
+    end
+    function Makie.ComputePipeline.is_same(
+            ::SciMLBase.DEIntegrator,
+            ::SciMLBase.DEIntegrator
+        )
+        return false
+    end
+end
+
 function _tspan_indices(t, tspan)
     lo, hi = minmax(tspan[1], tspan[end])
     if length(t) > 1 && t[end] < t[1]

--- a/test/downstream/plot_lines.jl
+++ b/test/downstream/plot_lines.jl
@@ -23,6 +23,48 @@ end
     @test !isempty(converted)
 end
 
+@testset "Makie scalar ODESolution plots time, not indices" begin
+    using Makie
+    scalar_sol = solve(ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0)), Tsit5())
+    fig, ax, plt = Makie.plot(scalar_sol)
+    @test plt isa Makie.PlotList
+    if plt isa Makie.PlotList
+        xs = [Float64(p[1]) for p in plt.plots[1].converted[][1]]
+        @test first(xs) ≈ 0.0 atol = 1.0e-6
+        @test last(xs) ≈ 1.0 atol = 1.0e-6
+    end
+    @test Makie.plot(scalar_sol; idxs = 1).plot isa Makie.PlotList
+end
+
+@testset "Makie Observable of integrator.sol tracks steps" begin
+    using Makie
+    osc = ODEProblem((u, p, t) -> [-u[2], u[1]], [1.0, 0.0], (0.0, 10.0))
+    plotted_xend(plt) = Float64(plt.plots[1].converted[][1][end][1])
+
+    integ = init(osc, Tsit5())
+    osol = Observable(integ.sol)
+    fig, ax, plt = Makie.plot(osol)
+    @test plt isa Makie.PlotList
+    @test plotted_xend(plt) ≈ 0.0 atol = 1.0e-6
+
+    step!(integ, 1.0, true)
+    osol[] = integ.sol
+    @test plotted_xend(plt) ≈ integ.t atol = 1.0e-5
+
+    step!(integ, 1.0, true)
+    osol[] = integ.sol
+    @test plotted_xend(plt) ≈ integ.t atol = 1.0e-5
+
+    integ2 = init(osc, Tsit5())
+    step!(integ2, 1.0, true)
+    osol2 = Observable(integ2.sol)
+    fig2, ax2, plt2 = Makie.plot(osol2)
+    @test plotted_xend(plt2) ≈ 1.0 atol = 1.0e-5
+    step!(integ2, 1.0, true)
+    osol2[] = integ2.sol
+    @test plotted_xend(plt2) ≈ integ2.t atol = 1.0e-5
+end
+
 @testset "tspan crops the plotted series" begin
     using Plots: Plots, plot
     sparse_sol = solve(prob, Tsit5(), dense = false)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -127,8 +127,11 @@ const _ei_nonpublic_third_party = (
     # Base reflection used by the `@generated` dual-eltype scan.
     Symbol("@pure"), :isType,
     # Makie's recipe/conversion plumbing; `Makie.SpecApi` is the documented spec API
-    # but is not marked public.
+    # but is not marked public. `expand_dimensions` opts a type out of PointBased
+    # index expansion. `ComputePipeline.is_same` is the Makie 0.24 hook that forces
+    # reconversion when an `Observable` is assigned an `isequal` solution wrapper.
     :Automatic, :SpecApi, :automatic, :conversion_trait, :plotsym, :plottype,
+    :expand_dimensions, :ComputePipeline, :is_same,
     # Mooncake's tangent-type interface.
     :FData, :RData, :Tangent, :MutableTangent, :NoTangent, :tangent_type,
     # Tracker / ReverseDiff tracked-value internals.
@@ -227,6 +230,8 @@ run_qa(
     ei_kwargs = (;
         all_qualified_accesses_are_public = (; ignore = _ei_nonpublic_qualified_accesses),
         all_explicit_imports_are_public = (; ignore = _ei_nonpublic_explicit_imports),
+        # Makie re-exports ComputePipeline; the owner is the ComputePipeline package.
+        all_qualified_accesses_via_owners = (; ignore = (:ComputePipeline,)),
     ),
 )
 


### PR DESCRIPTION
Please ignore this PR until it is reviewed by @ChrisRackauckas.

Makie was skipping the SciML timeseries recipe for two independent reasons, both of which made `plot(osol)` look frozen when `osol[]` was updated.

1. Scalar `ODESolution <: AbstractVector{<:Real}`, so Makie's `expand_dimensions(::PointBased, ::RealVector)` turned `plot(sol)` into `Lines` of indices vs values and rejected `idxs`.
2. The first `step!` replaces `integrator.sol` with a new wrapper that shares the mutated `t`/`u` arrays. Makie 0.24 `ComputePipeline.is_same` then returns `isequal`, which is true, and skips reconversion. Wrapping the Observable *after* the first step already reconverted (same-object mutation); wrapping at `init` did not.

This PR opts those types out of PointBased index expansion and forces `is_same` to `false` so an Observable assignment always reconverts.

**What this does not change.** Axis autolimits still do not follow a `PlotList` data update. The MRE in https://github.com/SciML/SciMLBase.jl/issues/1588 wraps after the first step, so converted points already grew; `record` looks frozen because the first displayed frame called `reset_limits!` around `[0,1]` and later frames did not. `empty!(ax); plot!(osol)` works because `plot!` on an open Axis resets limits. After this PR, call `autolimits!(ax)` (or `reset_limits!(ax)`) if the window should grow with the series. That is a Makie `PlotList` issue, not missing reconversion.

## Verification

Discriminating tests in `test/downstream/plot_lines.jl`. Fail-before on unfixed `SciMLBaseMakieExt` (SciMLBase 3.53.1, Makie 0.24.14, OrdinaryDiffEq 7.8.1):

```
Makie scalar ODESolution plots time, not indices:
  plt isa Makie.PlotList
  Evaluated: Lines{Tuple{Vector{Point{2, Float64}}}} isa PlotList
  plot(scalar_sol; idxs = 1) -> Invalid attribute idxs for plot type Lines

Makie Observable of integrator.sol tracks steps:
  plotted_xend(plt) ≈ integ.t   # wrap at init, after step 1
  Evaluated: 0.0 ≈ 1.0
  plotted_xend(plt) ≈ integ.t   # wrap at init, after step 2
  Evaluated: 0.0 ≈ 2.0
  # wrap-after-first-step already passed (same-object mutation)

Test Summary:                                      | Pass  Fail  Error  Total  Time
fail-before #1588                                  |    4     3      1      8  23.7s
  Makie scalar ODESolution plots time, not indices |           1      1      2  13.5s
  Makie Observable of integrator.sol tracks steps  |    4     2             6  10.2s
```

Pass-after with the extension restored (same tests, then the official `test/downstream/plot_lines.jl`):

```
fail-before #1588 | 10 passed / 10  20.2s

Plots recipe on multi-state ODESolution                  3 / 3
Makie convert_arguments on multi-state ODESolution       1 / 1
Makie scalar ODESolution plots time, not indices         4 / 4
Makie Observable of integrator.sol tracks steps          6 / 6
tspan crops the plotted series                           8 / 8
tspan crops solutions integrated backwards in time       2 / 2
Integrator recipe without symbolic metadata              9 / 9
Integrator recipe resolves observed equations           22 / 22
symbolic_interpolation on an integrator                  7 / 7
```

Runic 1.10.0 formatted the changed files. `typos` was clean. ExplicitImports on `SciMLBaseMakieExt` (all 6 checks) passed after allow-listing `expand_dimensions`, `ComputePipeline`, and `is_same` as Makie recipe plumbing.

## What was not verified

- Full `GROUP=Downstream` (only `plot_lines.jl`).
- `GROUP=QA` as `Pkg.test()`: Aqua passed; the run then died at `using PythonCall` in `test/qa/qa.jl:71` (pixi/CondaPkg `ProcessExited(1)` during PythonCall.C init). That is before ExplicitImports. Targeted ExplicitImports on the Makie extension passed.
- Docs build: no public API or docstring change.
- GLMakie `record` / interactive display. Converted-data assertions used Makie/CairoMakie without a GL backend.
- Makie 0.21–0.23. `expand_dimensions` is used there; the `is_same` override is gated on `isdefined(Makie, :ComputePipeline)` (0.24).
- GPU / allowed-to-fail jobs.

## Review notes

- `ComputePipeline.is_same` is not public Makie API. It is the 0.24 hook for "this value may have mutated / an `isequal` wrapper is not the same plot." Older Makie is skipped via `isdefined`.
- Judgment call: leave Axis autolimits to Makie rather than `empty!`/`plot!` from the recipe.

Please ignore this PR until it is reviewed by @ChrisRackauckas.

🤖 Generated with Grok Build TUI (model: grok-4.6)
Session: local `/home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260907_062232_52914/01a07b3f-05bc-77d1-9346-1f1581b8129f`
