### PR TITLE
Release SciMLBase 3.53.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.53.1"
+version = "3.53.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLBase` 3.53.1 -> 3.53.2 (patch).

Source files changed since 3.53.1:
- `ext/SciMLBaseMakieExt.jl`
- `src/scimlfunctions.jl`

Commits:
- Compare solution parameter cotangents against the solution's own parameters (#1587)
- Make Makie timeseries recipes Observable-aware (#1589)
- Add 32-bit Core CI lane via test_groups.toml (#1590)
- Trim unused Makie DEIntegrator hooks after #1589 (#1591)
- Keep 32-bit CI lane hard-failing. (#1593)
- Avoid broadcast-based getproperties on SciML functions. (#1595)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
