### PR TITLE
Trim unused Makie DEIntegrator hooks after #1589

### DIFF
--- a/ext/SciMLBaseMakieExt.jl
+++ b/ext/SciMLBaseMakieExt.jl
@@ -11,20 +11,18 @@ using Makie: Makie, Lines, Plot, PlotSpec
 import Makie.SpecApi as S
 
 # Scalar ODESolution <: AbstractVector{<:Real}; skip PointBased index expansion.
+# DEIntegrator is not an AbstractVector, so it does not need this hook.
 Makie.expand_dimensions(::Makie.PointBased, ::SciMLBase.AbstractTimeseriesSolution) = nothing
-Makie.expand_dimensions(::Makie.PointBased, ::SciMLBase.DEIntegrator) = nothing
 
 # `step!` replaces the solution wrapper with an isequal copy; still reconvert.
+# Same-object DEIntegrator mutation already makes ComputePipeline's default
+# `is_same` return false, so only solutions need an override.
+# Axis autolimits still do not follow PlotList data growth; call
+# `autolimits!(ax)` / `reset_limits!(ax)` after expanding the time window.
 if isdefined(Makie, :ComputePipeline)
     function Makie.ComputePipeline.is_same(
             ::SciMLBase.AbstractTimeseriesSolution,
             ::SciMLBase.AbstractTimeseriesSolution
-        )
-        return false
-    end
-    function Makie.ComputePipeline.is_same(
-            ::SciMLBase.DEIntegrator,
-            ::SciMLBase.DEIntegrator
         )
         return false
     end

--- a/test/downstream/plot_lines.jl
+++ b/test/downstream/plot_lines.jl
@@ -65,6 +65,31 @@ end
     @test plotted_xend(plt2) ≈ integ2.t atol = 1.0e-5
 end
 
+# Combines both #1588 fixes: scalar AbstractVector dispatch + isequal sol wrappers.
+@testset "Makie Observable of scalar integrator.sol tracks steps" begin
+    using Makie
+    decay = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 10.0))
+    plotted_xend(plt) = Float64(plt.plots[1].converted[][1][end][1])
+    plotted_yend(plt) = Float64(plt.plots[1].converted[][1][end][2])
+
+    integ = init(decay, Tsit5())
+    osol = Observable(integ.sol)
+    fig, ax, plt = Makie.plot(osol)
+    @test plt isa Makie.PlotList
+    @test plotted_xend(plt) ≈ 0.0 atol = 1.0e-6
+    @test plotted_yend(plt) ≈ 1.0 atol = 1.0e-6
+
+    step!(integ, 1.0, true)
+    osol[] = integ.sol
+    @test plotted_xend(plt) ≈ integ.t atol = 1.0e-5
+    @test plotted_yend(plt) ≈ integ.u atol = 1.0e-5
+
+    step!(integ, 1.0, true)
+    osol[] = integ.sol
+    @test plotted_xend(plt) ≈ integ.t atol = 1.0e-5
+    @test plotted_yend(plt) ≈ integ.u atol = 1.0e-5
+end
+
 @testset "tspan crops the plotted series" begin
     using Plots: Plots, plot
     sparse_sol = solve(prob, Tsit5(), dense = false)


### PR DESCRIPTION
## Summary
- Remove the unused `DEIntegrator` `expand_dimensions` / `ComputePipeline.is_same` overrides from #1589 (integrators are not `AbstractVector`, and same-object mutation already forces reconversion).
- Document that PlotList axis autolimits still need an explicit `autolimits!(ax)` / `reset_limits!(ax)` after the time window grows.
- Add a scalar `Observable(integrator.sol)` update test that exercises both #1588 fixes together (PointBased opt-out + isequal solution wrappers).

Follow-up to https://github.com/SciML/SciMLBase.jl/pull/1589.

## Test plan
- [x] Targeted Makie/CairoMakie regression for the existing scalar + Observable tests and the new scalar Observable test (all passed locally)
- [ ] CI `GROUP=Downstream` / `plot_lines.jl`


Made with [Cursor](https://cursor.com)