### PR TITLE
Format scimlfunctions.jl with Runic

### DIFF
--- a/src/scimlfunctions.jl
+++ b/src/scimlfunctions.jl
@@ -6012,8 +6012,10 @@ end
 # "irinterp is unable to handle heavy recursion correctly" internal error
 # (https://discourse.julialang.org/t/139291). A generated getfield-only path
 # keeps remake / Accessors off that broadcast edge set.
-@generated function ConstructionBase.getproperties(func::T) where {T <:
-                                                                      AbstractSciMLFunction}
+@generated function ConstructionBase.getproperties(func::T) where {
+        T <:
+        AbstractSciMLFunction,
+    }
     names = fieldnames(T)
     vals = Expr(:tuple, (:(getfield(func, $(QuoteNode(n)))) for n in names)...)
     return :(NamedTuple{$names}($vals))


### PR DESCRIPTION
## Summary

`format-check` on master fails on `src/scimlfunctions.jl`: the `where`-clause of the generated `ConstructionBase.getproperties` method isn't in canonical Runic form. Applied `runic` to the file (single hunk).

#### Test plan
- [x] `Runic.main(["--check", "src/scimlfunctions.jl"])` exits 0 locally

🤖 Generated with Devin CLI (model: SWE-2 Max) — local session, no shareable URL