### PR TITLE
Run runic on more docstrings and wrap some doc lines

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -359,9 +359,9 @@ const AbstractSteadyStateProblem{
 $(TYPEDEF)
 
 Base interface for problems that directly solve or sample an
-[`AbstractNoiseProcess`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoiseProcess). Concrete noise problems should provide a `noise`
-field, a `tspan`, and solver keyword arguments. Their in-place behavior delegates
-to the stored noise process through [`isinplace`](@ref).
+[`AbstractNoiseProcess`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#SciMLBase.AbstractNoiseProcess).
+Concrete noise problems should provide a `noise` field, a `tspan`, and solver keyword arguments.
+Their in-place behavior delegates to the stored noise process through [`isinplace`](@ref).
 """
 abstract type AbstractNoiseProblem <: AbstractDEProblem end
 
@@ -575,8 +575,10 @@ problem family stay as `solve` or `init` keyword arguments. Solver packages
 normally implement dispatches such as:
 
 ```julia
-CommonSolve.solve(prob::AbstractSciMLProblem, alg::AbstractSciMLAlgorithm;
-    kwargs...)
+CommonSolve.solve(
+    prob::AbstractSciMLProblem, alg::AbstractSciMLAlgorithm;
+    kwargs...
+)
 ```
 
 Algorithms should implement the relevant trait methods in `alg_traits.jl` when

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -466,7 +466,7 @@ Multiple callbacks can be chained together to form a `CallbackSet`. A
 `DiscreteCallback`, `VectorContinuousCallback`, `nothing`, or other
 `CallbackSet` instances:
 
-    CallbackSet(cb1,cb2,cb3)
+    CallbackSet(cb1, cb2, cb3)
 
 You can pass as many callbacks as needed. Nested callback sets are flattened into
 two ordered collections, `continuous_callbacks` and `discrete_callbacks`. Public
@@ -475,8 +475,8 @@ erased to reuse compilation.
 
 When a solver encounters multiple callbacks, the following rules apply:
 
-  - `ContinuousCallback`s and `VectorContinuousCallback`s are applied before `DiscreteCallback`s. (This is because
-    they often implement event-finding that will backtrack the timestep to smaller
+  - `ContinuousCallback`s and `VectorContinuousCallback`s are applied before `DiscreteCallback`s.
+    (This is because they often implement event-finding that will backtrack the timestep to smaller
     than `dt`).
   - For `ContinuousCallback`s and `VectorContinuousCallback`s, the event times are found by rootfinding and only
     the first `ContinuousCallback` or `VectorContinuousCallback` affect is applied.

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -28,11 +28,11 @@ of compile times has failed. This is most likely due to an issue internal to the
 found upon evaluation of the model. To work around this issue, use `SciMLBase.FullSpecialize`, like:
 
 ```julia
-ODEProblem{iip,SciMLBase.FullSpecialize}(f,u0,tspan,p)
+ODEProblem{iip, SciMLBase.FullSpecialize}(f, u0, tspan, p)
 ```
 
 where `iip` is either true or false depending on the in-placeness of the definition of `f` (i.e. for ODEs
-if `f` has 3 arguments `(u,p,t)` then it's false, otherwise `f(du,u,p,t)` is true).
+if `f` has 3 arguments `(u, p, t)` then it's false, otherwise `f(du, u, p, t)` is true).
 
 For more information on the control of specialization options, please see the documentation at:
 
@@ -48,11 +48,11 @@ An arithmetic operation was performed on a NullParameters object. This means no 
 into the AbstractSciMLProblem (e.x.: ODEProblem) but the parameters object `p` was used in an arithmetic
 expression. Two common reasons for this issue are:
 
-1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f,u0,tspan)` should
-   be `ODEProblem(f,u0,tspan,p)` in order to use parameters.
+1. Forgetting to pass parameters into the problem constructor. For example, `ODEProblem(f, u0, tspan)` should
+   be `ODEProblem(f, u0, tspan, p)` in order to use parameters.
 
 2. Using the wrong function signature. For example, with `ODEProblem`s the function signature is always
-   `f(du,u,p,t)` for the in-place form or `f(u,p,t)` for the out-of-place form. Note that the `p` argument
+   `f(du, u, p, t)` for the in-place form or `f(u, p, t)` for the out-of-place form. Note that the `p` argument
    will always be in the function signature regardless of if the problem is defined with parameters!
 """
 

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -14,11 +14,13 @@ per-trajectory RNG state when `rng` or `seed` is supplied to `solve`.
 ## Constructor
 
 ```julia
-EnsembleProblem(prob::AbstractSciMLProblem;
+EnsembleProblem(
+    prob::AbstractSciMLProblem;
     output_func = (sol, ctx) -> (sol, false),
     prob_func = (prob, ctx) -> prob,
     reduction = (u, data, I) -> (append!(u, data), false),
-    u_init = [], safetycopy = prob_func !== DEFAULT_PROB_FUNC)
+    u_init = [], safetycopy = prob_func !== DEFAULT_PROB_FUNC
+)
 ```
 
 ## Positional Arguments

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -211,11 +211,11 @@ This is incompatible because Numbers cannot be mutated, i.e.
 `x = 2.0; y = 2.0; x .= y` will error.
 
 If using a immutable initial condition type, please use the out-of-place form.
-I.e. define the function `du=f(u,p,t)` instead of attempting to "mutate" the immutable `du`.
+I.e. define the function `du = f(u, p, t)` instead of attempting to "mutate" the immutable `du`.
 
 If your differential equation function was defined with multiple dispatches and one is
 in-place, then the automatic detection will choose in-place. In this case, override the
-choice in the problem constructor, i.e. `ODEProblem{false}(f,u0,tspan,p,kwargs...)`.
+choice in the problem constructor, i.e. `ODEProblem{false}(f, u0, tspan, p, kwargs...)`.
 
 For a longer discussion on mutability vs immutability and in-place vs out-of-place, see:
 <https://docs.sciml.ai/DiffEqDocs/stable/tutorials/faster_ode_example#Example-Accelerating-a-Non-Stiff-Equation:-The-Lorenz-Equation>
@@ -268,7 +268,7 @@ end
 
 const NON_SOLVER_MESSAGE = """
 The arguments to solve are incorrect.
-The second argument must be a solver choice, `solve(prob,alg)`
+The second argument must be a solver choice, `solve(prob, alg)`
 where `alg` is a `<: AbstractDEAlgorithm`, e.g. `Tsit5()`.
 
 Please double check the arguments being sent to the solver.
@@ -291,10 +291,10 @@ Noise sizes are incompatible. The expected number of noise terms in the defined
 
 Note: Noise process definitions require that users specify `u0`, and this value is
 directly used in the definition. For example, if `noise = WienerProcess(0.0,0.0)`,
-then the noise process is a scalar with `u0=0.0`. If `noise = WienerProcess(0.0,[0.0])`,
-then the noise process is a vector with `u0=0.0`. If `noise_rate_prototype = zeros(2,4)`,
+then the noise process is a scalar with `u0=0.0`. If `noise = WienerProcess(0.0, [0.0])`,
+then the noise process is a vector with `u0=0.0`. If `noise_rate_prototype = zeros(2, 4)`,
 then the noise process must be a 4-dimensional process, for example
-`noise = WienerProcess(0.0,zeros(4))`. This error is a sign that the user definition
+`noise = WienerProcess(0.0, zeros(4))`. This error is a sign that the user definition
 of `noise_rate_prototype` and `noise` are not aligned in this manner and the definitions should
 be double checked.
 """
@@ -390,8 +390,8 @@ from RecursiveArrayTools.jl. For example:
 
 ```julia
 using RecursiveArrayTools
-u0 = ArrayPartition([1.0,2.0],[3.0,4.0])
-u0 = VectorOfArray([1.0,2.0],[3.0,4.0])
+u0 = ArrayPartition([1.0, 2.0], [3.0, 4.0])
+u0 = VectorOfArray([1.0, 2.0], [3.0, 4.0])
 ```
 
 are both initial conditions which would be compatible with
@@ -501,24 +501,24 @@ Instead, change your equation from using tuple constructors `()`
 to static array constructors `SA[]`. For example, change:
 
 ```julia
-function ftup((a,b),p,t)
-  return b,-a
+function ftup((a, b), p, t)
+    return (b, -a)
 end
 u0 = (1.0,2.0)
 tspan = (0.0,1.0)
-ODEProblem(ftup,u0,tspan)
+ODEProblem(ftup, u0, tspan)
 ```
 
 to:
 
 ```julia
 using StaticArrays
-function fsa(u,p,t)
-    SA[u[2],u[1]]
+function fsa(u, p, t)
+    return SA[u[2], u[1]]
 end
-u0 = SA[1.0,2.0]
-tspan = (0.0,1.0)
-ODEProblem(ftup,u0,tspan)
+u0 = SA[1.0, 2.0]
+tspan = (0.0, 1.0)
+ODEProblem(ftup, u0, tspan)
 ```
 
 This will be safer and fast for small ODEs. For more information, see:

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -892,17 +892,6 @@ documented `reinit!` method. Supported optional keywords can still vary by
 problem family. The default is `false`.
 """
 has_reinit(i::DEIntegrator) = false
-@doc """
-    has_reinit(i::DEIntegrator)
-
-Return whether `i` supports reinitialization through [`reinit!`](@ref).
-
-Generic code should query this trait before attempting to reuse an initialized
-solver object. A `true` result guarantees support for restarting from a new
-initial state and integration interval through the concrete integrator's
-documented `reinit!` method. Supported optional keywords can still vary by
-problem family. The default is `false`.
-""" has_reinit
 
 log_numerical_instability(integrator; jacobian_logging::Bool = true) = ""
 
@@ -1363,18 +1352,6 @@ integrator fields. The default is `false`, which tells generic code not to assum
 that a `stats` field or stats update path exists.
 """
 has_stats(i::DEIntegrator) = false
-@doc """
-    has_stats(i::DEIntegrator)
-
-Return whether `i` exposes mutable solve statistics through its integrator
-interface.
-
-Solver integrators that maintain counters such as function evaluations, rejected
-steps, nonlinear iterations, or linear solves should overload this trait to
-return `true` and provide the corresponding statistics through their documented
-integrator fields. The default is `false`, which tells generic code not to assume
-that a `stats` field or stats update path exists.
-""" has_stats
 
 """
     isadaptive(i::DEIntegrator)

--- a/src/problems/analytical_problems.jl
+++ b/src/problems/analytical_problems.jl
@@ -46,8 +46,11 @@ end
 
 export AnalyticalProblem, AbstractAnalyticalProblem
 
-@doc doc"""
-    AnalyticalAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    AnalyticalAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing,
+        alias_tstops = nothing, alias = nothing
+    )
 
 Control which `AnalyticalProblem` inputs and solver option arrays may be
 aliased.

--- a/src/problems/bvp_problems.jl
+++ b/src/problems/bvp_problems.jl
@@ -21,7 +21,7 @@ convention of the associated `BVPFunction` used for type-stable construction.
 """
 struct TwoPointBVProblem{iip} end # The iip is needed to make type stable construction easier
 
-@doc doc"""
+"""
 
 Defines an BVP problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/>
@@ -32,7 +32,7 @@ To define a BVP Problem, you simply need to give the function ``f`` and the init
 condition ``u_0`` which define an ODE:
 
 ```math
-\frac{du}{dt} = f(u,p,t)
+\\frac{du}{dt} = f(u,p,t)
 ```
 
 along with an implicit function `bc` which defines the residual equation, where
@@ -45,10 +45,10 @@ is the manifold on which the solution must live. A common form for this is the
 two-point `BVProblem` where the manifold defines the solution at two points:
 
 ```math
-\begin{align*}
-u(t_0) &= a, \\
+\\begin{align*}
+u(t_0) &= a, \\\\
 u(t_f) &= b
-\end{align*}
+\\end{align*}
 ```
 
 ## Problem Type
@@ -56,16 +56,16 @@ u(t_f) &= b
 ### Constructors
 
 ```julia
-TwoPointBVProblem{isinplace}(f, bc, u0, tspan, p=NullParameters(); kwargs...)
-BVProblem{isinplace}(f, bc, u0, tspan, p=NullParameters(); kwargs...)
+TwoPointBVProblem{isinplace}(f, bc, u0, tspan, p = NullParameters(); kwargs...)
+BVProblem{isinplace}(f, bc, u0, tspan, p = NullParameters(); kwargs...)
 ```
 
 or if we have an initial guess function `initialGuess(p, t)` for the given BVP,
 we can pass the initial guess to the problem constructors:
 
 ```julia
-TwoPointBVProblem{isinplace}(f, bc, initialGuess, tspan, p=NullParameters(); kwargs...)
-BVProblem{isinplace}(f, bc, initialGuess, tspan, p=NullParameters(); kwargs...)
+TwoPointBVProblem{isinplace}(f, bc, initialGuess, tspan, p = NullParameters(); kwargs...)
+BVProblem{isinplace}(f, bc, initialGuess, tspan, p = NullParameters(); kwargs...)
 ```
 
 For any BVP problem type, `bc` must be inplace if `f` is inplace. Otherwise it must be
@@ -331,7 +331,7 @@ used for type-stable construction.
 """
 struct TwoPointSecondOrderBVProblem{iip} end # The iip is needed to make type stable construction easier
 
-@doc doc"""
+"""
 
 Defines a second order BVP problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/bvp_types/>
@@ -342,7 +342,7 @@ To define a second order BVP Problem, you simply need to give the function ``f``
 condition ``u_0`` which define an ODE:
 
 ```math
-u'' = \frac{d^2 u}{dt^2} = f(u', u, p, t)
+u'' = \\frac{d^2 u}{dt^2} = f(u', u, p, t)
 ```
 
 along with an implicit function `bc` which defines the residual equation, where
@@ -355,10 +355,10 @@ is the manifold on which the solution must live. A common form for this is the
 two-point `SecondOrderBVProblem` where the manifold defines the solution at two points:
 
 ```math
-\begin{align*}
-g(u(t_0), u'(t_0)) &= 0 \\
+\\begin{align*}
+g(u(t_0), u'(t_0)) &= 0 \\\\
 g(u(t_f), u'(t_f)) &= 0
-\end{align*}
+\\end{align*}
 ```
 
 ## Problem Type
@@ -366,16 +366,16 @@ g(u(t_f), u'(t_f)) &= 0
 ### Constructors
 
 ```julia
-TwoPointSecondOrderBVProblem{isinplace}(f, bc, u0, tspan, p=NullParameters(); kwargs...)
-SecondOrderBVProblem{isinplace}(f, bc, u0, tspan, p=NullParameters(); kwargs...)
+TwoPointSecondOrderBVProblem{isinplace}(f, bc, u0, tspan, p = NullParameters(); kwargs...)
+SecondOrderBVProblem{isinplace}(f, bc, u0, tspan, p = NullParameters(); kwargs...)
 ```
 
 or if we have an initial guess function `initialGuess(p, t)` for the given BVP,
 we can pass the initial guess to the problem constructors:
 
 ```julia
-TwoPointSecondOrderBVProblem{isinplace}(f, bc, initialGuess, tspan, p=NullParameters(); kwargs...)
-SecondOrderBVProblem{isinplace}(f, bc, initialGuess, tspan, p=NullParameters(); kwargs...)
+TwoPointSecondOrderBVProblem{isinplace}(f, bc, initialGuess, tspan, p = NullParameters(); kwargs...)
+SecondOrderBVProblem{isinplace}(f, bc, initialGuess, tspan, p = NullParameters(); kwargs...)
 ```
 
 For any BVP problem type, `bc` must be inplace if `f` is inplace. Otherwise it must be
@@ -412,7 +412,8 @@ resid_b = bcb(du_b, u_b, p)
 ```
 
 where `resid_a` and `resid_b` are the residuals at the two endpoints, `u_a` and `u_b` are
-the solution values at the two endpoints, `du_a` and `du_b` are the derivative of solution values at the two endpoints, and `p` are the parameters.
+the solution values at the two endpoints, `du_a` and `du_b` are the derivative
+of solution values at the two endpoints, and `p` are the parameters.
 
 
 Parameters are optional, and if not given, then a `NullParameters()` singleton
@@ -573,8 +574,11 @@ function TwoPointSecondOrderBVProblem(
     return TwoPointSecondOrderBVProblem(f, bc, u0, (tspan[1], tspan[end]), p; kwargs...)
 end
 
-@doc doc"""
-    BVPAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    BVPAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing
+    )
 
 Control which BVP problem inputs and solver option arrays may be aliased.
 

--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -13,7 +13,7 @@ prefer the [`AbstractDAEProblem`](@ref) interface and problem traits.
 """
 struct StandardDAEProblem end
 
-@doc doc"""
+"""
 
 Defines an implicit ordinary differential equation (ODE) or
 differential-algebraic equation (DAE) problem.
@@ -79,7 +79,7 @@ To use a sample problem, such as `prob_dae_resrob`, you can do something like:
 #] add DAEProblemLibrary
 using DAEProblemLibrary
 prob = DAEProblemLibrary.prob_dae_resrob
-sol = solve(prob,IDA())
+sol = solve(prob, IDA())
 ```
 """
 struct DAEProblem{uType, duType, tType, isinplace, P, F, K, D, PT} <:
@@ -166,8 +166,11 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: DAEProblem}
     end
 end
 
-@doc doc"""
-    DAEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    DAEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing
+    )
 
 Control which `DAEProblem` inputs and solver option arrays may be aliased.
 

--- a/src/problems/dde_problems.jl
+++ b/src/problems/dde_problems.jl
@@ -11,7 +11,7 @@ dynamical or second-order DDE encodings.
 """
 struct StandardDDEProblem end
 
-@doc doc"""
+"""
 
 Defines a delay differential equation (DDE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dde_types/>
@@ -23,11 +23,11 @@ condition ``u_0`` at time point ``t_0``, and the history function ``h``
 which together define a DDE:
 
 ```math
-\begin{align*}
-\frac{du}{dt} &= f(u,h,p,t) & (t \geq t_0) \\
-u(t_0) &= u_0, \\
+\\begin{align*}
+\\frac{du}{dt} &= f(u,h,p,t) & (t ≥ t_0) \\\\
+u(t_0) &= u_0, \\\\
 u(t)   &= h(t) & (t < t_0).
-\end{align*}
+\\end{align*}
 ```
 
 ``f`` should be specified as `f(u, h, p, t)` (or in-place as `f(du, u, h, p, t)`),
@@ -78,7 +78,8 @@ DDEProblem{isinplace,specialize}(f[, u0], h, tspan[, p]; <keyword arguments>)
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+the specialization level. See
+[Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -96,7 +97,8 @@ For specifying Jacobians and mass matrices, see the
 ### Arguments
 
 * `f`: The function in the DDE.
-* `u0`: The initial condition. Defaults to the value `h(p, first(tspan))` of the history function evaluated at the initial time point.
+* `u0`: The initial condition. Defaults to the value `h(p, first(tspan))` of the
+  history function evaluated at the initial time point.
 * `h`: The history function for the DDE before `t0`.
 * `tspan`: The timespan for the problem.
 * `p`: The parameters with which function `f` is called. Defaults to `NullParameters`.
@@ -104,20 +106,22 @@ For specifying Jacobians and mass matrices, see the
 * `dependent_lags` A tuple of functions `(u, p, t) -> lag` for the state-dependent lags
   used by the history function `h`. Defaults to `()`.
 * `neutral`: If the DDE is neutral, i.e., if delays appear in derivative terms.
-* `order_discontinuity_t0`: The order of the discontinuity at the initial time point. Defaults to `0` if an initial condition `u0` is provided. Otherwise, it is forced to be greater or equal than `1`.
+* `order_discontinuity_t0`: The order of the discontinuity at the initial time point.
+  Defaults to `0` if an initial condition `u0` is provided. Otherwise, it
+  is forced to be greater or equal than `1`.
 * `kwargs`: The keyword arguments passed onto the solves.
 
 ## Dynamical Delay Differential Equations
 
-Much like the dynamical ODE problem (see the Differential Equation Problem Types page of the SciMLBase interface documentation), a
-Dynamical DDE is a partitioned DDE
+Much like the dynamical ODE problem (see the Differential Equation Problem Types
+page of the SciMLBase interface documentation), a Dynamical DDE is a partitioned DDE
 of the form:
 
 ```math
-\begin{align*}
-\frac{dv}{dt} &= f_1(u,t,h) \\
-\frac{du}{dt} &= f_2(v,h) \\
-\end{align*}
+\\begin{align*}
+\\frac{dv}{dt} &= f_1(u,t,h) \\\\
+\\frac{du}{dt} &= f_2(v,h) \\\\
+\\end{align*}
 ```
 
 ### Constructors
@@ -132,20 +136,24 @@ This is determined automatically, but not inferred.
 ### Arguments
 
 * `f`: The function in the DDE.
-* `v0` and `u0`: The initial condition. Defaults to the values `h(p, first(tspan))...` of the history function evaluated at the initial time point.
-* `h`: The history function for the DDE before `t0`. Must return an object with the indices 1 and 2, with the values of `v` and `u` respectively.
+* `v0` and `u0`: The initial condition. Defaults to the values `h(p, first(tspan))...`
+  of the history function evaluated at the initial time point.
+* `h`: The history function for the DDE before `t0`. Must return an object with
+  the indices 1 and 2, with the values of `v` and `u` respectively.
 * `tspan`: The timespan for the problem.
 * `p`: The parameters with which function `f` is called. Defaults to `NullParameters`.
 * `constant_lags`: A collection of constant lags used by the history function `h`. Defaults to `()`.
 * `dependent_lags` A tuple of functions `(v, u, p, t) -> lag` for the state-dependent lags
   used by the history function `h`. Defaults to `()`.
 * `neutral`: If the DDE is neutral, i.e., if delays appear in derivative terms.
-* `order_discontinuity_t0`: The order of the discontinuity at the initial time point. Defaults to `0` if an initial condition `u0` is provided. Otherwise, it is forced to be greater or equal than `1`.
+* `order_discontinuity_t0`: The order of the discontinuity at the initial time point.
+  Defaults to `0` if an initial condition `u0` is provided.
+  Otherwise, it is forced to be greater or equal than `1`.
 * `kwargs`: The keyword arguments passed onto the solves.
 
 For dynamical and second order DDEs, the history function will return an object with
 the indices 1 and 2 defined, where `h(p, t_prev)[1]` is the value of ``f_2(v, u, h, p,
-t_{\mathrm{prev}})`` and `h(p, t_prev)[2]` is the value of ``f_1(v, u, h, p, t_{\mathrm{prev}})``
+t_{\\mathrm{prev}})`` and `h(p, t_prev)[2]` is the value of ``f_1(v, u, h, p, t_{\\mathrm{prev}})``
 (this is for consistency with the ordering of the initial conditions in the constructor).
 The supplied history function must also return such a 2-index object, which can be accomplished
 with a tuple `(v,u)` or vector `[v,u]`.
@@ -168,10 +176,10 @@ as well.
 From this form, a dynamical ODE:
 
 ```math
-\begin{align*}
-v' &= f(v,u,h,p,t) \\
+\\begin{align*}
+v' &= f(v,u,h,p,t) \\\\
 u' &= v
-\end{align*}
+\\end{align*}
 ```
 
 ### Constructors
@@ -187,18 +195,24 @@ This is determined automatically, but not inferred.
 ### Arguments
 
 * `f`: The function in the DDE.
-* `du0` and `u0`: The initial condition. Defaults to the values `h(p, first(tspan))...` of the history function evaluated at the initial time point.
-* `h`: The history function for the DDE before `t0`. Must return an object with the indices 1 and 2, with the values of `v` and `u` respectively.
+* `du0` and `u0`: The initial condition. Defaults to the values `h(p, first(tspan))...`
+  of the history function evaluated at the initial time point.
+* `h`: The history function for the DDE before `t0`. Must return an object with
+  the indices 1 and 2, with the values of `v` and `u` respectively.
 * `tspan`: The timespan for the problem.
 * `p`: The parameters with which function `f` is called. Defaults to `NullParameters`.
 * `constant_lags`: A collection of constant lags used by the history function `h`. Defaults to `()`.
 * `dependent_lags` A tuple of functions `(v, u, p, t) -> lag` for the state-dependent lags
   used by the history function `h`. Defaults to `()`.
 * `neutral`: If the DDE is neutral, i.e., if delays appear in derivative terms.
-* `order_discontinuity_t0`: The order of the discontinuity at the initial time point. Defaults to `0` if an initial condition `u0` is provided. Otherwise, it is forced to be greater or equal than `1`.
+* `order_discontinuity_t0`: The order of the discontinuity at the initial time point.
+  Defaults to `0` if an initial condition `u0` is provided.
+  Otherwise, it is forced to be greater or equal than `1`.
 * `kwargs`: The keyword arguments passed onto the solves.
 
-As above, the history function will return an object with indices 1 and 2, with the values of `du` and `u` respectively. The supplied history function must also match this return type, e.g. by returning a 2-element tuple or vector.
+As above, the history function will return an object with indices 1 and 2, with the values
+of `du` and `u` respectively. The supplied history function must also match this return
+type, e.g. by returning a 2-element tuple or vector.
 
 ## Example Problems
 
@@ -307,7 +321,8 @@ Marker supertype for structured DDE problem layouts.
 
 Subtypes identify DDE problems constructed from partitioned first-order dynamics
 or from second-order dynamics. These markers are available through
-[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) on the common `DDEProblem` representation so solvers can
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+on the common `DDEProblem` representation so solvers can
 preserve or recover the structured interpretation when needed.
 """
 abstract type AbstractDynamicalDDEProblem end
@@ -317,8 +332,9 @@ $(TYPEDEF)
 
 Marker for partitioned dynamical DDE problem layouts.
 
-`DynamicalDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when a DDE is
-constructed from two coupled first-order components. The `iip` parameter records
+`DynamicalDDEProblem{iip}` is returned by
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+when a DDE is constructed from two coupled first-order components. The `iip` parameter records
 the in-place convention of the underlying `DynamicalDDEFunction`.
 """
 struct DynamicalDDEProblem{iip} <: AbstractDynamicalDDEProblem end
@@ -381,8 +397,9 @@ $(TYPEDEF)
 
 Marker for second-order DDE problem layouts.
 
-`SecondOrderDDEProblem{iip}` is returned by [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when a
-second-order delay equation is converted to the partitioned DDE form used by
+`SecondOrderDDEProblem{iip}` is returned by
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+when a second-order delay equation is converted to the partitioned DDE form used by
 `DDEProblem`. The `iip` parameter records the in-place convention of the
 second-derivative function.
 """
@@ -459,8 +476,11 @@ function SecondOrderDDEProblem(f::DynamicalDDEFunction, args...; kwargs...)
     end
 end
 
-@doc doc"""
-    DDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    DDEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing
+    )
 
 Control which `DDEProblem` inputs and solver option arrays may be aliased.
 

--- a/src/problems/discrete_problems.jl
+++ b/src/problems/discrete_problems.jl
@@ -1,7 +1,7 @@
 const DISCRETE_INPLACE_DEFAULT = DiscreteFunction{true}((du, u, p, t) -> du .= u)
 const DISCRETE_OUTOFPLACE_DEFAULT = DiscreteFunction{false}((u, p, t) -> u)
 
-@doc doc"""
+"""
 
 Defines a discrete dynamical system problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/>
@@ -12,7 +12,7 @@ To define a Discrete Problem, you simply need to give the function ``f`` and the
 condition ``u_0`` which define a function map:
 
 ```math
-u_{n+1} = f(u_{n},p,t_{n+1})
+u_{n+1} = f(u_n, p, t_{n+1})
 ```
 
 `f` should be specified as `f(un,p,t)` (or in-place as `f(unp1,un,p,t)`), and `u_0` should
@@ -27,7 +27,7 @@ Note that if the discrete solver is set to have `scale_by_time=true`, then the p
 is interpreted as the map:
 
 ```math
-u_{n+1} = u_n + dt f(u_{n},p,t_{n+1})
+u_{n+1} = u_n + dt \\, f(u_n, p, t_{n+1})
 ```
 
 ## Problem Type
@@ -183,8 +183,8 @@ function DiscreteProblem(
     return DiscreteProblem(f, u0, tspan, p; kwargs...)
 end
 
-@doc doc"""
-    DiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+"""
+    DiscreteAliasSpecifier(; alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
 
 Control which `DiscreteProblem` inputs a solver may alias.
 

--- a/src/problems/eigenvalue_problems.jl
+++ b/src/problems/eigenvalue_problems.jl
@@ -19,22 +19,22 @@ EnumX.@enumx EigenvalueTarget begin
     SmallestImaginaryPart
 end
 
-@doc doc"""
+"""
 
 Defines a standard or generalized eigenvalue problem.
 
 ## Mathematical Specification of an Eigenvalue Problem
 
-The standard problem finds pairs ``(\lambda, v)`` satisfying
+The standard problem finds pairs ``(λ, v)`` satisfying
 
 ```math
-A v = \lambda v
+A v = λ v
 ```
 
 If a second operator `B` is supplied, the generalized problem is solved instead:
 
 ```math
-A v = \lambda B v
+A v = λ B v
 ```
 
 ### Type Promotion Rules
@@ -52,9 +52,11 @@ A v = \lambda B v
 ### Constructors
 
 ```julia
-EigenvalueProblem(A, B = nothing, p = NullParameters();
+EigenvalueProblem(
+    A, B = nothing, p = NullParameters();
     num_eigenpairs = nothing, eigentarget = EigenvalueTarget.LargestMagnitude,
-    shift = nothing, u0 = nothing, kwargs...)
+    shift = nothing, u0 = nothing, kwargs...
+)
 ```
 
 ### Keyword Arguments

--- a/src/problems/implicit_discrete_problems.jl
+++ b/src/problems/implicit_discrete_problems.jl
@@ -1,4 +1,4 @@
-@doc doc"""
+"""
 
 Defines a discrete dynamical system problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/discrete_types/>
@@ -9,7 +9,7 @@ To define an ImplicitDiscrete Problem, you simply need to give the function ``f`
 condition ``u_0`` which define a function map:
 
 ```math
-f(u_{n+1}, u_n, p, t_{n+1}, \text{integ}) = 0
+f(u_{n+1}, u_n, p, t_{n+1}, \\text{integ}) = 0
 ```
 
 `f` should be specified as `f(un,p,t)` (or in-place as `f(unp1,un,p,t)`), and
@@ -19,24 +19,23 @@ one is allowed to provide `u₀` as arbitrary matrices / higher dimension tensor
 as well. ``u_{n+1}`` only depends on the previous iteration ``u_{n}`` and
 ``t_{n+1}``. The default ``t_{n+1}`` is chosen adaptively, and when ``dt`` is
 specified, we have ``t_n = t_0 + n*dt``. `integ` contains the fields:
-```julia
-dt: the time step
-```
+- `dt`: the time step
 
 ## Problem Type
 
 ### Constructors
 
-- `ImplicitDiscreteProblem(f::ImplicitDiscreteFunction,u0,tspan,p=NullParameters();kwargs...)` :
+- `ImplicitDiscreteProblem(f::ImplicitDiscreteFunction, u0, tspan, p = NullParameters(); kwargs...)` :
   Defines the discrete problem with the specified functions.
-- `ImplicitDiscreteProblem{isinplace,specialize}(f,u0,tspan,p=NullParameters();kwargs...)` :
+- `ImplicitDiscreteProblem{isinplace, specialize}(f, u0, tspan, p = NullParameters(); kwargs...)` :
   Defines the discrete problem with the specified functions.
-- `ImplicitDiscreteProblem{isinplace,specialize}(u0,tspan,p=NullParameters();kwargs...)` :
+- `ImplicitDiscreteProblem{isinplace, specialize}(u0, tspan, p = NullParameters(); kwargs...)` :
   Defines the discrete problem with the identity map.
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+the specialization level. See
+[Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction
@@ -143,8 +142,10 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: ImplicitDiscreteP
     end
 end
 
-@doc doc"""
-    ImplicitDiscreteAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+"""
+    ImplicitDiscreteAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
+    )
 
 Control which `ImplicitDiscreteProblem` inputs a solver may alias.
 

--- a/src/problems/integral_problems.jl
+++ b/src/problems/integral_problems.jl
@@ -1,4 +1,4 @@
-@doc doc"""
+"""
 
 Defines an integral problem.
 Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
@@ -8,7 +8,7 @@ Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
 Integral problems are multi-dimensional integrals defined as:
 
 ```math
-\int_{lb}^{ub} f(u,p) du
+∫_{lb}^{ub} f(u,p) du
 ```
 
 where `p` are parameters. `u` is a `Number` or `AbstractVector`
@@ -21,10 +21,10 @@ which are `Number`s or `AbstractVector`s with the same geometry as `u`.
 ### Constructors
 
 ```julia
-IntegralProblem(f::AbstractIntegralFunction,domain,p=NullParameters(); kwargs...)
-IntegralProblem(f::AbstractIntegralFunction,lb,ub,p=NullParameters(); kwargs...)
-IntegralProblem(f,domain,p=NullParameters(); nout=nothing, batch=nothing, kwargs...)
-IntegralProblem(f,lb,ub,p=NullParameters(); nout=nothing, batch=nothing, kwargs...)
+IntegralProblem(f::AbstractIntegralFunction, domain, p = NullParameters(); kwargs...)
+IntegralProblem(f::AbstractIntegralFunction, lb, ub, p = NullParameters(); kwargs...)
+IntegralProblem(f, domain, p = NullParameters(); nout = nothing, batch = nothing, kwargs...)
+IntegralProblem(f, lb, ub, p = NullParameters(); nout = nothing, batch = nothing, kwargs...)
 ```
 
 - `f`: the integrand, callable function `y = f(u,p)` for out-of-place (default) or an
@@ -88,7 +88,7 @@ function IntegralProblem{iip}(
 end
 
 
-@doc doc"""
+"""
 
 Defines a integral problem over pre-sampled data.
 Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
@@ -98,7 +98,7 @@ Documentation Page: <https://docs.sciml.ai/Integrals/stable/>
 Sampled integral problems are defined as:
 
 ```math
-\sum_i w_i y_i
+∑_i w_i y_i
 ```
 where `y_i` are sampled values of the integrand, and `w_i` are weights
 assigned by a quadrature rule, which depend on sampling points `x`.
@@ -108,7 +108,7 @@ assigned by a quadrature rule, which depend on sampling points `x`.
 ### Constructors
 
 ```julia
-SampledIntegralProblem(y::AbstractArray, x::AbstractVector; dim=ndims(y), kwargs...)
+SampledIntegralProblem(y::AbstractArray, x::AbstractVector; dim = ndims(y), kwargs...)
 ```
 - `y`: The sampled integrand, must be a subtype of `AbstractArray`.
   It is assumed that the values of `y` along dimension `dim`
@@ -138,7 +138,7 @@ struct SampledIntegralProblem{Y, X, K} <: AbstractIntegralProblem{false}
     end
 end
 
-@doc doc"""
+"""
     IntegralAliasSpecifier(alias_p = nothing, alias_f = nothing, alias = nothing)
 
 Control which `IntegralProblem` inputs a solver may alias.

--- a/src/problems/linear_problems.jl
+++ b/src/problems/linear_problems.jl
@@ -57,8 +57,8 @@ parameters. New code should use the unified `update_Ab` keyword constructor.
 
 ```julia
 update_Ab = (A, b, p) -> (A .= p[1]; b .= p[2]; (A, b))
-interface = SciMLBase.SymbolicLinearInterface(
-    ; update_Ab, sys = :my_system, observed = nothing, metadata = nothing
+interface = SciMLBase.SymbolicLinearInterface(;
+    update_Ab, sys = :my_system, observed = nothing, metadata = nothing
 )
 ```
 """
@@ -111,7 +111,7 @@ function SymbolicIndexingInterface.observed(fn::SymbolicLinearInterface, sym)
     end
 end
 
-@doc doc"""
+"""
 
 Defines a linear system problem.
 Documentation Page: <https://docs.sciml.ai/LinearSolve/stable/basics/LinearProblem/>
@@ -135,7 +135,8 @@ are specified via the `AbstractSciMLOperator` interface. For more details, see
 the [SciMLBase Documentation](https://docs.sciml.ai/SciMLBase/stable/).
 
 Note that matrix-free versions of LinearProblem definitions are not compatible
-with all solvers. To check a solver for compatibility, use the function `needs_concrete_A(alg::AbstractLinearAlgorithm)`.
+with all solvers. To check a solver for compatibility, use the function
+`needs_concrete_A(alg::AbstractLinearAlgorithm)`.
 
 ## Problem Type
 
@@ -145,8 +146,8 @@ Optionally, an initial guess ``u₀`` can be supplied which is used for iterativ
 methods.
 
 ```julia
-LinearProblem{isinplace}(A,b,p=NullParameters();u0=nothing,kwargs...)
-LinearProblem(f::AbstractSciMLOperator,b,p=NullParameters();u0=nothing,kwargs...)
+LinearProblem{isinplace}(A, b, p = NullParameters(); u0 = nothing, kwargs...)
+LinearProblem(f::AbstractSciMLOperator, b, p = NullParameters(); u0 = nothing, kwargs...)
 ```
 
 `isinplace` optionally sets whether the function is in-place or not, i.e. whether
@@ -218,7 +219,7 @@ function SymbolicIndexingInterface.set_parameter!(
     return nothing
 end
 
-@doc doc"""
+"""
     LinearAliasSpecifier(; alias_A = nothing, alias_b = nothing, alias = nothing)
 
 Control which `LinearProblem` inputs a solver may alias.

--- a/src/problems/nonlinear_problems.jl
+++ b/src/problems/nonlinear_problems.jl
@@ -6,13 +6,14 @@ Marker for standard nonlinear problem layouts.
 `StandardNonlinearProblem()` is the default `problem_type` metadata for
 nonlinear problems represented directly by a residual function and either an
 initial guess or an interval. Solver code may inspect this marker through
-[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) when it needs to distinguish the standard residual layout
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+when it needs to distinguish the standard residual layout
 from specialized nonlinear problem encodings, while generic nonlinear code should rely on the
 `AbstractNonlinearProblem` fields and traits instead.
 """
 struct StandardNonlinearProblem end
 
-@doc doc"""
+"""
 
 Defines an interval nonlinear system problem.
 Documentation Page: <https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/>
@@ -26,7 +27,7 @@ which defines the nonlinear system:
 f(t,p) = u = 0
 ```
 
-along with an interval `tspan`, ``t \in [t_0,t_f]``, within which the root should be found.
+along with an interval `tspan`, ``t ∈ [t_0,t_f]``, within which the root should be found.
 `f` should be specified as `f(t,p)` (or in-place as `f(u,t,p)`), and `tspan` should be a
 `Tuple{T,T} where T <: Number`.
 
@@ -120,7 +121,7 @@ function IntervalNonlinearProblem(f, tspan, p = NullParameters(); kwargs...)
     return IntervalNonlinearProblem(IntervalNonlinearFunction(f), tspan, p; kwargs...)
 end
 
-@doc doc"""
+"""
 
 Defines a nonlinear system problem.
 Documentation Page: <https://docs.sciml.ai/NonlinearSolve/stable/basics/nonlinear_problem/>
@@ -246,7 +247,7 @@ $(SIGNATURES)
 Define a nonlinear problem using an instance of
 [`AbstractODEFunction`](@ref AbstractODEFunction). Note that
 this is interpreted in the form of the steady state problem, i.e.
-find the ODE's solution at time ``t = \\infty``.
+find the ODE's solution at time ``t = ∞``.
 """
 function NonlinearProblem(f::AbstractODEFunction, u0, p = NullParameters(); kwargs...)
     return NonlinearProblem{isinplace(f)}(f, u0, p; kwargs...)
@@ -284,7 +285,7 @@ function Base.setproperty!(prob::NonlinearProblem, s::Symbol, v, order::Symbol)
     return Base.setfield!(prob, s, v, order)
 end
 
-@doc doc"""
+"""
 Defines a nonlinear least squares problem.
 
 ## Mathematical Specification of a Nonlinear Least Squares Problem
@@ -293,7 +294,7 @@ To define a Nonlinear Problem, you simply need to give the function ``f`` which 
 nonlinear system:
 
 ```math
-\min_x \| f(x, p) \|
+\\min_x ‖ f(x, p) ‖
 ```
 
 and an initial guess ``u_0`` for the minimization problem. ``f`` should be specified as
@@ -388,7 +389,7 @@ function ConstructionBase.constructorof(::Type{P}) where {P <: NonlinearLeastSqu
     end
 end
 
-@doc doc"""
+"""
     SCCNonlinearProblem(probs, explicitfuns!)
 
 Defines an SCC-split nonlinear system to be solved iteratively.
@@ -403,16 +404,16 @@ f(u,p) = 0
 
 with the special property that its Jacobian is in block-lower-triangular
 form. In this form, the nonlinear problem can be decomposed into a system
-of nonlinear systems. 
+of nonlinear systems.
 
 ```math
-\begin{align*}
-f_1(u_1,p) &= 0 \\
-f_2(u_2,u_1,p) &= 0 \\
-f_3(u_3,u_2,u_1,p) &= 0 \\
-& \vdots \\
-f_n(u_n,\ldots,u_3,u_2,u_1,p) &= 0
-\end{align*}
+\\begin{align*}
+f_1(u_1,p) &= 0 \\\\
+f_2(u_2,u_1,p) &= 0 \\\\
+f_3(u_3,u_2,u_1,p) &= 0 \\\\
+& ⋮ \\\\
+f_n(u_n,…,u_3,u_2,u_1,p) &= 0
+\\end{align*}
 ```
 
 Splitting the system in this form can have multiple advantages, including:
@@ -420,7 +421,7 @@ Splitting the system in this form can have multiple advantages, including:
 * Improved numerical stability and robustness of the solving process
 * Improved performance due to using smaller Jacobians
 
-The SCC-Split Nonlinear Problem is the ordered collection of nonlinear systems 
+The SCC-Split Nonlinear Problem is the ordered collection of nonlinear systems
 to solve in order solve the system in the optimized split form.
 
 ## Representation
@@ -430,13 +431,13 @@ of `NonlinearProblem`s, `probs`, with an attached explicit function for pre-proc
 a cache. This can be interpreted as follows:
 
 ```math
-\begin{align*}
-p_1 &= g_1(u,p) & f_1(u_1,p_1)         &= 0 \\
-p_2 &= g_2(u,p) & f_2(u_2,u_1,p_2)     &= 0 \\
-p_3 &= g_3(u,p) & f_3(u_3,u_2,u_1,p_3) &= 0 \\
-& \vdots \\
-p_n &= g_n(u,p) & f_n(u_n,\ldots,u_3,u_2,u_1,p_n) &= 0 \\
-\end{align*}
+\\begin{align*}
+p_1 &= g_1(u,p) & f_1(u_1,p_1)         &= 0 \\\\
+p_2 &= g_2(u,p) & f_2(u_2,u_1,p_2)     &= 0 \\\\
+p_3 &= g_3(u,p) & f_3(u_3,u_2,u_1,p_3) &= 0 \\\\
+& ⋮ \\\\
+p_n &= g_n(u,p) & f_n(u_n,…,u_3,u_2,u_1,p_n) &= 0 \\\\
+\\end{align*}
 ```
 
 where ``g_i`` is `explicitfuns![i]`. In a computational sense, `explictfuns!`
@@ -463,15 +464,16 @@ and below.
 For the following nonlinear problem:
 
 ```julia
-function f(du,u,p)
+function f(du, u, p)
     du[1] = cos(u[2]) - u[1]
     du[2] = sin(u[1] + u[2]) + u[2]
     du[3] = 2u[4] + u[3] + 1.0
     du[4] = u[5]^2 + u[4]
     du[5] = u[3]^2 + u[5]
-    du[6] = u[1] + u[2] + u[3] + u[4] + u[5]    + 2.0u[6] + 2.5u[7] + 1.5u[8]
+    du[6] = u[1] + u[2] + u[3] + u[4] + u[5] + 2.0u[6] + 2.5u[7] + 1.5u[8]
     du[7] = u[1] + u[2] + u[3] + 2.0u[4] + u[5] + 4.0u[6] - 1.5u[7] + 1.5u[8]
     du[8] = u[1] + 2.0u[2] + 3.0u[3] + 5.0u[4] + 6.0u[5] + u[6] - u[7] - u[8]
+    return
 end
 prob = NonlinearProblem(f, zeros(8))
 sol = solve(prob)
@@ -482,41 +484,46 @@ The split SCC form is:
 ```julia
 cache = zeros(3)
 
-function f1(du,u,cache)
+function f1(du, u, cache)
     du[1] = cos(u[2]) - u[1]
     du[2] = sin(u[1] + u[2]) + u[2]
+    return
 end
-explicitfun1(cache,sols) = nothing
+explicitfun1(cache, sols) = nothing
 prob1 = NonlinearProblem(NonlinearFunction{true, SciMLBase.NoSpecialize}(f1), zeros(2), cache)
 sol1 = solve(prob1, NewtonRaphson())
 
-function f2(du,u,cache)
+function f2(du, u, cache)
     du[1] = 2u[2] + u[1] + 1.0
     du[2] = u[3]^2 + u[2]
     du[3] = u[1]^2 + u[3]
+    return
 end
-explicitfun2(cache,sols) = nothing
+explicitfun2(cache, sols) = nothing
 prob2 = NonlinearProblem(NonlinearFunction{true, SciMLBase.NoSpecialize}(f2), zeros(3), cache)
 sol2 = solve(prob2, NewtonRaphson())
 
-function f3(du,u,cache)
+function f3(du, u, cache)
     du[1] = cache[1] + 2.0u[1] + 2.5u[2] + 1.5u[3]
     du[2] = cache[2] + 4.0u[1] - 1.5u[2] + 1.5u[3]
     du[3] = cache[3] + + u[1] - u[2] - u[3]
+    return
 end
 prob3 = NonlinearProblem(NonlinearFunction{true, SciMLBase.NoSpecialize}(f3), zeros(3), cache)
-function explicitfun3(cache,sols)
+function explicitfun3(cache, sols)
     cache[1] = sols[1][1] + sols[1][2] + sols[2][1] + sols[2][2] + sols[2][3]
     cache[2] = sols[1][1] + sols[1][2] + sols[2][1] + 2.0sols[2][2] + sols[2][3]
     cache[3] = sols[1][1] + 2.0sols[1][2] + 3.0sols[2][1] + 5.0sols[2][2] + 6.0sols[2][3]
+    return
 end
-explicitfun3(cache,[sol1,sol2])
+explicitfun3(cache, [sol1, sol2])
 sol3 = solve(prob3, NewtonRaphson())
 manualscc = [sol1; sol2; sol3]
 
 sccprob = SciMLBase.SCCNonlinearProblem(
-    [prob1,prob2,prob3],
-    SciMLBase.Void{Any}.([explicitfun1,explicitfun2,explicitfun3]))
+    [prob1, prob2, prob3],
+    SciMLBase.Void{Any}.([explicitfun1, explicitfun2, explicitfun3])
+)
 ```
 
 Note that this example aliases the parameters together for a memory-reduced representation.
@@ -630,8 +637,10 @@ function SymbolicIndexingInterface.set_parameter!(prob::SCCNonlinearProblem, val
     return
 end
 
-@doc doc"""
-    NonlinearAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+"""
+    NonlinearAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
+    )
 
 Control which `NonlinearProblem` inputs a solver may alias.
 
@@ -744,7 +753,7 @@ function Base.convert(
     )
 end
 
-@doc doc"""
+"""
 
 Defines a one-parameter homotopy nonlinear problem.
 This is the embedding / natural-parameter continuation problem type. It is unrelated to
@@ -756,12 +765,12 @@ This is the embedding / natural-parameter continuation problem type. It is unrel
 To define a Homotopy Problem, you give the residual function ``f``
 
 ```math
-0 = f(u, p, \lambda)
+0 = f(u, p, λ)
 ```
 
-where ``\lambda \in \texttt{λspan}`` is the scalar continuation parameter, passed to
+where ``λ ∈ \\texttt{λspan}`` is the scalar continuation parameter, passed to
 `f` as a separate trailing argument after the parameters `p`. A continuation solver
-sweeps ``\lambda`` from `λspan[1]` to `λspan[2]`, warm-starting each step from the
+sweeps ``λ`` from `λspan[1]` to `λspan[2]`, warm-starting each step from the
 previous solution; the target system is the one at `λspan[2]`.
 
 ## Problem Type
@@ -775,7 +784,7 @@ HomotopyProblem{isinplace}(f, u0, p = NullParameters(); λspan = (0.0, 1.0), kwa
 
 `isinplace` optionally sets whether the function is in-place or not. This is
 determined automatically, but not inferred. The residual follows the time-dependent
-argument convention with ``\lambda`` in place of `t`:
+argument convention with ``λ`` in place of `t`:
 
 - out-of-place: `f(u, p, λ)`
 - in-place: `f(du, u, p, λ)`
@@ -790,7 +799,7 @@ argument convention with ``\lambda`` in place of `t`:
   `NonlinearFunction` constructor so that `jac`, `jvp`, and `vjp` are validated against
   the λ-extended arities instead of the standard nonlinear ones.
 * `u0`: The initial guess (a solution of the simplified system at `λspan[1]`).
-* `p`: The parameters, passed through to `f` unchanged; ``\lambda`` is not part of `p`.
+* `p`: The parameters, passed through to `f` unchanged; ``λ`` is not part of `p`.
 * `λspan`: the `(start, stop)` continuation interval; the target system is at `stop`.
 * `kwargs`: The keyword arguments passed on to the solvers.
 """

--- a/src/problems/ode_problems.jl
+++ b/src/problems/ode_problems.jl
@@ -18,8 +18,7 @@ prefer the [`AbstractODEProblem`](@ref) interface and problem traits.
 """
 struct StandardODEProblem end
 
-@doc doc"""
-
+"""
 Defines an ordinary differential equation (ODE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/ode_types/>
 
@@ -29,12 +28,14 @@ To define an ODE Problem, you simply need to give the function ``f`` and the ini
 condition ``u_0`` which define an ODE:
 
 ```math
-M \frac{du}{dt} = f(u,p,t)
+M \\frac{du}{dt} = f(u,p,t)
 ```
 
 There are two different ways of specifying `f`:
-- `f(du,u,p,t)`: in-place. Memory-efficient when avoiding allocations. Best option for most cases unless mutation is not allowed.
-- `f(u,p,t)`: returning `du`. Less memory-efficient way, particularly suitable when mutation is not allowed (e.g. with certain automatic differentiation packages such as Zygote).
+- `f(du,u,p,t)`: in-place. Memory-efficient when avoiding allocations. Best option for most
+  cases unless mutation is not allowed.
+- `f(u,p,t)`: returning `du`. Less memory-efficient way, particularly suitable when mutation
+  is not allowed (e.g. with certain automatic differentiation packages such as Zygote).
 
 `u₀` should be an AbstractArray (or number) whose geometry matches the desired geometry of `u`.
 Note that we are not limited to numbers or vectors for `u₀`; one is allowed to
@@ -81,19 +82,20 @@ For specifying Jacobians and mass matrices, see the `ODEFunction` documentation.
 
 ```julia
 using SciMLBase
-function lorenz!(du,u,p,t)
-  du[1] = 10.0(u[2]-u[1])
-  du[2] = u[1]*(28.0-u[3]) - u[2]
-  du[3] = u[1]*u[2] - (8/3)*u[3]
+function lorenz!(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return
 end
 u0 = [1.0;0.0;0.0]
-tspan = (0.0,100.0)
-prob = ODEProblem(lorenz!,u0,tspan)
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz!, u0, tspan)
 
 # Test that it worked
 using OrdinaryDiffEq
-sol = solve(prob,Tsit5())
-using Plots; plot(sol,vars=(1,2,3))
+sol = solve(prob, Tsit5())
+using Plots; plot(sol, vars = (1, 2, 3))
 ```
 
 ## More Example Problems
@@ -261,12 +263,13 @@ Marker supertype for structured ODE problem layouts.
 
 Subtypes identify ODE problems that are constructed from partitioned or
 second-order dynamics and then stored in the common `ODEProblem` representation.
-The concrete marker is available through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) so solvers can
-preserve structure when they support specialized methods.
+The concrete marker is available through
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+so solvers can preserve structure when they support specialized methods.
 """
 abstract type AbstractDynamicalODEProblem end
 
-@doc doc"""
+"""
 
 Defines a dynamical ordinary differential equation (ODE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/>
@@ -281,10 +284,10 @@ how to define second order differential equations for their efficient numerical 
 These algorithms require a Partitioned ODE of the form:
 
 ```math
-\begin{align*}
-\frac{dv}{dt} &= f_1(u,t) \\
-\frac{du}{dt} &= f_2(v) \\
-\end{align*}
+\\begin{align*}
+\\frac{dv}{dt} &= f_1(u,t) \\\\
+\\frac{du}{dt} &= f_2(v) \\\\
+\\end{align*}
 ```
 This is a Partitioned ODE partitioned into two groups, so the functions should be
 specified as `f1(dv,v,u,p,t)` and `f2(du,v,u,p,t)` (in the inplace form), where `f1`
@@ -295,7 +298,7 @@ and Hamiltonians where the potential is (or can be) time-dependent, but the kine
 energy is only dependent on `v`.
 
 Note that some methods assume that the integral of `f2` is a quadratic form. That
-means that `f2=v'*M*v`, i.e. ``\int f_2 = \frac{1}{2} m v^2``, giving `du = v`.
+means that `f2 = v'*M*v`, i.e. ``∫ f_2 = \\frac{1}{2} m v^2``, giving `du = v`.
 This is equivalent to saying that the kinetic energy is related to ``v^2``. The
 methods which require this assumption will lose accuracy if this assumption is
 violated. Methods listed make note of this requirement with "Requires
@@ -304,8 +307,8 @@ quadratic kinetic energy".
 ### Constructor
 
 ```julia
-DynamicalODEProblem(f::DynamicalODEFunction,v0,u0,tspan,p=NullParameters();kwargs...)
-DynamicalODEProblem{isinplace}(f1,f2,v0,u0,tspan,p=NullParameters();kwargs...)
+DynamicalODEProblem(f::DynamicalODEFunction, v0, u0, tspan, p = NullParameters(); kwargs...)
+DynamicalODEProblem{isinplace}(f1, f2, v0, u0, tspan, p = NullParameters(); kwargs...)
 ```
 
 Defines the ODE with the specified functions. `isinplace` optionally sets whether
@@ -364,7 +367,7 @@ function DynamicalODEProblem{iip}(
     )
 end
 
-@doc doc"""
+"""
 
 Defines a second order ordinary differential equation (ODE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/>
@@ -387,10 +390,10 @@ as well.
 From this form, a dynamical ODE:
 
 ```math
-\begin{align*}
-v' &= f(v,u,p,t) \\
+\\begin{align*}
+v' &= f(v,u,p,t) \\\\
 u' &= v
-\end{align*}
+\\end{align*}
 ```
 
 is generated.
@@ -398,7 +401,7 @@ is generated.
 ### Constructors
 
 ```julia
-SecondOrderODEProblem{isinplace}(f,du0,u0,tspan,callback=CallbackSet())
+SecondOrderODEProblem{isinplace}(f, du0, u0, tspan, callback = CallbackSet())
 ```
 
 Defines the ODE with the specified functions.
@@ -484,7 +487,7 @@ the ordinary `ODEProblem` storage layout.
 """
 abstract type AbstractSplitODEProblem end
 
-@doc doc"""
+"""
 
 Defines a split ordinary differential equation (ODE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/split_ode_types/>
@@ -496,7 +499,7 @@ To define a `SplitODEProblem`, you simply need to give two functions
 define an ODE:
 
 ```math
-\frac{du}{dt} =  f_1(u,p,t) + f_2(u,p,t)
+\\frac{du}{dt} =  f_1(u,p,t) + f_2(u,p,t)
 ```
 
 `f` should be specified as `f(u,p,t)` (or in-place as `f(du,u,p,t)`), and `u₀` should
@@ -507,16 +510,17 @@ provide `u₀` as arbitrary matrices / higher dimension tensors as well.
 Many splits are at least partially linear. That is the equation:
 
 ```math
-\frac{du}{dt} =  Au + f_2(u,p,t)
+\\frac{du}{dt} =  Au + f_2(u,p,t)
 ```
 
-For how to define a linear function `A`, see the documentation for the [AbstractSciMLOperator](https://docs.sciml.ai/SciMLOperators/stable/interface/).
+For how to define a linear function `A`, see the documentation for the
+[AbstractSciMLOperator](https://docs.sciml.ai/SciMLOperators/stable/interface/).
 
 ### Constructors
 
 ```julia
-SplitODEProblem(f::SplitFunction,u0,tspan,p=NullParameters();kwargs...)
-SplitODEProblem{isinplace}(f1,f2,u0,tspan,p=NullParameters();kwargs...)
+SplitODEProblem(f::SplitFunction, u0, tspan, p = NullParameters(); kwargs...)
+SplitODEProblem{isinplace}(f1, f2, u0, tspan, p = NullParameters(); kwargs...)
 ```
 
 The `isinplace` parameter can be omitted and will be determined using the signature of `f2`.
@@ -589,7 +593,9 @@ Internal supertype for incrementing ODE constructor tags. Concrete tags record
 the in-place convention while [`IncrementingODEProblem`](@ref) converts the
 input into an `ODEProblem` with an [`IncrementingODEFunction`](@ref).
 
-These tags are available from [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits) on the resulting problem;
+These tags are available from
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits)
+on the resulting problem;
 they are not standalone problem containers. Solvers that require incrementing
 evaluation may dispatch on the tag or the wrapped function, but ordinary ODE
 tooling should use the returned `ODEProblem` interface.
@@ -604,8 +610,9 @@ Construct an experimental ODE problem for a model function that can update an
 existing derivative buffer in an incrementing form.
 
 The constructor wraps `f` in an [`IncrementingODEFunction`](@ref), exposes an
-`IncrementingODEProblem{iip}` tag through [`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits), and returns a
-standard `ODEProblem`. The result therefore follows the ordinary ODE problem
+`IncrementingODEProblem{iip}` tag through
+[`problem_type`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Problem-Traits),
+and returns a standard `ODEProblem`. The result therefore follows the ordinary ODE problem
 field, symbolic-indexing, keyword-forwarding, and solve interfaces.
 
 Low-storage solvers commonly use the in-place convention
@@ -647,8 +654,11 @@ function IncrementingODEProblem{iip}(
     return ODEProblem(f, u0, tspan, p, IncrementingODEProblem{iip}(); kwargs...)
 end
 
-@doc doc"""
-    ODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    ODEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing
+    )
 
 Control which ODE problem inputs and solver option arrays may be aliased.
 

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -1,6 +1,6 @@
 @enum ObjSense MinSense MaxSense
 
-@doc doc"""
+"""
 
 Defines an optimization problem.
 Documentation Page: <https://docs.sciml.ai/Optimization/stable/API/optimization_problem/>
@@ -11,7 +11,7 @@ To define an optimization problem, you need the objective function ``f``
 which is minimized over the domain of ``u``, the collection of optimization variables:
 
 ```math
-\min_u f(u,p)
+\\min_u f(u,p)
 ```
 
 ``u₀`` is an initial guess for the minimizer. `f` should be specified as `f(u,p)`
@@ -25,13 +25,15 @@ higher-dimension tensors as well.
 ### Constructors
 
 ```julia
-OptimizationProblem{isinplace}(f, u0, p = SciMLBase.NullParameters(),;
-                        lb = nothing,
-                        ub = nothing,
-                        lcons = nothing,
-                        ucons = nothing,
-                        sense = nothing,
-                        kwargs...)
+OptimizationProblem{isinplace}(
+    f, u0, p = SciMLBase.NullParameters();
+    lb = nothing,
+    ub = nothing,
+    lcons = nothing,
+    ucons = nothing,
+    sense = nothing,
+    kwargs...
+)
 ```
 
 `isinplace` optionally sets whether the function is in-place or not.
@@ -52,7 +54,8 @@ optimization and if they are set to be equal then it represents an equality cons
 They should be an `AbstractArray`, where `(lcons[i],ucons[i])`
 are the lower and upper bounds for `cons[i]`.
 
-The `f` in the `OptimizationProblem` should typically be an instance of [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
+The `f` in the `OptimizationProblem` should typically be an instance of
+[`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
 to specify the objective function and its derivatives either by passing
 predefined functions for them or automatically generated using the [ADType](https://github.com/SciML/ADTypes.jl).
 
@@ -66,34 +69,55 @@ Any extra keyword arguments are captured to be sent to the optimizers.
 
 * `f`: the function in the problem.
 * `u0`: the initial guess for the optimization variables.
-* `p`: Either the constant parameters or fixed data (full batch) used in the objective or a [MLUtils](https://github.com/JuliaML/MLUtils.jl) [`DataLoader`](https://juliaml.github.io/MLUtils.jl/stable/api/#MLUtils.DataLoader) for minibatching with stochastic optimization solvers. Defaults to `NullParameters`.
+* `p`: Either the constant parameters or fixed data (full batch) used in the
+  objective or a [MLUtils](https://github.com/JuliaML/MLUtils.jl)
+  [`DataLoader`](https://juliaml.github.io/MLUtils.jl/stable/api/#MLUtils.DataLoader)
+  for minibatching with stochastic optimization solvers. Defaults to `NullParameters`.
 * `lb`: the lower bounds for the optimization variables `u`.
 * `ub`: the upper bounds for the optimization variables `u`.
 * `int`: integrality indicator for `u`. If `int[i] == true`, then `u[i]` is an integer variable.
     Defaults to `nothing`, implying no integrality constraints.
-* `lcons`: the vector of lower bounds for the constraints passed to [OptimizationFunction](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction).
+* `lcons`: the vector of lower bounds for the constraints passed to
+  [OptimizationFunction](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction).
     Defaults to `nothing`, implying no lower bounds for the constraints (i.e. the constraint bound is `-Inf`)
-* `ucons`: the vector of upper bounds for the constraints passed to [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction).
+* `ucons`: the vector of upper bounds for the constraints passed to
+  [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction).
     Defaults to `nothing`, implying no upper bounds for the constraints (i.e. the constraint bound is `Inf`)
 * `sense`: the objective sense, can take `MaxSense` or `MinSense` from Optimization.jl.
 * `kwargs`: the keyword arguments passed on to the solvers.
 
 ## Inequality and Equality Constraints
 
-Both inequality and equality constraints are defined by the `f.cons` function in the [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
+Both inequality and equality constraints are defined by the `f.cons` function in the
+[`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction)
 description of the problem structure. This `f.cons` is given as a function `f.cons(u,p)` which computes
 the value of the constraints at `u`. For example, take `f.cons(u,p) = u[1] - u[2]`.
 With these definitions, `lcons` and `ucons` define the bounds on the constraint that the solvers try to satisfy.
-If `lcons` and `ucons` are `nothing`, then there are no constraints bounds, meaning that the constraint is satisfied when `-Inf < f.cons < Inf` (which of course is always!). If `lcons[i] = ucons[i] = 0`, then the constraint is satisfied when `f.cons(u,p)[i] = 0`, and so this implies the equality constraint `u[1] = u[2]`. If `lcons[i] = ucons[i] = a`, then ``u[1] - u[2] = a`` is the equality constraint.
+If `lcons` and `ucons` are `nothing`, then there are no constraints bounds, meaning that the
+constraint is satisfied when `-Inf < f.cons < Inf` (which of course is always!). If
+`lcons[i] = ucons[i] = 0`, then the constraint is satisfied when `f.cons(u,p)[i] = 0`, and
+so this implies the equality constraint `u[1] = u[2]`. If `lcons[i] = ucons[i] = a`, then
+``u[1] - u[2] = a`` is the equality constraint.
 
-Inequality constraints are then given by making `lcons[i] != ucons[i]`. For example, `lcons[i] = -Inf` and `ucons[i] = 0` would imply the inequality constraint `u[1] <= u[2]` since any `f.cons[i] <= 0` satisfies the constraint. Similarly, `lcons[i] = -1` and `ucons[i] = 1` would imply that `-1 <= f.cons[i] <= 1` is required or `-1 <= u[1] - u[2] <= 1`.
+Inequality constraints are then given by making `lcons[i] != ucons[i]`. For example,
+`lcons[i] = -Inf` and `ucons[i] = 0` would imply the inequality constraint `u[1] <= u[2]`
+since any `f.cons[i] <= 0` satisfies the constraint. Similarly, `lcons[i] = -1` and
+`ucons[i] = 1` would imply that `-1 <= f.cons[i] <= 1` is required or `-1 <= u[1] - u[2] <=
+1`.
 
-Note that these vectors must be sized to match the number of constraints, with one set of conditions for each constraint.
+Note that these vectors must be sized to match the number of constraints,
+with one set of conditions for each constraint.
 
 ## Data handling
 
-As described above the second argument of the objective definition can take a full batch or a [`DataLoader`](https://juliaml.github.io/MLUtils.jl/stable/api/#MLUtils.DataLoader) object for mini-batching which is useful for stochastic optimization solvers. Thus the data either as an Array or a `DataLoader` object should be passed as the third argument of the `OptimizationProblem` constructor.
-For an example of how to use this data handling, see the `Sophia` example in the [Optimization.jl documentation](https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/) or the [mini-batching tutorial](https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/).
+As described above the second argument of the objective definition can take a full batch or
+a [`DataLoader`](https://juliaml.github.io/MLUtils.jl/stable/api/#MLUtils.DataLoader) object
+for mini-batching which is useful for stochastic optimization solvers. Thus the data either
+as an Array or a `DataLoader` object should be passed as the third argument of the
+`OptimizationProblem` constructor.
+For an example of how to use this data handling, see the `Sophia` example in the
+[Optimization.jl documentation](https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/)
+or the [mini-batching tutorial](https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/).
 """
 struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
     AbstractOptimizationProblem{iip}
@@ -162,10 +186,12 @@ end
 isinplace(f::OptimizationFunction{iip}) where {iip} = iip
 isinplace(f::OptimizationProblem{iip}) where {iip} = iip
 
-@doc doc"""
-    ConvexOptimizationProblem{iip}(f, u0, p = NullParameters();
+"""
+    ConvexOptimizationProblem{iip}(
+        f, u0, p = NullParameters();
         constraints = nothing, lb = nothing, ub = nothing, int = nothing,
-        sense = MinSense, kwargs...)
+        sense = MinSense, kwargs...
+    )
 
 **Experimental.** A disciplined-convex-programming problem: minimize (or
 maximize) a *convex* objective subject to *convex* cone constraints. Unlike a
@@ -239,8 +265,10 @@ end
 
 isinplace(f::ConvexOptimizationProblem{iip}) where {iip} = iip
 
-@doc doc"""
-    OptimizationAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing)
+"""
+    OptimizationAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias = nothing
+    )
 
 Control which `OptimizationProblem` inputs a solver may alias.
 

--- a/src/problems/rode_problems.jl
+++ b/src/problems/rode_problems.jl
@@ -1,4 +1,4 @@
-@doc doc"""
+"""
 
 Defines a random ordinary differential equation (RODE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/rode_types/>
@@ -9,7 +9,7 @@ To define a RODE Problem, you simply need to give the function ``f`` and the ini
 condition ``u_0`` which define an ODE:
 
 ```math
-\frac{du}{dt} = f(u,p,t,W(t))
+\\frac{du}{dt} = f(u,p,t,W(t))
 ```
 
 where `W(t)` is a random process. `f` should be specified as `f(u,p,t,W)`
@@ -20,8 +20,8 @@ to numbers or vectors for `u₀`; one is allowed to provide `u₀` as arbitrary 
 
 ### Constructors
 
-- `RODEProblem(f::RODEFunction,u0,tspan,p=NullParameters();noise=WHITE_NOISE,rand_prototype=nothing,callback=nothing)`
-- `RODEProblem{isinplace,specialize}(f,u0,tspan,p=NullParameters();noise=WHITE_NOISE,rand_prototype=nothing,callback=nothing,mass_matrix=I)` :
+- `RODEProblem(f::RODEFunction, u0, tspan, p = NullParameters(); noise = WHITE_NOISE, rand_prototype = nothing, callback = nothing)`
+- `RODEProblem{isinplace, specialize}(f, u0, tspan, p = NullParameters(); noise = WHITE_NOISE, rand_prototype = nothing, callback = nothing, mass_matrix = I)` :
   Defines the RODE with the specified functions. The default noise is `WHITE_NOISE`.
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
@@ -97,8 +97,12 @@ function RODEProblem(f, u0, tspan, p = NullParameters(); kwargs...)
     return RODEProblem(RODEFunction(f), u0, tspan, p; kwargs...)
 end
 
-@doc doc"""
-    RODEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias_noise = nothing, alias_jumps = nothing, alias = nothing)
+"""
+    RODEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias_noise = nothing,
+        alias_jumps = nothing, alias = nothing
+    )
 
 Control which `RODEProblem` inputs, noise data, and solver option arrays may be
 aliased.

--- a/src/problems/sdde_problems.jl
+++ b/src/problems/sdde_problems.jl
@@ -1,4 +1,4 @@
-@doc doc"""
+"""
 
 Defines a stochastic delay differential equation (SDDE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/sdde_types/>
@@ -10,11 +10,11 @@ the diffusion function `g`, the initial condition ``u_0`` at time point ``t_0``,
 and the history function ``h`` which together define a SDDE:
 
 ```math
-\begin{align*}
-du(t)  &= f(u,h,p,t) \, dt + g(u,h,p,t) \, dW_t & (t \geq t_0) \\
-u(t_0) &= u_0, \\
+\\begin{align*}
+du(t)  &= f(u,h,p,t) \\, dt + g(u,h,p,t) \\, dW_t & (t ≥ t_0) \\\\
+u(t_0) &= u_0, \\\\
 u(t)   &= h(t) & (t < t_0).
-\end{align*}
+\\end{align*}
 ```
 
 ``f`` should be specified as `f(u, h, p, t)` (or in-place as `f(du, u, h, p, t)`)
@@ -67,7 +67,8 @@ SDDEProblem{isinplace,specialize}(f,g[, u0], h, tspan[, p]; <keyword arguments>)
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+the specialization level. See
+[Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 For more details on the in-place and specialization controls, see the ODEFunction documentation.
@@ -86,7 +87,8 @@ For specifying Jacobians and mass matrices, see the
 
 * `f`: The drift function in the SDDE.
 * `g`: The diffusion function in the SDDE.
-* `u0`: The initial condition. Defaults to the value `h(p, first(tspan))` of the history function evaluated at the initial time point.
+* `u0`: The initial condition. Defaults to the value `h(p, first(tspan))` of the
+  history function evaluated at the initial time point.
 * `h`: The history function for the DDE before `t0`.
 * `tspan`: The timespan for the problem.
 * `p`: The parameters with which function `f` is called. Defaults to `NullParameters`.
@@ -186,8 +188,11 @@ end
 
 SymbolicIndexingInterface.get_history_function(prob::AbstractSDDEProblem) = prob.h
 
-@doc doc"""
-    SDDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
+"""
+    SDDEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing,
+        alias_tstops = nothing, alias_jumps = nothing, alias = nothing
+    )
 
 Control which `SDDEProblem` inputs and solver option arrays may be aliased.
 

--- a/src/problems/sde_problems.jl
+++ b/src/problems/sde_problems.jl
@@ -12,7 +12,7 @@ on `AbstractSDEProblem` and the problem's function type instead of depending on
 """
 struct StandardSDEProblem end
 
-@doc doc"""
+"""
 
 Defines an stochastic differential equation (SDE) problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/sde_types/>
@@ -23,7 +23,7 @@ To define an SDE Problem, you simply need to give the forcing function `f`,
 the noise function `g`, and the initial condition `u₀` which define an SDE:
 
 ```math
-du = f(u,p,t) \, dt + ∑ᵢ gᵢ(u,p,t) \, dWⁱ
+du = f(u,p,t) \\, dt + ∑ᵢ gᵢ(u,p,t) \\, dWⁱ
 ```
 
 `f` and `g` should be specified as `f(u,p,t)` and  `g(u,p,t)` respectively, and `u₀`
@@ -37,7 +37,7 @@ of `g`s can also be defined to determine an SDE of higher Ito dimension.
 Wraps the data which defines an SDE problem
 
 ```math
-u = f(u,p,t) \, dt + ∑ᵢ gᵢ(u,p,t) \, dWⁱ
+u = f(u,p,t) \\, dt + ∑ᵢ gᵢ(u,p,t) \\, dWⁱ
 ```
 
 with initial condition `u0`.
@@ -49,7 +49,8 @@ with initial condition `u0`.
   Defines the SDE with the specified functions. The default noise is `WHITE_NOISE`.
   `isinplace` optionally sets whether the function is inplace or not. This is
   determined automatically, but not inferred. `specialize` optionally controls
-  the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+  the specialization level. See
+  [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
   for more details. The default is `AutoSpecialize`.
 
 Parameters are optional, and if not given then a `NullParameters()` singleton
@@ -288,8 +289,11 @@ function DynamicalSDEProblem{iip}(
     return SDEProblem(_f, ArrayPartition(v0, u0), tspan, p; kwargs...)
 end
 
-@doc doc"""
-    SDEAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_tstops = nothing, alias_jumps = nothing, alias = nothing)
+"""
+    SDEAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_tstops = nothing, alias_jumps = nothing, alias = nothing
+    )
 
 Control which `SDEProblem` inputs and solver option arrays may be aliased.
 

--- a/src/problems/steady_state_problems.jl
+++ b/src/problems/steady_state_problems.jl
@@ -1,4 +1,4 @@
-@doc doc"""
+"""
 
 Defines a steady state ODE problem.
 Documentation Page: <https://docs.sciml.ai/DiffEqDocs/stable/types/steady_state_types/>
@@ -9,7 +9,7 @@ To define a Steady State Problem, you simply need to give the function ``f``
 which defines the ODE:
 
 ```math
-\frac{du}{dt} = f(u, p, t)
+\\frac{du}{dt} = f(u, p, t)
 ```
 
 and an initial guess ``u_0`` of where `f(u, p, t) = 0`. `f` should be specified as
@@ -34,7 +34,8 @@ SteadyStateProblem{isinplace, specialize}(f, u0, p = NullParameters(); kwargs...
 
 `isinplace` optionally sets whether the function is inplace or not. This is
 determined automatically, but not inferred. `specialize` optionally controls
-the specialization level. See [Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
+the specialization level. See
+[Specialization Levels](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#specialization_levels)
 for more details. The default is `AutoSpecialize`.
 
 Parameters are optional, and if not given, a `NullParameters()` singleton
@@ -139,8 +140,11 @@ end
 
 SymbolicIndexingInterface.is_time_dependent(::SteadyStateProblem) = true
 
-@doc doc"""
-    SteadyStateAliasSpecifier(;alias_p = nothing, alias_f = nothing, alias_u0 = nothing, alias_du0 = nothing, alias_tstops = nothing, alias = nothing)
+"""
+    SteadyStateAliasSpecifier(;
+        alias_p = nothing, alias_f = nothing, alias_u0 = nothing,
+        alias_du0 = nothing, alias_tstops = nothing, alias = nothing
+    )
 
 Control which `SteadyStateProblem` inputs and solver option arrays may be
 aliased.

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -708,8 +708,10 @@ function _remake_odeproblem(
 end
 
 """
-    remake(prob::DynamicalODEProblem; f = missing, v0 = missing, u0 = missing,
-           tspan = missing, p = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::DynamicalODEProblem; f = missing, v0 = missing, u0 = missing,
+        tspan = missing, p = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `DynamicalODEProblem`.
 `u0 = ArrayPartition(v0, u0)` remains supported as a full-state replacement when `v0`
@@ -727,8 +729,10 @@ function remake(
 end
 
 """
-    remake(prob::SecondOrderODEProblem; f = missing, du0 = missing, u0 = missing,
-          tspan = missing, p = missing, kwargs = missing, _kwargs...)
+    remake(
+        prob::SecondOrderODEProblem; f = missing, du0 = missing, u0 = missing,
+        tspan = missing, p = missing, kwargs = missing, _kwargs...
+    )
 
 Remake the given `SecondOrderODEProblem`.
 `u0 = ArrayPartition(du0, u0)` remains supported as a full-state replacement when `du0`
@@ -826,9 +830,10 @@ accept the context argument and must not dispatch on undocumented implementation
 struct RemakeInitializationDataContext end
 
 """
-    remake_initialization_data(sys, scimlfn, u0, t0, p, newu0, newp,
-        ctx = RemakeInitializationDataContext())
-        -> initialization_data
+    remake_initialization_data(
+            sys, scimlfn, u0, t0, p, newu0, newp,
+            ctx = RemakeInitializationDataContext()
+        ) -> initialization_data
 
 Recreate a SciML function's initialization data after symbolic `remake` changes state or
 parameters.

--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -364,19 +364,21 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-ODEFunction{iip,specialize}(f;
-                           mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                           vjp_p = __has_vjp_p(f) ? f.vjp_p : nothing,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+ODEFunction{iip, specialize}(
+    f;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    vjp_p = __has_vjp_p(f) ? f.vjp_p : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 
 ODEFunction{iip,specialize}(f::ODEFunction; kwargs...)
 ```
@@ -468,10 +470,10 @@ The following example creates an inplace `ODEFunction` whose Jacobian is a `Diag
 
 ```julia
 using LinearAlgebra
-f = (du,u,p,t) -> du .= t .* u
-jac = (J,u,p,t) -> (J[1,1] = t; J[2,2] = t; J)
+f = (du, u, p, t) -> du .= t .* u
+jac = (J, u, p, t) -> (J[1, 1] = t; J[2, 2] = t; J)
 jp = Diagonal(zeros(2))
-fun = ODEFunction(f; jac, jac_prototype=jp)
+fun = ODEFunction(f; jac, jac_prototype = jp)
 ```
 
 The prototype declares Jacobian shape, element type, and structure. It must support
@@ -496,9 +498,10 @@ the function `f(du,u,p,t)` with an in-place updating function for the Jacobian:
 take the Lotka-Volterra model:
 
 ```julia
-function f(du,u,p,t)
-  du[1] = 2.0 * u[1] - 1.2 * u[1]*u[2]
-  du[2] = -3 * u[2] + u[1]*u[2]
+function f(du, u, p, t)
+    du[1] = 2.0 * u[1] - 1.2 * u[1] * u[2]
+    du[2] = -3 * u[2] + u[1] * u[2]
+    return
 end
 ```
 
@@ -506,24 +509,24 @@ To declare the Jacobian, we simply add the dispatch:
 
 ```julia
 function f_jac(J,u,p,t)
-  J[1,1] = 2.0 - 1.2 * u[2]
-  J[1,2] = -1.2 * u[1]
-  J[2,1] = 1 * u[2]
-  J[2,2] = -3 + u[1]
-  nothing
+    J[1,1] = 2.0 - 1.2 * u[2]
+    J[1,2] = -1.2 * u[1]
+    J[2,1] = 1 * u[2]
+    J[2,2] = -3 + u[1]
+    return
 end
 ```
 
 Then we can supply the Jacobian with our ODE as:
 
 ```julia
-ff = ODEFunction(f;jac=f_jac)
+ff = ODEFunction(f; jac = f_jac)
 ```
 
 and use this in an `ODEProblem`:
 
 ```julia
-prob = ODEProblem(ff,ones(2),(0.0,10.0))
+prob = ODEProblem(ff, ones(2), (0.0, 10.0))
 ```
 
 ## Symbolically Generating the Functions
@@ -583,19 +586,21 @@ and exponential integrators.
 ## Constructor
 
 ```julia
-SplitFunction{iip,specialize}(f1,f2;
-                             mass_matrix = __has_mass_matrix(f1) ? f1.mass_matrix : I,
-                             analytic = __has_analytic(f1) ? f1.analytic : nothing,
-                             tgrad= __has_tgrad(f1) ? f1.tgrad : nothing,
-                             jac = __has_jac(f1) ? f1.jac : nothing,
-                             jvp = __has_jvp(f1) ? f1.jvp : nothing,
-                             vjp = __has_vjp(f1) ? f1.vjp : nothing,
-                             jac_prototype = __has_jac_prototype(f1) ? f1.jac_prototype : nothing,
-                             W_prototype = __has_W_prototype(f1) ? f1.W_prototype : nothing,
-                             sparsity = __has_sparsity(f1) ? f1.sparsity : jac_prototype,
-                             paramjac = __has_paramjac(f1) ? f1.paramjac : nothing,
-                             colorvec = __has_colorvec(f1) ? f1.colorvec : nothing,
-                             sys = __has_sys(f1) ? f1.sys : nothing)
+SplitFunction{iip, specialize}(
+    f1, f2;
+    mass_matrix = __has_mass_matrix(f1) ? f1.mass_matrix : I,
+    analytic = __has_analytic(f1) ? f1.analytic : nothing,
+    tgrad= __has_tgrad(f1) ? f1.tgrad : nothing,
+    jac = __has_jac(f1) ? f1.jac : nothing,
+    jvp = __has_jvp(f1) ? f1.jvp : nothing,
+    vjp = __has_vjp(f1) ? f1.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f1) ? f1.jac_prototype : nothing,
+    W_prototype = __has_W_prototype(f1) ? f1.W_prototype : nothing,
+    sparsity = __has_sparsity(f1) ? f1.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f1) ? f1.paramjac : nothing,
+    colorvec = __has_colorvec(f1) ? f1.colorvec : nothing,
+    sys = __has_sys(f1) ? f1.sys : nothing
+)
 ```
 
 Note that only the functions `f_i` themselves are required. These functions should
@@ -711,18 +716,20 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DynamicalODEFunction{iip,specialize}(f1,f2;
-                                    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                                    analytic = __has_analytic(f) ? f.analytic : nothing,
-                                    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                                    jac = __has_jac(f) ? f.jac : nothing,
-                                    jvp = __has_jvp(f) ? f.jvp : nothing,
-                                    vjp = __has_vjp(f) ? f.vjp : nothing,
-                                    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                                    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                                    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                                    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                    sys = __has_sys(f) ? f.sys : nothing)
+DynamicalODEFunction{iip, specialize}(
+    f1, f2;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the functions `f_i` themselves are required. These functions should
@@ -825,18 +832,20 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DDEFunction{iip,specialize}(f;
-                 mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                 analytic = __has_analytic(f) ? f.analytic : nothing,
-                 tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                 jac = __has_jac(f) ? f.jac : nothing,
-                 jvp = __has_jvp(f) ? f.jvp : nothing,
-                 vjp = __has_vjp(f) ? f.vjp : nothing,
-                 jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                 sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                 paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                 colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                 sys = __has_sys(f) ? f.sys : nothing)
+DDEFunction{iip, specialize}(
+    f;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -931,18 +940,20 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DynamicalDDEFunction{iip,specialize}(f1,f2;
-                                    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                                    analytic = __has_analytic(f) ? f.analytic : nothing,
-                                    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                                    jac = __has_jac(f) ? f.jac : nothing,
-                                    jvp = __has_jvp(f) ? f.jvp : nothing,
-                                    vjp = __has_vjp(f) ? f.vjp : nothing,
-                                    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                                    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                                    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                                    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                    sys = __has_sys(f) ? f.sys : nothing)
+DynamicalDDEFunction{iip, specialize}(
+    f1, f2;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the functions `f_i` themselves are required. These functions should
@@ -1047,8 +1058,10 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DiscreteFunction{iip,specialize}(f;
-                                analytic = __has_analytic(f) ? f.analytic : nothing)
+DiscreteFunction{iip, specialize}(
+    f;
+    analytic = __has_analytic(f) ? f.analytic : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1102,9 +1115,11 @@ dt: the time step
 ## Constructor
 
 ```julia
-ImplicitDiscreteFunction{iip,specialize}(f;
-                                analytic = __has_analytic(f) ? f.analytic : nothing,
-                                resid_prototype = __has_resid_prototype(f) ? f.resid_prototype : nothing)
+ImplicitDiscreteFunction{iip, specialize}(
+    f;
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    resid_prototype = __has_resid_prototype(f) ? f.resid_prototype : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1170,19 +1185,21 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-SDEFunction{iip,specialize}(f,g;
-                           mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           ggprime = nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+SDEFunction{iip, specialize}(
+    f, g;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    ggprime = nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that both the function `f` and `g` are required. This function should
@@ -1277,19 +1294,21 @@ and exponential integrators.
 ## Constructor
 
 ```julia
-SplitSDEFunction{iip,specialize}(f1,f2,g;
-                 mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                 analytic = __has_analytic(f) ? f.analytic : nothing,
-                 tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                 jac = __has_jac(f) ? f.jac : nothing,
-                 jvp = __has_jvp(f) ? f.jvp : nothing,
-                 vjp = __has_vjp(f) ? f.vjp : nothing,
-                 ggprime = nothing,
-                 jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                 sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                 paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                 colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                 sys = __has_sys(f) ? f.sys : nothing)
+SplitSDEFunction{iip, specialize}(
+    f1, f2, g;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    ggprime = nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the function `f` itself is required. All of the remaining functions
@@ -1390,19 +1409,21 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DynamicalSDEFunction{iip,specialize}(f1,f2;
-                                    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                                    analytic = __has_analytic(f) ? f.analytic : nothing,
-                                    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                                    jac = __has_jac(f) ? f.jac : nothing,
-                                    jvp = __has_jvp(f) ? f.jvp : nothing,
-                                    vjp = __has_vjp(f) ? f.vjp : nothing,
-                                    ggprime=nothing,
-                                    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                                    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                                    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                                    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                    sys = __has_sys(f) ? f.sys : nothing)
+DynamicalSDEFunction{iip, specialize}(
+    f1, f2;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    ggprime = nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the functions `f_i` themselves are required. These functions should
@@ -1509,19 +1530,21 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-RODEFunction{iip,specialize}(f;
-                           mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing,
-                           analytic_full = __has_analytic_full(f) ? f.analytic_full : false)
+RODEFunction{iip, specialize}(
+    f;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing,
+    analytic_full = __has_analytic_full(f) ? f.analytic_full : false
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1629,18 +1652,20 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DAEFunction{iip,specialize}(f;
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           jac_u = __has_jac_u(f) ? f.jac_u : nothing,
-                           jac_du = __has_jac_du(f) ? f.jac_du : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing,
-                           nlstep_data = __has_nlstep_data(f) ? f.nlstep_data : nothing)
+DAEFunction{iip, specialize}(
+    f;
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jac_u = __has_jac_u(f) ? f.jac_u : nothing,
+    jac_du = __has_jac_du(f) ? f.jac_du : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing,
+    nlstep_data = __has_nlstep_data(f) ? f.nlstep_data : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1710,27 +1735,28 @@ The Jacobian should be given in the form `gamma*dG/d(du) + dG/du ` where `gamma`
 is given by the solver. This means that the signature is:
 
 ```julia
-f(J,du,u,p,gamma,t)
+f(J, du, u, p, gamma, t)
 ```
 
 For example, for the equation
 
 ```julia
-function testjac(res,du,u,p,t)
-  res[1] = du[1] - 2.0 * u[1] + 1.2 * u[1]*u[2]
-  res[2] = du[2] -3 * u[2] - u[1]*u[2]
+function testjac(res, du, u, p, t)
+    res[1] = du[1] - 2.0 * u[1] + 1.2 * u[1] * u[2]
+    res[2] = du[2] - 3 * u[2] - u[1] * u[2]
+    return
 end
 ```
 
 we would define the Jacobian as:
 
 ```julia
-function testjac(J,du,u,p,gamma,t)
-  J[1,1] = gamma - 2.0 + 1.2 * u[2]
-  J[1,2] = 1.2 * u[1]
-  J[2,1] = - 1 * u[2]
-  J[2,2] = gamma - 3 - u[1]
-  nothing
+function testjac(J, du, u, p, gamma, t)
+    J[1, 1] = gamma - 2.0 + 1.2 * u[2]
+    J[1, 2] = 1.2 * u[1]
+    J[2, 1] = - 1 * u[2]
+    J[2, 2] = gamma - 3 - u[1]
+    return
 end
 ```
 
@@ -1796,18 +1822,20 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-SDDEFunction{iip,specialize}(f,g;
-                 mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                 analytic = __has_analytic(f) ? f.analytic : nothing,
-                 tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                 jac = __has_jac(f) ? f.jac : nothing,
-                 jvp = __has_jvp(f) ? f.jvp : nothing,
-                 vjp = __has_vjp(f) ? f.vjp : nothing,
-                 jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                 sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                 paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                 colorvec = __has_colorvec(f) ? f.colorvec : nothing
-                 sys = __has_sys(f) ? f.sys : nothing)
+SDDEFunction{iip, specialize}(
+    f, g;
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -1910,16 +1938,18 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-NonlinearFunction{iip, specialize}(f;
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           jac = __has_jac(f) ? f.jac : nothing,
-                           jvp = __has_jvp(f) ? f.jvp : nothing,
-                           vjp = __has_vjp(f) ? f.vjp : nothing,
-                           jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                           sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                           paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                           colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+NonlinearFunction{iip, specialize}(
+    f;
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -2124,9 +2154,11 @@ interval variable.
 ## Constructor
 
 ```julia
-IntervalNonlinearFunction{iip, specialize}(f;
-                           analytic = __has_analytic(f) ? f.analytic : nothing,
-                           sys = __has_sys(f) ? f.sys : nothing)
+IntervalNonlinearFunction{iip, specialize}(
+    f;
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 Note that only the function `f` itself is required. This function should
@@ -2172,12 +2204,14 @@ A representation of an objective function `f`, defined by:
 ```
 
 and all of its related functions, such as the gradient of `f`, its Hessian,
-and more. For all cases, `u` is the state which in this case are the optimization variables and `p` are the fixed parameters or data.
+and more. For all cases, `u` is the state which in this case are the
+optimization variables and `p` are the fixed parameters or data.
 
 ## Constructor
 
 ```julia
-OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
+OptimizationFunction{iip}(
+    f, adtype::AbstractADType = NoAD();
     grad = nothing, hess = nothing, hv = nothing,
     cons = nothing, cons_j = nothing, cons_jvp = nothing,
     cons_vjp = nothing, cons_h = nothing,
@@ -2190,14 +2224,18 @@ OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
     cons_jac_colorvec = __has_colorvec(f) ? f.colorvec : nothing,
     cons_hess_colorvec = __has_colorvec(f) ? f.colorvec : nothing,
     lag_hess_colorvec = nothing,
-    sys = __has_sys(f) ? f.sys : nothing)
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 ## Positional Arguments
 
-  - `f(u,p)`: the function to optimize. `u` are the optimization variables and `p` are fixed parameters or data used in the objective,
-    even if no such parameters are used in the objective it should be an argument in the function. For minibatching `p` can be used to pass in
-    a minibatch, take a look at the tutorial [here](https://docs.sciml.ai/Optimization/stable/tutorials/minibatch/) to see how to do it.
+  - `f(u,p)`: the function to optimize. `u` are the optimization variables and
+    `p` are fixed parameters or data used in the objective,
+    even if no such parameters are used in the objective it should be an
+    argument in the function. For minibatching `p` can be used to pass in
+    a minibatch, take a look at the tutorial [here](https://docs.sciml.ai/Optimization/stable/tutorials/minibatch/)
+    to see how to do it.
     This should return a scalar, the loss value, as the return output.
   - `adtype`: see the Defining Optimization Functions via AD section below.
 
@@ -2243,7 +2281,8 @@ OptimizationFunction{iip}(f, adtype::AbstractADType = NoAD();
   - `cons_hess_colorvec`: an array of color vector according to the SparseDiffTools.jl definition for
     the sparsity pattern of the `cons_hess_prototype`.
 
-When [Symbolic Problem Building with ModelingToolkit](https://docs.sciml.ai/Optimization/stable/tutorials/symbolic/) interface is used the following arguments are also relevant:
+When [Symbolic Problem Building with ModelingToolkit](https://docs.sciml.ai/Optimization/stable/tutorials/symbolic/)
+interface is used the following arguments are also relevant:
 
   - `observed`: an algebraic combination of optimization variables that is of interest to the user
     which will be available in the solution. This can be single or multiple expressions.
@@ -2397,7 +2436,8 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 `p` are the parameters, and `t` is the independent variable.
 
 ```julia
-ODEInputFunction{iip, specialize}(f;
+ODEInputFunction{iip, specialize}(
+    f;
     mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
     analytic = __has_analytic(f) ? f.analytic : nothing,
     tgrad= __has_tgrad(f) ? f.tgrad : nothing,
@@ -2410,7 +2450,8 @@ ODEInputFunction{iip, specialize}(f;
     sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
     paramjac = __has_paramjac(f) ? f.paramjac : nothing,
     colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-    sys = __has_sys(f) ? f.sys : nothing)
+    sys = __has_sys(f) ? f.sys : nothing
+)
 ```
 
 `f` should be given as `f(x_out,x,u,p,t)` or `out = f(x,u,p,t)`.
@@ -2513,7 +2554,7 @@ If the size of `g(u, p, t)` is different from the size of `u`, then the constrai
 interpreted as a least squares problem, i.e. the objective function is:
 
 ```math
-\\min_u \\| g_i(u, p, t) \\|^2
+\\min_u ‖ g_i(u, p, t) ‖^2
 ```
 
 and all of its related functions, such as the Jacobian of `f`, its gradient
@@ -2521,7 +2562,8 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 `p` are the parameters, and `t` is the independent variable.
 
 ```julia
-BVPFunction{iip, specialize}(f, bc;
+BVPFunction{iip, specialize}(
+    f, bc;
     cost = __has_cost(f) ? f.cost : nothing,
     equality = __has_equality(f) ? f.equality : nothing,
     inequality = __has_inequality(f) ? f.inequality : nothing,
@@ -2540,7 +2582,8 @@ BVPFunction{iip, specialize}(f, bc;
     colorvec = __has_colorvec(f) ? f.colorvec : nothing,
     bccolorvec = __has_colorvec(f) ? bc.colorvec : nothing,
     sys = __has_sys(f) ? f.sys : nothing,
-    twopoint::Union{Val, Bool} = Val(false))
+    twopoint::Union{Val, Bool} = Val(false)
+)
 ```
 
 Note that both the function `f` and boundary condition `bc` are required. `f` should
@@ -2649,7 +2692,7 @@ $(TYPEDEF)
 A representation of a dynamical BVP function `f`, defined by:
 
 ```math
-M u'' = f(u',u,p,t)
+M u'' = f(u', u, p, t)
 ```
 
 along with its boundary condition:
@@ -2665,22 +2708,24 @@ with respect to time, and more. For all cases, `u0` is the initial condition,
 ## Constructor
 
 ```julia
-DynamicalBVPFunction{iip,specialize}(f, bc;
-                                    cost = __has_cost(f) ? f.cost : nothing,
-                                    equality = __has_equality(f) ? f.equality : nothing,
-                                    inequality = __has_inequality(f) ? f.inequality : nothing,
-                                    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
-                                    analytic = __has_analytic(f) ? f.analytic : nothing,
-                                    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
-                                    jac = __has_jac(f) ? f.jac : nothing,
-                                    jvp = __has_jvp(f) ? f.jvp : nothing,
-                                    vjp = __has_vjp(f) ? f.vjp : nothing,
-                                    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
-                                    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
-                                    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
-                                    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
-                                    sys = __has_sys(f) ? f.sys : nothing
-                                    twopoint::Union{Val, Bool} = Val(false))
+DynamicalBVPFunction{iip, specialize}(
+    f, bc;
+    cost = __has_cost(f) ? f.cost : nothing,
+    equality = __has_equality(f) ? f.equality : nothing,
+    inequality = __has_inequality(f) ? f.inequality : nothing,
+    mass_matrix = __has_mass_matrix(f) ? f.mass_matrix : I,
+    analytic = __has_analytic(f) ? f.analytic : nothing,
+    tgrad= __has_tgrad(f) ? f.tgrad : nothing,
+    jac = __has_jac(f) ? f.jac : nothing,
+    jvp = __has_jvp(f) ? f.jvp : nothing,
+    vjp = __has_vjp(f) ? f.vjp : nothing,
+    jac_prototype = __has_jac_prototype(f) ? f.jac_prototype : nothing,
+    sparsity = __has_sparsity(f) ? f.sparsity : jac_prototype,
+    paramjac = __has_paramjac(f) ? f.paramjac : nothing,
+    colorvec = __has_colorvec(f) ? f.colorvec : nothing,
+    sys = __has_sys(f) ? f.sys : nothing
+    twopoint::Union{Val, Bool} = Val(false)
+)
 ```
 
 Note that only the functions `f_i` themselves are required. These functions should
@@ -2768,8 +2813,8 @@ struct DynamicalBVPFunction{
     initialization_data::ID
 end
 
-@doc doc"""
-    IntegralFunction{iip,specialize,F,T} <: AbstractIntegralFunction{iip}
+"""
+    IntegralFunction{iip, specialize, F, T} <: AbstractIntegralFunction{iip}
 
 A representation of an integrand `f` defined by:
 
@@ -2781,7 +2826,7 @@ For an in-place form of `f` see the `iip` section below for details on in-place 
 out-of-place handling.
 
 ```julia
-IntegralFunction{iip,specialize}(f, [integrand_prototype])
+IntegralFunction{iip, specialize}(f, [integrand_prototype])
 ```
 
 Note that only `f` is required, and in the case of inplace integrands a mutable array
@@ -2814,8 +2859,8 @@ struct IntegralFunction{iip, specialize, F, T} <:
     integrand_prototype::T
 end
 
-@doc doc"""
-    BatchIntegralFunction{iip,specialize,F,T} <: AbstractIntegralFunction{iip}
+"""
+    BatchIntegralFunction{iip, specialize, F, T} <: AbstractIntegralFunction{iip}
 
 A batched representation of an (non-batched) integrand `f(u, p)` that can be
 evaluated at multiple points simultaneously using threads, the gpu, or
@@ -2840,8 +2885,9 @@ For an in-place form of `bf` see the `iip` section below for details on in-place
 or out-of-place handling.
 
 ```julia
-BatchIntegralFunction{iip,specialize}(bf, [integrand_prototype];
-                                     max_batch=typemax(Int))
+BatchIntegralFunction{iip, specialize}(
+    bf, [integrand_prototype]; max_batch = typemax(Int)
+)
 ```
 Note that only `bf` is required, and in the case of inplace integrands a mutable
 array `integrand_prototype` to store a batch of integrand evaluations, with

--- a/src/solutions/basic_solutions.jl
+++ b/src/solutions/basic_solutions.jl
@@ -209,7 +209,8 @@ Construct the solution object returned by a SciML solver for `prob` solved with
 Solver packages extend `build_solution` for the problem and algorithm families
 they own so that direct solver implementations can share the same solution
 construction path. Methods should attach the original problem, algorithm,
-[`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes), residual or error information, solver statistics, dense
+[`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes),
+residual or error information, solver statistics, dense
 interpolation data, and saved values expected by the corresponding
 [`AbstractSciMLSolution`](@ref) interface.
 
@@ -239,24 +240,6 @@ function build_solution(
         stats
     )
 end
-@doc """
-    build_solution(prob, alg, args...; kwargs...)
-
-Construct the solution object returned by a SciML solver for `prob` solved with
-`alg`.
-
-Solver packages extend `build_solution` for the problem and algorithm families
-they own so that direct solver implementations can share the same solution
-construction path. Methods should attach the original problem, algorithm,
-[`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes), residual or error information, solver statistics, dense
-interpolation data, and saved values expected by the corresponding
-[`AbstractSciMLSolution`](@ref) interface.
-
-The accepted positional arguments are problem-family specific. Implementations
-should document the argument order they expect and should preserve common SciML
-solution behavior such as array indexing, symbolic indexing, and retcode
-inspection.
-""" build_solution
 
 """
     wrap_sol(sol)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,7 +1,7 @@
 const NONCONCRETE_ELTYPE_MESSAGE = """
 Non-concrete element type inside of an `Array` detected.
 Arrays with non-concrete element types, such as
-`Array{Union{Float32,Float64}}`, are not supported by the
+`Array{Union{Float32, Float64}}`, are not supported by the
 differential equation solvers. Anyways, this is bad for
 performance so you don't want to be doing this!
 
@@ -14,8 +14,8 @@ from RecursiveArrayTools.jl. For example:
 
 ```julia
 using RecursiveArrayTools
-x = ArrayPartition([1.0,2.0],[1f0,2f0])
-y = ArrayPartition([3.0,4.0],[3f0,4f0])
+x = ArrayPartition([1.0, 2.0], [1.0f0, 2.0f0])
+y = ArrayPartition([3.0, 4.0], [3.0f0, 4.0f0])
 x .+ y # fast, stable, and usable as u0 into DiffEq!
 ```
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,26 +89,23 @@ struct or other collection to hold the parameters. For example, here is the
 parameterized Lorenz equation:
 
 ```julia
-function lorenz(du,u,p,t)
-  du[1] = p[1]*(u[2]-u[1])
-  du[2] = u[1]*(p[2]-u[3]) - u[2]
-  du[3] = u[1]*u[2] - p[3]*u[3]
+function lorenz(du, u, p, t)
+    du[1] = p[1] * (u[2] - u[1])
+    du[2] = u[1] * (p[2] - u[3]) - u[2]
+    du[3] = u[1] * u[2] - p[3] * u[3]
+    return
 end
-u0 = [1.0;0.0;0.0]
-p = [10.0,28.0,8/3]
-tspan = (0.0,100.0)
-prob = ODEProblem(lorenz,u0,tspan,p)
+u0 = [1.0; 0.0; 0.0]
+p = [10.0, 28.0, 8/3]
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz, u0, tspan, p)
 ```
 
 Notice that `f` is defined with a single `p`, an array which matches the definition
 of the `p` in the `ODEProblem`. Note that `p` can be any Julia struct.
 """
 
-struct TooManyArgumentsError <: Exception
-    fname::String
-    f::Any
-end
-@doc """
+"""
     TooManyArgumentsError
 
 Exception thrown when a model function defines methods with more arguments than the
@@ -123,7 +120,11 @@ ODE right-hand side must be callable as `f(u, p, t)` or `f(du, u, p, t)`, not as
 
 - `fname`: Display name used in the error message, such as `"f"` or `"jac"`.
 - `f`: The offending callable; `showerror` prints its method table.
-""" TooManyArgumentsError
+"""
+struct TooManyArgumentsError <: Exception
+    fname::String
+    f::Any
+end
 
 function Base.showerror(io::IO, e::TooManyArgumentsError)
     println(io, TOO_MANY_ARGUMENTS_ERROR_MESSAGE)
@@ -148,23 +149,23 @@ For example, here is a parameterized optimization problem:
 
 ```julia
 using Optimization, OptimizationOptimJL
-rosenbrock(u,p) =  (p[1] - u[1])^2 + p[2] * (u[2] - u[1]^2)^2
+rosenbrock(u, p) = (p[1] - u[1])^2 + p[2] * (u[2] - u[1]^2)^2
 u0 = zeros(2)
-p  = [1.0,100.0]
+p = [1.0,100.0]
 
-prob = OptimizationProblem(rosenbrock,u0,p)
-sol = solve(prob,NelderMead())
+prob = OptimizationProblem(rosenbrock, u0, p)
+sol = solve(prob, NelderMead())
 ```
 
 and a parameter-less example:
 
 ```julia
 using Optimization, OptimizationOptimJL
-rosenbrock(u,p) =  (1 - u[1])^2 + (u[2] - u[1]^2)^2
+rosenbrock(u, p) = (1 - u[1])^2 + (u[2] - u[1]^2)^2
 u0 = zeros(2)
 
-prob = OptimizationProblem(rosenbrock,u0)
-sol = solve(prob,NelderMead())
+prob = OptimizationProblem(rosenbrock, u0)
+sol = solve(prob, NelderMead())
 ```
 """
 
@@ -180,37 +181,33 @@ For example, here is the no parameter Lorenz equation. The two valid versions
 are out of place:
 
 ```julia
-function lorenz(u,p,t)
-  du1 = 10.0*(u[2]-u[1])
-  du2 = u[1]*(28.0-u[3]) - u[2]
-  du3 = u[1]*u[2] - 8/3*u[3]
-  [du1,du2,du3]
+function lorenz(u, p, t)
+    du1 = 10.0 * (u[2] - u[1])
+    du2 = u[1] * (28.0 - u[3]) - u[2]
+    du3 = u[1] * u[2] - 8/3 * u[3]
+    return [du1, du2, du3]
 end
-u0 = [1.0;0.0;0.0]
-tspan = (0.0,100.0)
-prob = ODEProblem(lorenz,u0,tspan)
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz, u0, tspan)
 ```
 
 and in-place:
 
 ```julia
-function lorenz!(du,u,p,t)
-  du[1] = 10.0*(u[2]-u[1])
-  du[2] = u[1]*(28.0-u[3]) - u[2]
-  du[3] = u[1]*u[2] - 8/3*u[3]
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - 8/3 * u[3]
+    return
 end
-u0 = [1.0;0.0;0.0]
-tspan = (0.0,100.0)
-prob = ODEProblem(lorenz!,u0,tspan)
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz!, u0, tspan)
 ```
 """
 
-struct TooFewArgumentsError <: Exception
-    fname::String
-    f::Any
-    isoptimization::Bool
-end
-@doc """
+"""
     TooFewArgumentsError
 
 Exception thrown when a model function defines methods with fewer arguments than the
@@ -227,7 +224,12 @@ and time arguments.
 - `fname`: Display name used in the error message, such as `"f"` or `"jac"`.
 - `f`: The offending callable; `showerror` prints its method table.
 - `isoptimization`: Whether to use the optimization-specific explanation.
-""" TooFewArgumentsError
+"""
+struct TooFewArgumentsError <: Exception
+    fname::String
+    f::Any
+    isoptimization::Bool
+end
 
 function Base.showerror(io::IO, e::TooFewArgumentsError)
     if e.isoptimization
@@ -250,11 +252,7 @@ on the required dispatches for the given model function, consult the documentati
 for the appropriate `SciMLProblem` or `AbstractSciMLFunction`.
 """
 
-struct FunctionArgumentsError <: Exception
-    fname::String
-    f::Any
-end
-@doc """
+"""
     FunctionArgumentsError
 
 Exception thrown when a model function's methods do not match the accepted SciML
@@ -270,7 +268,11 @@ problem or SciMLFunction interface.
 
 - `fname`: Display name used in the error message, such as `"f"` or `"jac"`.
 - `f`: The offending callable; `showerror` prints its method table.
-""" FunctionArgumentsError
+"""
+struct FunctionArgumentsError <: Exception
+    fname::String
+    f::Any
+end
 
 function Base.showerror(io::IO, e::FunctionArgumentsError)
     println(io, ARGUMENTS_ERROR_MESSAGE)
@@ -281,9 +283,11 @@ function Base.showerror(io::IO, e::FunctionArgumentsError)
 end
 
 """
-    isinplace(f, inplace_param_number, fname = "f", iip_preferred = true;
-              has_two_dispatches = true,
-              outofplace_param_number = inplace_param_number - 1)
+    isinplace(
+        f, inplace_param_number, fname = "f", iip_preferred = true;
+        has_two_dispatches = true,
+        outofplace_param_number = inplace_param_number - 1
+    )
     isinplace(f::AbstractSciMLFunction[, inplace_param_number])
 
 Check whether a user callback follows the in-place SciML convention.
@@ -547,16 +551,16 @@ warn_compat() = @warn("https://docs.sciml.ai/DiffEqDocs/stable/basics/compatibil
 
 Define keyword-only version of the `function_definition`.
 
-    @add_kwonly function f(x; y=1)
+    @add_kwonly function f(x; y = 1)
         ...
     end
 
 expands to:
 
-    function f(x; y=1)
+    function f(x; y = 1)
         ...
     end
-    function f(; x = error("No argument x"), y=1)
+    function f(; x = error("No argument x"), y = 1)
         ...
     end
 """


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

As a side effect, this removed some more duplicate docstrings, and also lowered the usage of the `@doc` macro which runic was having a hard time seeing through (which also required fiddling with some of the LaTeX). Also moved the docstrings for some error types to right before the struct definition so that an unnecessary `@doc` wasn't used.
