### PR TITLE
Handle array symbols in symbolic remake

### DIFF
--- a/src/remake.jl
+++ b/src/remake.jl
@@ -1827,6 +1827,22 @@ end
 function fill_vars(
         prob, varmap; defs = nothing, use_defaults = false, allsyms, index_function
     )
+    scalar_syms = Any[]
+    for sym in allsyms
+        if symbolic_type(sym) == ArraySymbolic() &&
+                index_function(prob, sym) isa AbstractArray
+            append!(scalar_syms, sym)
+            if defs !== nothing && (defval = varmap_get(defs, sym)) !== nothing
+                defs = Dict{Any, Any}(defs)
+                for (element, value) in zip(sym, defval)
+                    get!(defs, element, value)
+                end
+            end
+        else
+            push!(scalar_syms, sym)
+        end
+    end
+    allsyms = scalar_syms
     idx_to_vsym = anydict(index_function(prob, sym) => sym for sym in allsyms)
     sym_to_idx = anydict()
     idx_to_sym = anydict()

--- a/test/remake_tests.jl
+++ b/test/remake_tests.jl
@@ -418,6 +418,58 @@ a = Remake_Test1(p = 1)
     @test get(newp, :b, 0) == 4.5
 end
 
+struct RemakeArraySymbol{N} <: AbstractArray{Symbol, N}
+    elements::Array{Symbol, N}
+end
+Base.size(sym::RemakeArraySymbol) = size(sym.elements)
+Base.getindex(sym::RemakeArraySymbol, inds...) = sym.elements[inds...]
+SymbolicIndexingInterface.symbolic_type(::Type{<:RemakeArraySymbol}) = ArraySymbolic()
+
+struct RemakeArraySystem{S, V, P}
+    cache::S
+    variables::V
+    parameters::P
+end
+SymbolicIndexingInterface.symbolic_container(sys::RemakeArraySystem) = sys.cache
+SymbolicIndexingInterface.variable_symbols(sys::RemakeArraySystem) = sys.variables
+SymbolicIndexingInterface.parameter_symbols(sys::RemakeArraySystem) = sys.parameters
+
+@testset "remake with unscalarized array symbols" begin
+    @testset "shape $shape" for shape in ((2,), (2, 2))
+        n = prod(shape)
+        x = RemakeArraySymbol(reshape([Symbol(:x, i) for i in 1:n], shape))
+        a = RemakeArraySymbol(reshape([Symbol(:a, i) for i in 1:n], shape))
+        indices = reshape(collect(1:n), shape)
+        vars = Dict{Any, Any}(x => indices, :x => indices, :y => n + 1)
+        params = Dict{Any, Any}(a => indices, :a => indices, :b => n + 1)
+        merge!(vars, Dict(zip(x, indices)))
+        merge!(params, Dict(zip(a, indices)))
+        defaults = Dict{Any, Any}(x => fill(10.0, shape), a => fill(20.0, shape))
+        sys = RemakeArraySystem(SymbolCache(vars, params, :t; defaults), [x, :y], [a, :b])
+        prob = ODEProblem(ODEFunction((u, p, t) -> -u; sys), collect(1.0:(n + 1)), (0.0, 1.0), collect(2.0:(n + 2)))
+        for (key, pkey) in ((x, a), (:x, :a))
+            changed = remake(prob; u0 = [key => fill(3.0, shape)], p = [pkey => fill(4.0, shape)])
+            @test changed.u0 == [fill(3.0, n); n + 1]
+            @test changed.p == [fill(4.0, n); n + 2]
+        end
+        changed = remake(prob; u0 = [x[1] => 7.0], p = [a[1] => 8.0])
+        @test changed.u0 == [7.0; prob.u0[2:end]]
+        @test changed.p == [8.0; prob.p[2:end]]
+        changed = remake(prob; u0 = [:y => 7.0], p = [:b => 8.0])
+        @test changed.u0 == [prob.u0[1:n]; 7.0]
+        @test changed.p == [prob.p[1:n]; 8.0]
+        changed = remake(prob; u0 = [x[1] => 7.0], p = [a[1] => 8.0], use_defaults = true)
+        @test changed.u0 == [7.0; fill(10.0, n - 1); n + 1]
+        @test changed.p == [8.0; fill(20.0, n - 1); n + 2]
+        @test defaults == Dict(x => fill(10.0, shape), a => fill(20.0, shape))
+        defaults[x[1]] = 30.0
+        defaults[a[1]] = 40.0
+        changed = remake(prob; u0 = [:y => 7.0], p = [:b => 8.0], use_defaults = true)
+        @test changed.u0 == [30.0; fill(10.0, n - 1); 7.0]
+        @test changed.p == [40.0; fill(20.0, n - 1); 8.0]
+    end
+end
+
 @testset "value of `nothing` is ignored" begin
     sys = SymbolCache(
         Dict(:x => 1, :y => 2), Dict(:a => 1, :b => 2),


### PR DESCRIPTION
Symbolic `remake` now handles providers that enumerate whole-array variables or parameters while mapping their elements to flat numerical indices. Previously `fill_vars` mapped the array index range to its parent symbol, then looked up individual indices and raised `KeyError: key 1 not found`. The fix expands symbols locally, preserves parent and scalar defaults, and copies the defaults dictionary before expansion.

This is a prerequisite found while implementing array DAE unknowns for https://github.com/SciML/MethodOfLines.jl/issues/695. Public symbol enumeration is unchanged; no dependencies or public API are added.

### Regression evidence

The official `SII_Remake` group was run with the new vector/matrix regression on clean upstream source and again with the fix:
```sh
GROUP=SII_Remake TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.12 --project=scimlbase-unfixed -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=SII_Remake TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.12 --project=SciMLBase.jl -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```
Before (both array cases error before their assertions):
```text
KeyError: key 1 not found
Test Summary:                                                                                        | Pass  Error  Total     Time
Remake                                                                                               | 4605      2   4607  4m04.8s
```
After, with the byte-identical test file:
```text
Test Summary: | Pass  Total     Time
Remake        | 4631   4631  4m13.9s
Testing SciMLBase tests passed
```
The isolated array regression passed 26/26.

The cases cover variable and parameter arrays, vector and matrix shapes, parent and indexed keys, array name aliases, partial updates, sibling scalar values, default precedence, and nonmutation of caller defaults.

### Validation

Runic confirmed both changed files already formatted. Typos over the diff and `git diff --check` passed.

Full QA passed with the system Python interpreter (the first attempt failed during Conda Python provisioning, before QA completed):
```sh
GROUP=QA TMPDIR="$PWD/tmp" JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.12 --project=SciMLBase.jl -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```
```text
Test Summary: | Pass  Total      Time
QA            |  123    123  10m47.3s
Testing SciMLBase tests passed
```
No tests or assertions were disabled. An integration check with local ModelingToolkit array DAE support also passed 24/24 checks, covering initialization, a DFBDF solve, shape-preserving indexing, and symbolic remake.

A second integration run with the completed local ModelingToolkit constructor stack passed on Julia 1.10.12 and the minimum CI dependencies (Symbolics 7.37.0, SymbolicUtils 4.37.0, SymbolicIndexingInterface 0.3.46, NonlinearSolveBase 2.49.4). Only the MTKBase and SciMLBase source paths changed from the copied minimum-dependency manifest:
```sh
TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.10.12 --project=array_constructors_downgrade_env array_constructors_downgrade_tests.jl
```
The driver uses the official `SafeTestsets` isolation for these three unchanged test files:
```text
Array derivative initialization |  6/6   | 2m23.6s
Array DAE Unknowns               | 46/46  |   52.5s
Array unknown DAE Jacobians      | 96/96  |   11.5s
```
The constructor stack includes a separate MTK integer-index bound correction exposed by older SII; that correction is not part of this SciMLBase diff. Julia emitted the previously identified Moshi precompilation warning and continued loading; the test process completed with exit 0.

No docs or public API changed. GPU, the full downstream matrix, and prerelease Julia jobs were not run locally. Focused downstream controls are documented below.

### Downstream failure investigation

Three downstream failures have independent baseline evidence; no tests were disabled or weakened to hide them.

- **SciMLSensitivity Core8:** the unchanged official `test/Core8/desauty_dae_mwe.jl` fails identically on clean SciMLBase [base source](https://github.com/SciML/SciMLBase.jl/commit/573bc6c305c4321b7095da74f92f19ce034c16ee) and this feature. Both use Julia 1.13.0, SciMLSensitivity `a5a9b938aeca1eab8009fd35ec33bfea40656f33`, ModelingToolkit 11.43.1, ModelingToolkitBase 1.71.1, NonlinearSolve 4.28.0, NonlinearSolveBase 2.49.5, and Enzyme 0.13.203; the manifests differ only in the SciMLBase source path. The sole error is `EnzymeNoTypeError` through `CacheWriter{Any}` during SCC initialization. A separate reduced parent/commit comparison identifies [ModelingToolkit's initialization change](https://github.com/SciML/ModelingToolkit.jl/commit/07e618174820bbe7a2847cdbfd1ba1af6d854cbc): its immediate parent passes 2/2, and that commit errors. The reproducer and introduction boundary are tracked in https://github.com/SciML/ModelingToolkit.jl/issues/5140. No production fix is claimed here.

  Exact local commands (the first pins NonlinearSolve to the CI version):
  ```sh
  TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.13.0 --project=scimlbase-sensitivity-ci-env -e 'using Pkg; Pkg.add(PackageSpec(name="NonlinearSolve", version="4.28.0")); include("scimlbase-sensitivity-check/test/Core8/desauty_dae_mwe.jl")'
  TMPDIR="$PWD/tmp" JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.13.0 --project=scimlbase-sensitivity-ci-feature-env -e 'include("scimlbase-sensitivity-check/test/Core8/desauty_dae_mwe.jl")'
  ```
  ```text
  # Clean base
  DAE with SCC Initialization | Pass 19  Error 1  Broken 5  Total 25  10m46.6s
  # Feature, identical test and dependency versions
  DAE with SCC Initialization | Pass 19  Error 1  Broken 5  Total 25  10m34.9s
  ```
  The five broken tests are pre-existing in the unchanged upstream file.

- **SciMLSensitivity Core1:** the same LLVM 20 `ClobberWalker` / `getMatchingValue` / `loadCSE` crash occurs in the [clean-base job](https://github.com/SciML/SciMLBase.jl/actions/runs/34718814288/job/103620749296) and [feature job](https://github.com/SciML/SciMLBase.jl/actions/runs/34748767539/job/103701355097). The standalone LLVM IR already published in https://github.com/llvm/llvm-project/issues/222852 independently segfaults locally with Julia 1.13's LLVM 20 (exit 139), while LLVM 18 passes; its backtrace matches the leading CI frames. https://github.com/EnzymeAD/Enzyme.jl/issues/3568 tracks that defect. **The exact solver-specific crash did not reproduce locally:** the unchanged clean-base test prefix through the failing CI assertion passes 1/1 with matching package versions and coverage/check-bounds enabled. No monotonic SciMLBase source regression was established.

- **Catalyst ReleaseTest:** both the [clean-base job](https://github.com/SciML/SciMLBase.jl/actions/runs/34718813799/job/103620745932) and [feature job](https://github.com/SciML/SciMLBase.jl/actions/runs/34748767320/job/103701354449) fail when the registered package's tests try to write `test/extensions/Project.toml` inside its read-only installed source. This was reproduced independently and is tracked with a reproducer in https://github.com/SciML/Catalyst.jl/issues/1561.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.154.0 (model: gpt-6-astra; local session ID: 01a099aa-308a-7fd3-91bd-9fb2dc357b91).
