### PR TITLE
Add 32-bit Core CI lane via test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,6 +2,12 @@
 versions = ["lts", "1", "pre"]
 num_threads = 11
 
+["Core 32-bit"]
+group = "Core"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [Downstream]
 versions = ["lts", "1", "pre"]
 num_threads = 11


### PR DESCRIPTION

## Summary
- Add a `["Core 32-bit"]` matrix-only alias (`group = "Core"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- Infrastructure already lives in SciML/.github; this is the per-repo opt-in.

## Test plan
- [ ] CI shows `Core (julia 1, ubuntu-latest, x86)`
- [ ] Job green, or failure is a real Int32/WordSize bug to fix
