### PR TITLE
Add a problem_type slot to OptimizationProblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLBase"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "3.53.3"
+version = "3.54.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com> and contributors"]
 
 [deps]

--- a/src/problems/optimization_problems.jl
+++ b/src/problems/optimization_problems.jl
@@ -32,6 +32,7 @@ OptimizationProblem{isinplace}(
     lcons = nothing,
     ucons = nothing,
     sense = nothing,
+    problem_type = nothing,
     kwargs...
 )
 ```
@@ -84,6 +85,10 @@ Any extra keyword arguments are captured to be sent to the optimizers.
   [`OptimizationFunction`](https://docs.sciml.ai/Optimization/stable/API/optimization_function/#optfunction).
     Defaults to `nothing`, implying no upper bounds for the constraints (i.e. the constraint bound is `Inf`)
 * `sense`: the objective sense, can take `MaxSense` or `MinSense` from Optimization.jl.
+* `problem_type`: an optional tag describing the origin of the problem, returned by
+  [`problem_type`](@ref). PDE discretizations store their
+  [`AbstractDiscretizationMetadata`](@ref) here so that [`wrap_sol`](@ref) can wrap the
+  optimization solution into a [`PDENoTimeSolution`](@ref).
 * `kwargs`: the keyword arguments passed on to the solvers.
 
 ## Inequality and Equality Constraints
@@ -119,7 +124,7 @@ For an example of how to use this data handling, see the `Sophia` example in the
 [Optimization.jl documentation](https://docs.sciml.ai/Optimization/dev/optimization_packages/sophia/)
 or the [mini-batching tutorial](https://docs.sciml.ai/Optimization/dev/tutorials/minibatch/).
 """
-struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
+struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, PT, K} <:
     AbstractOptimizationProblem{iip}
     f::F
     u0::uType
@@ -130,6 +135,7 @@ struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
     lcons::LC
     ucons::UC
     sense::S
+    problem_type::PT
     kwargs::K
     @add_kwonly function OptimizationProblem{iip}(
             f::Union{OptimizationFunction{iip}, MultiObjectiveOptimizationFunction{iip}},
@@ -137,7 +143,7 @@ struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
             p = NullParameters();
             lb = nothing, ub = nothing, int = nothing,
             lcons = nothing, ucons = nothing,
-            sense = nothing, kwargs...
+            sense = nothing, problem_type = nothing, kwargs...
         ) where {iip}
         if xor(lb === nothing, ub === nothing)
             error("If any of `lb` or `ub` is provided, both must be provided.")
@@ -146,9 +152,9 @@ struct OptimizationProblem{iip, F, uType, P, LB, UB, I, LC, UC, S, K} <:
         new{
             iip, typeof(f), typeof(u0), typeof(p),
             typeof(lb), typeof(ub), typeof(int), typeof(lcons), typeof(ucons),
-            typeof(sense), typeof(kwargs),
+            typeof(sense), typeof(problem_type), typeof(kwargs),
         }(
-            f, u0, p, lb, ub, int, lcons, ucons, sense,
+            f, u0, p, lb, ub, int, lcons, ucons, sense, problem_type,
             kwargs
         )
     end

--- a/src/remake.jl
+++ b/src/remake.jl
@@ -1275,7 +1275,7 @@ end
     remake(
         prob::OptimizationProblem; f = missing, u0 = missing, p = missing,
         lb = missing, ub = missing, int = missing, lcons = missing, ucons = missing,
-        sense = missing, kwargs = missing, _kwargs...
+        sense = missing, problem_type = missing, kwargs = missing, _kwargs...
     )
 
 Remake the given `OptimizationProblem`.
@@ -1292,6 +1292,7 @@ function remake(
         lcons = missing,
         ucons = missing,
         sense = missing,
+        problem_type = missing,
         kwargs = missing,
         interpret_symbolicmap = true,
         use_defaults = false,
@@ -1300,6 +1301,9 @@ function remake(
     u0, p = updated_u0_p(prob, u0, p; interpret_symbolicmap, use_defaults)
     if f === missing
         f = prob.f
+    end
+    if problem_type === missing
+        problem_type = prob.problem_type
     end
     if lb === missing
         lb = prob.lb
@@ -1326,13 +1330,14 @@ function remake(
             f, u0, p, lb,
             ub, int,
             lcons, ucons,
-            sense, (values(prob.kwargs)::NamedTuple)..., (values(_kwargs)::NamedTuple)...
+            sense, problem_type, (values(prob.kwargs)::NamedTuple)...,
+            (values(_kwargs)::NamedTuple)...
         )
     else
         OptimizationProblem{isinplace(prob)}(;
             f, u0, p, lb,
             ub, int,
-            lcons, ucons,
+            lcons, ucons, problem_type,
             sense, kwargs...
         )
     end

--- a/test/pde_solutions.jl
+++ b/test/pde_solutions.jl
@@ -41,3 +41,20 @@ end
     @test wrapped[1] === :time_series
     @test wrapped[3] === metadata
 end
+
+@testset "OptimizationProblem carries discretization metadata as its problem_type" begin
+    optf = OptimizationFunction((u, p) -> sum(abs2, u))
+    metadata = TestNoTimeMetadata()
+    prob = OptimizationProblem(optf, [1.0]; problem_type = metadata)
+
+    @test SciMLBase.problem_type(prob) === metadata
+    @test SciMLBase.problem_type(remake(prob; u0 = [2.0])) === metadata
+    @test SciMLBase.problem_type(remake(prob; problem_type = nothing)) === nothing
+    @test SciMLBase.problem_type(OptimizationProblem(optf, [1.0])) === nothing
+
+    sol = Any[:optimization_solution]
+    wrapped = SciMLBase.wrap_sol(sol, SciMLBase.problem_type(prob))
+    @test wrapped[1] === :no_time
+    @test wrapped[3] === metadata
+    @test SciMLBase.wrap_sol(sol, SciMLBase.problem_type(OptimizationProblem(optf, [1.0]))) === sol
+end


### PR DESCRIPTION
> **Note:** please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

PDE discretizations that lower to an optimization problem (the NeuralPDE parser rewrite, https://github.com/SciML/NeuralPDE.jl/issues/1161) need `wrap_sol` to turn the `OptimizationSolution` into a `PDENoTimeSolution`. `wrap_sol` decides that through `problem_type(prob)`, and `OptimizationProblem` had no `problem_type` field, so it always returned `nothing`. This adds the field (keyword `problem_type = nothing`, so nothing changes for existing problems), documents it, and carries it through `remake`.

Companion PRs: OptimizationBase passes `problem_type(prob)` to `wrap_sol` (an `OptimizationSolution` has no `prob` field, so the one-argument `wrap_sol(sol)` cannot find it) at https://github.com/SciML/Optimization.jl/pull/1354, and ModelingToolkitBase forwards `ProblemTypeCtx` metadata into the new slot at https://github.com/SciML/ModelingToolkit.jl/pull/5115.

Minor version bump (3.53.3 → 3.54.0): new keyword and a new type parameter on `OptimizationProblem`.

## Verification

New testset in `test/pde_solutions.jl`. Without the change the constructor rejects the keyword:

```
MethodError: no method matching OptimizationProblem{true}(::OptimizationFunction{…}, ::Vector{Float64}; problem_type::TestNoTimeMetadata)
```

With the change (`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` on Julia 1.11.9):

```
Test Summary: | Pass  Total  Time
pde           |   18     18  1.6s
...
exit=0
```

(The full Core group passed; the tail of the log only shows the last summaries.)

## Not verified

Downstream groups and Julia 1.10/pre were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01WYPUXLxE9jVu2jXLFRd8ax

