### PR TITLE
Remove stale Markdown doc-string macro import

### DIFF
--- a/src/SciMLBase.jl
+++ b/src/SciMLBase.jl
@@ -37,7 +37,7 @@ using DocStringExtensions: DocStringExtensions, FIELDS, SIGNATURES, TYPEDEF,
 using LinearAlgebra: LinearAlgebra, I, det, norm
 using Statistics: Statistics, mean, median
 using Distributed: Distributed, CachingPool, myid, nworkers, pmap, workers
-using Markdown: Markdown, @doc_str
+using Markdown: Markdown
 using Printf: Printf, @printf
 import Preferences
 using PreallocationTools: get_tmp, DiffCache, FixedSizeDiffCache


### PR DESCRIPTION
Please ignore this draft until reviewed by @ChrisRackauckas.

Remove the unused `Markdown.@doc_str` import. The docstring cleanup in https://github.com/SciML/SciMLBase.jl/commit/fae101f1ef5672cee315051fb581c331bee2cabb replaced its last two uses with ordinary docstrings, causing the existing `no_stale_explicit_imports` QA check to fail on master. This is a standalone mechanical prerequisite for https://github.com/SciML/OrdinaryDiffEq.jl/pull/4436.

Verification used the existing QA group, unchanged, on clean checkouts of both sides of the introducing commit:

```sh
GROUP=QA JULIA_PKG_PRECOMPILE_AUTO=0 \
  TMPDIR="$PWD/../OrdinaryDiffEq-shared-reactant/.work/tmp" \
  PIXI_CACHE_DIR="$PWD/../OrdinaryDiffEq-shared-reactant/.work/pixi-base-review" \
  RATTLER_CACHE_DIR="$PWD/../OrdinaryDiffEq-shared-reactant/.work/rattler-base-review" \
  /home/crackauc/.juliaup/bin/julia +1.12.4 --project=. \
  -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```

Before the introducing commit, https://github.com/SciML/SciMLBase.jl/commit/bd9cf3240a03c9e4e55b6f4fd6a492b0cbee969a:

```text
QA | 123 123 8m05.3s
Testing SciMLBase tests passed
```

At the introducing commit:

```text
Module `SciMLBase` has stale (unused) explicit imports for:
* `@doc_str`
QA | 122 1 123 9m14.9s
ERROR: Package SciMLBase errored during testing
```

The same failure also reproduces on unmodified master https://github.com/SciML/SciMLBase.jl/commit/0d5c48897. With this change on master:

```text
QA | 123 123 11m01.3s
Testing SciMLBase tests passed
```

Formatting, spelling, and whitespace checks:

```sh
/home/crackauc/.juliaup/bin/julia +1.10 --project=../runic-1.10-env -e 'using Runic;exit(Runic.main(ARGS))' -- --check src/SciMLBase.jl
typos src/SciMLBase.jl
git diff --check
```

All exited zero. No new test duplicates the existing discriminating QA check. No public API or documentation changes; docs, full Everything, GPU, and downstream groups were not run for this unused-import deletion. The existing shared Pixi cache was corrupt, so the command uses a fresh workspace-local cache.

## CI follow-up (2026-09-12)

Downstream CI is not green: SciMLSensitivity Core3 received signal 11 in Julia 1.13 LLVM loop-unrolling code, and Catalyst failed during setup while writing its installed `test/extensions/Project.toml` (`Permission denied`). These failures remain unresolved; local master QA and the minimal import cleanup were verified as recorded above.

- SciMLSensitivity failure: https://github.com/SciML/SciMLBase.jl/actions/runs/34686221797/job/103533554372
- Catalyst setup failure: https://github.com/SciML/SciMLBase.jl/actions/runs/34686221580/job/103533552953

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local transcript `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T07-40-10-01a0715e-73c9-7e21-a18b-c5b0504a4bf3.jsonl`).

